### PR TITLE
controller: test.yaml: Fix the test.yaml file

### DIFF
--- a/ciao-controller/test.yaml
+++ b/ciao-controller/test.yaml
@@ -1,12 +1,10 @@
 ---
 #cloud-config
-password: hello
-chpasswd: { expire: False }
 users:
   - name: ciao
     gecos: CIAO Rules
     lock-passwd: false
-    passwd: "$6$rounds=4096$w9I3hR4g/hu$AnYjaC2DfznbPSG3vxsgtgAS4mJwWBkcR74Y/KHNB5OsfAlA4gpU5j6CHWMOkkt9j.9d7OYJXJ4icXHzKXTAO."
+    passwd: $6$rounds=4096$w9I3hR4g/hu$AnYjaC2DfznbPSG3vxsgtgAS4mJwWBkcR74Y/KHNB5OsfAlA4gpU5j6CHWMOkkt9j.9d7OYJXJ4icXHzKXTAO.
     sudo: ciao ALL=(ALL) NOPASSWD:ALL
     ssh-authorized-keys:
     - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDerQfD+qkb0V0XdQs8SBWqy4sQmqYFP96n/kI4Cq162w4UE8pTxy0ozAPldOvBJjljMvgaNKSAddknkhGcrNUvvJsUcZFm2qkafi32WyBdGFvIc45A+8O7vsxPXgHEsS9E3ylEALXAC3D0eX7pPtRiAbasLlY+VcACRqr3bPDSZTfpCmIkV2334uZD9iwOvTVeR+FjGDqsfju4DyzoAIqpPasE0+wk4Vbog7osP+qvn1gj5kQyusmr62+t0wx+bs2dF5QemksnFOswUrv9PGLhZgSMmDQrRYuvEfIAC7IdN/hfjTn0OokzljBiuWQ4WIIba/7xTYLVujJV65qH3heaSMxJJD7eH9QZs9RdbbdTXMFuJFsHV2OF6wZRp18tTNZZJMqiHZZSndC5WP1WrUo3Au/9a+ighSaOiVddHsPG07C/TOEnr3IrwU7c9yIHeeRFHmcQs9K0+n9XtrmrQxDQ9/mLkfje80Ko25VJ/QpAQPzCKh2KfQ4RD+/PxBUScx/lHIHOIhTSCh57ic629zWgk0coSQDi4MKSa5guDr3cuDvt4RihGviDM6V68ewsl0gh6Z9c0Hw7hU0vky4oxak5AiySiPz0FtsOnAzIL0UON+yMuKzrJgLjTKodwLQ0wlBXu43cD+P8VXwQYeqNSzfrhBnHqsrMf4lTLtc7kDDTcw== ciao@ciao

--- a/ciao-vendor/ciao-vendor.go
+++ b/ciao-vendor/ciao-vendor.go
@@ -1,0 +1,265 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"sort"
+	"strings"
+)
+
+type repoInfo struct {
+	URL     string
+	version string
+}
+
+var repos = map[string]repoInfo{
+	"github.com/docker/distribution": {"https://github.com/docker/distribution.git", "v2.4.0"},
+}
+
+var vendorTmpPath = "/tmp/ciao-vendor"
+
+func isStandardPackage(name string) bool {
+	cmd := exec.Command("go", "list", "-f", "{{.Standard}}", name)
+	output, err := cmd.Output()
+	if err != nil {
+		return true
+	}
+	return bytes.HasPrefix(output, []byte{'t', 'r', 'u', 'e'})
+}
+
+func calcDeps() ([]string, error) {
+	deps := make(map[string]struct{})
+
+	listTemplate := `
+{{- range .Deps -}}
+{{.}}
+{{end -}}
+`
+	var output bytes.Buffer
+	cmd := exec.Command("go", "list", "-f", listTemplate, "./...")
+	cmd.Stdout = &output
+	err := cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("go list failed: %v\n", err)
+	}
+
+	scanner := bufio.NewScanner(&output)
+	for scanner.Scan() {
+		deps[scanner.Text()] = struct{}{}
+	}
+
+	ch := make(chan string)
+	for pkg := range deps {
+		go func(pkg string) {
+			if !isStandardPackage(pkg) {
+				ch <- pkg
+			} else {
+				ch <- ""
+			}
+		}(pkg)
+	}
+
+	depsAr := make([]string, 0, len(deps))
+	for i := 0; i < cap(depsAr); i++ {
+		pkg := <-ch
+		if pkg != "" {
+			depsAr = append(depsAr, pkg)
+		}
+	}
+
+	sort.Strings(depsAr)
+	return depsAr, nil
+}
+
+func checkWD() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("Unable to determine cwd: %v", err)
+	}
+	gopath, _ := os.LookupEnv("GOPATH")
+	if gopath == "" {
+		return "", fmt.Errorf("GOPATH is not set")
+	}
+
+	pths := strings.Split(gopath, ":")
+
+	for _, p := range pths {
+		if path.Join(p, "src/github.com/01org/ciao") == cwd {
+			return cwd, nil
+		}
+	}
+
+	return "", fmt.Errorf("ciao-vendor must be run from $GOPATH/src/01org/ciao")
+}
+
+func cloneRepos() error {
+	err := os.MkdirAll(vendorTmpPath, 0755)
+	if err != nil {
+		return fmt.Errorf("Unable to create %s : %v", vendorTmpPath, err)
+	}
+
+	errCh := make(chan error)
+
+	for _, r := range repos {
+		go func(URL string) {
+			cmd := exec.Command("git", "clone", URL)
+			cmd.Dir = vendorTmpPath
+			err := cmd.Run()
+			if err != nil {
+				errCh <- fmt.Errorf("git clone %s failed : %v", URL, err)
+			} else {
+				errCh <- nil
+			}
+		}(r.URL)
+	}
+
+	for _ = range repos {
+		rcvErr := <-errCh
+		if err == nil && rcvErr != nil {
+			err = rcvErr
+		}
+	}
+
+	return err
+}
+
+func copyRepos(cwd string, subPackages map[string][]string) error {
+	errCh := make(chan error)
+	for k, r := range repos {
+		packages, ok := subPackages[k]
+		if !ok {
+			fmt.Printf("Warning: No packages found for: %s\n", r.URL)
+			continue
+		}
+		go func(k string, packages []string) {
+			args := []string{"archive", repos[k].version}
+			args = append(args, packages...)
+			cmd1 := exec.Command("git", args...)
+			index := strings.LastIndex(k, "/")
+			cmd1.Dir = path.Join(vendorTmpPath, k[index+1:])
+			fmt.Println(cmd1.Dir)
+			fmt.Println(path.Join(cwd, k))
+			os.MkdirAll(path.Join(cwd, "vendor", k), 0755)
+			cmd2 := exec.Command("tar", "-x", "-C", path.Join(cwd, "vendor", k))
+			fmt.Println(args)
+			pipe, err := cmd1.StdoutPipe()
+			if err != nil {
+				errCh <- fmt.Errorf("Unable to retrieve pipe for git command %v: %v", args, err)
+				return
+			}
+			defer func() {
+				_ = pipe.Close()
+			}()
+			cmd2.Stdin = pipe
+			err = cmd1.Start()
+			if err != nil {
+				errCh <- fmt.Errorf("Unable to start git command %v: %v", args, err)
+				return
+			}
+			err = cmd2.Run()
+			if err != nil {
+				errCh <- fmt.Errorf("Unable to run tar command %v", err)
+				return
+			}
+			errCh <- nil
+		}(k, packages)
+	}
+
+	var err error
+	for _ = range repos {
+		rcvErr := <-errCh
+		if err == nil && rcvErr != nil {
+			err = rcvErr
+		}
+	}
+
+	return err
+}
+
+func vendor(cwd string) error {
+	vendorPath := path.Join(cwd, "vendor")
+
+	err := os.RemoveAll(vendorPath)
+	if err != nil {
+		return err
+	}
+
+	err = os.RemoveAll(vendorTmpPath)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = os.RemoveAll(vendorTmpPath)
+	}()
+
+	err = cloneRepos()
+	if err != nil {
+		return err
+	}
+
+	deps, err := calcDeps()
+	if err != nil {
+		return err
+	}
+
+	subPackages := make(map[string][]string)
+	for _, d := range deps {
+		for k := range repos {
+			if !strings.HasPrefix(d, k) {
+				continue
+			}
+
+			packages := subPackages[k]
+			if len(packages) == 1 && packages[0] == "" {
+				continue
+			}
+
+			subPackage := d[len(k):]
+			if subPackage == "" {
+				subPackages[k] = []string{""}
+			} else if subPackage[0] == '/' {
+				subPackages[k] = append(packages, subPackage[1:])
+			} else {
+				fmt.Printf("Warning: unvendored package: %s\n", d)
+			}
+		}
+	}
+
+	return copyRepos(cwd, subPackages)
+}
+
+func main() {
+
+	cwd, err := checkWD()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	err = vendor(cwd)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/ciao-vendor/ciao-vendor.go
+++ b/ciao-vendor/ciao-vendor.go
@@ -25,6 +25,7 @@ import (
 	"path"
 	"sort"
 	"strings"
+	"text/tabwriter"
 )
 
 type repoInfo struct {
@@ -32,12 +33,41 @@ type repoInfo struct {
 	version string
 }
 
+type packageDeps struct {
+	p    string
+	deps []string
+}
+
 var repos = map[string]repoInfo{
-	"github.com/docker/distribution": {"https://github.com/docker/distribution.git", "v2.4.0"},
-	"gopkg.in/yaml.v2":               {"https://gopkg.in/yaml.v2", "a83829b"},
+	"github.com/docker/distribution":    {"https://github.com/docker/distribution.git", "v2.4.0"},
+	"gopkg.in/yaml.v2":                  {"https://gopkg.in/yaml.v2", "a83829b"},
+	"github.com/Sirupsen/logrus":        {"https://github.com/Sirupsen/logrus.git", "v0.9.0"},
+	"github.com/boltdb/bolt":            {"https://github.com/boltdb/bolt.git", "144418e"},
+	"github.com/coreos/go-iptables":     {"https://github.com/coreos/go-iptables.git", "fbb7337"},
+	"github.com/davecgh/go-spew":        {"https://github.com/davecgh/go-spew.git", "5215b55"},
+	"github.com/docker/docker":          {"https://github.com/docker/docker.git", "v1.10.3"},
+	"github.com/docker/engine-api":      {"https://github.com/docker/engine-api.git", "v0.3.3"},
+	"github.com/docker/go-connections":  {"https://github.com/docker/go-connections.git", "5b7154b"},
+	"github.com/docker/go-units":        {"https://github.com/docker/go-units.git", "651fc22"},
+	"github.com/docker/libnetwork":      {"https://github.com/docker/libnetwork.git", "dbb0722"},
+	"github.com/golang/glog":            {"https://github.com/golang/glog.git", "23def4e"},
+	"github.com/gorilla/context":        {"https://github.com/gorilla/context.git", "1ea2538"},
+	"github.com/gorilla/mux":            {"https://github.com/gorilla/mux.git", "0eeaf83"},
+	"github.com/mattn/go-sqlite3":       {"https://github.com/mattn/go-sqlite3.git", "467f50b"},
+	"github.com/mitchellh/mapstructure": {"https://github.com/mitchellh/mapstructure.git", "d2dd026"},
+	"github.com/opencontainers/runc":    {"https://github.com/opencontainers/runc.git", "v0.1.0"},
+	"github.com/rackspace/gophercloud":  {"https://github.com/rackspace/gophercloud.git", "c54bbac"},
+	"github.com/tylerb/graceful":        {"https://github.com/tylerb/graceful.git", "9a3d423"},
+	"github.com/vishvananda/netlink":    {"https://github.com/vishvananda/netlink.git", "a632d6d"},
+	"golang.org/x/net":                  {"https://go.googlesource.com/net", "origin/release-branch.go1.6"},
 }
 
 var vendorTmpPath = "/tmp/ciao-vendor"
+var listTemplate = `
+{{- range .Deps -}}
+{{.}}
+{{end -}}
+`
 
 func isStandardPackage(name string) bool {
 	cmd := exec.Command("go", "list", "-f", "{{.Standard}}", name)
@@ -48,16 +78,12 @@ func isStandardPackage(name string) bool {
 	return bytes.HasPrefix(output, []byte{'t', 'r', 'u', 'e'})
 }
 
-func calcDeps() ([]string, error) {
+func calcDeps(projectRoot string, packages []string) ([]string, error) {
 	deps := make(map[string]struct{})
-
-	listTemplate := `
-{{- range .Deps -}}
-{{.}}
-{{end -}}
-`
+	args := []string{"list", "-f", listTemplate}
+	args = append(args, packages...)
 	var output bytes.Buffer
-	cmd := exec.Command("go", "list", "-f", listTemplate, "./...")
+	cmd := exec.Command("go", args...)
 	cmd.Stdout = &output
 	err := cmd.Run()
 	if err != nil {
@@ -72,7 +98,7 @@ func calcDeps() ([]string, error) {
 	ch := make(chan string)
 	for pkg := range deps {
 		go func(pkg string) {
-			if !isStandardPackage(pkg) {
+			if !strings.HasPrefix(pkg, projectRoot) && !isStandardPackage(pkg) {
 				ch <- pkg
 			} else {
 				ch <- ""
@@ -92,25 +118,25 @@ func calcDeps() ([]string, error) {
 	return depsAr, nil
 }
 
-func checkWD() (string, error) {
+func checkWD() (string, string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return "", fmt.Errorf("Unable to determine cwd: %v", err)
+		return "", "", fmt.Errorf("Unable to determine cwd: %v", err)
 	}
 	gopath, _ := os.LookupEnv("GOPATH")
 	if gopath == "" {
-		return "", fmt.Errorf("GOPATH is not set")
+		return "", "", fmt.Errorf("GOPATH is not set")
 	}
 
 	pths := strings.Split(gopath, ":")
 
 	for _, p := range pths {
 		if path.Join(p, "src/github.com/01org/ciao") == cwd {
-			return cwd, nil
+			return cwd, gopath, nil
 		}
 	}
 
-	return "", fmt.Errorf("ciao-vendor must be run from $GOPATH/src/01org/ciao")
+	return "", "", fmt.Errorf("ciao-vendor must be run from $GOPATH/src/01org/ciao")
 }
 
 func cloneRepos() error {
@@ -144,6 +170,20 @@ func cloneRepos() error {
 	return err
 }
 
+func baseCloneDir(URL string) string {
+	index := strings.LastIndex(URL, "/")
+	if index == -1 {
+		return URL
+	}
+
+	dir := URL[index+1:]
+	index = strings.LastIndex(dir, ".git")
+	if index == -1 {
+		return dir
+	}
+	return dir[:index]
+}
+
 func copyRepos(cwd string, subPackages map[string][]string) error {
 	errCh := make(chan error)
 	for k, r := range repos {
@@ -158,13 +198,9 @@ func copyRepos(cwd string, subPackages map[string][]string) error {
 			args := []string{"archive", repos[k].version}
 			args = append(args, packages...)
 			cmd1 := exec.Command("git", args...)
-			index := strings.LastIndex(k, "/")
-			cmd1.Dir = path.Join(vendorTmpPath, k[index+1:])
-			fmt.Println(cmd1.Dir)
-			fmt.Println(path.Join(cwd, k))
+			cmd1.Dir = path.Join(vendorTmpPath, baseCloneDir(URL))
 			os.MkdirAll(path.Join(cwd, "vendor", k), 0755)
 			cmd2 := exec.Command("tar", "-x", "-C", path.Join(cwd, "vendor", k))
-			fmt.Println(args)
 			pipe, err := cmd1.StdoutPipe()
 			if err != nil {
 				errCh <- fmt.Errorf("Unable to retrieve pipe for git command %v: %v", args, err)
@@ -199,7 +235,7 @@ func copyRepos(cwd string, subPackages map[string][]string) error {
 	return err
 }
 
-func vendor(cwd string) error {
+func vendor(cwd, projectRoot string) error {
 	vendorPath := path.Join(cwd, "vendor")
 
 	err := os.RemoveAll(vendorPath)
@@ -211,17 +247,19 @@ func vendor(cwd string) error {
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		_ = os.RemoveAll(vendorTmpPath)
-	}()
-
+	/*
+		defer func() {
+			_ = os.RemoveAll(vendorTmpPath)
+		}()
+	*/
+	fmt.Println("Cloning Repos")
 	err = cloneRepos()
 	if err != nil {
 		return err
 	}
 
-	deps, err := calcDeps()
+	fmt.Println("Calculating Dependencies")
+	deps, err := calcDeps(projectRoot, []string{"./..."})
 	if err != nil {
 		return err
 	}
@@ -249,18 +287,161 @@ func vendor(cwd string) error {
 		}
 	}
 
+	fmt.Println("Populating vendor folder")
+
 	return copyRepos(cwd, subPackages)
 }
 
-func main() {
+func usedBy(name string, packages []string, depsMap map[string][]string) string {
+	var users bytes.Buffer
 
-	cwd, err := checkWD()
+	for _, p := range packages {
+		if p == name {
+			continue
+		}
+
+		deps := depsMap[p]
+		for _, d := range deps {
+			if d == name {
+				users.WriteString(" ")
+				users.WriteString(p)
+				break
+			}
+		}
+	}
+
+	// BUG(markus): We don't report when a depdenency is used by ciao if
+	// it is also used by a depdenency
+
+	if users.Len() == 0 {
+		return "ciao"
+	}
+
+	return users.String()[1:]
+}
+
+func depsByPackage(packages []string) map[string][]string {
+	depsMap := make(map[string][]string)
+	depsCh := make(chan packageDeps)
+	for _, p := range packages {
+		go func(p string) {
+			var output bytes.Buffer
+			cmd := exec.Command("go", "list", "-f", listTemplate, p)
+			cmd.Stdout = &output
+			err := cmd.Run()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Unable to call get list on %s : %v", p, err)
+				depsCh <- packageDeps{p: p}
+				return
+			}
+			scanner := bufio.NewScanner(&output)
+			deps := make([]string, 0, 32)
+			for scanner.Scan() {
+				deps = append(deps, scanner.Text())
+			}
+			depsCh <- packageDeps{p, deps}
+		}(p)
+	}
+
+	for _ = range packages {
+		pkgDeps := <-depsCh
+		depsMap[pkgDeps.p] = pkgDeps.deps
+	}
+
+	return depsMap
+}
+
+func computeClients(packages []string) map[string]string {
+	depsMap := depsByPackage(packages)
+	clientMap := make(map[string]string)
+	for _, p := range packages {
+		clientMap[p] = usedBy(p, packages, depsMap)
+	}
+	return clientMap
+}
+
+func check(cwd, projectRoot string) error {
+	var output bytes.Buffer
+	cmd := exec.Command("go", "list", "./...")
+	cmd.Stdout = &output
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("go list failed: %v\n", err)
+	}
+
+	packages := make([]string, 0, 128)
+	scanner := bufio.NewScanner(&output)
+
+	vendorDir := path.Join(projectRoot, "vendor")
+
+	for scanner.Scan() {
+		pkg := scanner.Text()
+		if !strings.HasPrefix(pkg, vendorDir) {
+			packages = append(packages, pkg)
+		}
+	}
+
+	deps, err := calcDeps(projectRoot, packages)
+	if err != nil {
+		return err
+	}
+
+	missing := make([]string, 0, 128)
+
+depLoop:
+	for _, d := range deps {
+		for k := range repos {
+			if strings.HasPrefix(d, k) {
+				continue depLoop
+			}
+		}
+		missing = append(missing, d)
+	}
+
+	if len(missing) == 0 {
+		fmt.Println("All dependencies are vendored")
+		return nil
+	}
+
+	clientMap := computeClients(deps)
+
+	fmt.Println("NON-VENDORED DEPENDENCIES FOUND\n")
+	w := new(tabwriter.Writer)
+	w.Init(os.Stdout, 0, 8, 1, '\t', 0)
+	fmt.Fprintln(w, "Package\tUsed By")
+	for _, d := range missing {
+		fmt.Fprintf(w, "%s\t%s\n", d, clientMap[d])
+	}
+	w.Flush()
+
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 || (os.Args[1] != "vendor" && os.Args[1] != "check") {
+		fmt.Fprintln(os.Stderr, "Usage: ciao-vendor vendor|check")
+		os.Exit(1)
+	}
+
+	cwd, gopath, err := checkWD()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
-	err = vendor(cwd)
+	sourceRoot := path.Join(gopath, "src")
+	if len(cwd) < len(sourceRoot)+1 {
+		fmt.Fprintln(os.Stderr, "Could not determine project root")
+		os.Exit(1)
+	}
+	projectRoot := cwd[len(sourceRoot)+1:]
+
+	if os.Args[1] == "check" {
+		err = check(cwd, projectRoot)
+	} else {
+		err = vendor(cwd, projectRoot)
+	}
+
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)


### PR DESCRIPTION
The password and chpasswd fields were upsetting clr-cloud-init.

The unnecessary quotes surrounding the password field have also
been removed.  The new configuration works on both Ubuntu 15.10
and clear-7490-cloud.img.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>