### PR TITLE
Add configuration file support to ciao-launcher

### DIFF
--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/golang/glog"
 
+	"github.com/01org/ciao/config"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp"
 )
@@ -94,16 +95,26 @@ var simulate bool
 var maxInstances = int(math.MaxInt32)
 
 func init() {
-	flag.StringVar(&serverURL, "server", "localhost", "URL of SSNTP server")
-	flag.StringVar(&serverCertPath, "cacert", "/etc/pki/ciao/CAcert-server-localhost.pem", "Client certificate")
-	flag.StringVar(&clientCertPath, "cert", "/etc/pki/ciao/cert-client-localhost.pem", "CA certificate")
-	flag.StringVar(&computeNet, "compute-net", "", "Compute Subnet")
-	flag.StringVar(&mgmtNet, "mgmt-net", "", "Management Subnet")
+	defaults := config.InitConfig()
+	flag.StringVar(&serverURL, "server",
+		defaults.Launcher.Server, "URL of SSNTP server")
+	flag.StringVar(&serverCertPath, "cacert",
+		defaults.Launcher.CACert, "Client certificate")
+	flag.StringVar(&clientCertPath, "cert",
+		defaults.Launcher.Cert, "CA certificate")
+	flag.StringVar(&computeNet, "compute-net",
+		defaults.Launcher.ComputeNet, "Compute Subnet")
+	flag.StringVar(&mgmtNet, "mgmt-net",
+		defaults.Launcher.MgmtNet, "Management Subnet")
 	flag.Var(&networking, "network", "Can be none, cn (compute node) or nn (network node)")
-	flag.BoolVar(&hardReset, "hard-reset", false, "Kill and delete all instances, reset networking and exit")
-	flag.BoolVar(&diskLimit, "disk-limit", true, "Use disk usage limits")
-	flag.BoolVar(&memLimit, "mem-limit", true, "Use memory usage limits")
-	flag.BoolVar(&simulate, "simulation", false, "Launcher simulation")
+	flag.BoolVar(&hardReset, "hard-reset",
+		defaults.Launcher.HardReset, "Kill and delete all instances, reset networking and exit")
+	flag.BoolVar(&diskLimit, "disk-limit",
+		defaults.Launcher.DiskLimit, "Use disk usage limits")
+	flag.BoolVar(&memLimit, "mem-limit",
+		defaults.Launcher.MemLimit, "Use memory usage limits")
+	flag.BoolVar(&simulate, "simulation",
+		defaults.Launcher.Simulation, "Launcher simulation")
 }
 
 const (

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,83 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+type CIAOConfig struct {
+	UsedFile  string
+	Launcher  LauncherConfig
+}
+
+type LauncherConfig struct {
+	Server      string `json:"server"`
+	CACert      string `json:"cacert"`
+	Cert        string `json:"cert"`
+	ComputeNet  string `json:"compute-net"`
+	MgmtNet     string `json:"mgmt-net"`
+	HardReset   bool   `json:"hard-reset"`
+	DiskLimit   bool   `json:"disk-limit"`
+	MemLimit    bool   `json:"mem-limit"`
+	Simulation  bool   `json:"simulation"`
+}
+
+func (launcher *LauncherConfig) initLauncher(){
+	launcher.Server     = "localhost"
+	launcher.CACert     = "/etc/pki/ciao/CAcert-server-localhost.pem"
+	launcher.Cert       = "/etc/pki/ciao/cert-client-localhost.pem"
+	launcher.ComputeNet = ""
+	launcher.MgmtNet    = ""
+ 	launcher.HardReset  = false
+	launcher.DiskLimit  = true
+	launcher.MemLimit = true
+	launcher.Simulation = false
+}
+
+func loadConfigFile(path, filename string, ciaoConf CIAOConfig)  CIAOConfig {
+	filePath := fmt.Sprintf("%s/%s", path, filename)
+
+	if _, err := os.Stat(filePath); err == nil {
+		file,err := ioutil.ReadFile(filePath)
+		if err != nil {
+			log.Fatalf("Error on file:  %v \n %v", filePath, err)
+		} else {
+			json.Unmarshal(file, &ciaoConf)
+			ciaoConf.UsedFile = filePath
+		}
+	} 
+	return ciaoConf
+}
+
+func InitConfig() CIAOConfig {
+	config := CIAOConfig{}
+	config.Launcher.initLauncher()
+	configPaths := [...]string{
+		"/home/onmunoz/dev/go/dev/viper/config1",
+		"/home/onmunoz/dev/go/dev/viper/config2"}
+	configFile := "ciao.json"
+
+	for _, path := range configPaths {
+		config = loadConfigFile(path, configFile, config)
+	}
+	return config
+}

--- a/etc/ciao/ciao.json
+++ b/etc/ciao/ciao.json
@@ -1,0 +1,13 @@
+{
+    "launcher": {
+	"server": "localhost",
+	"cacert": "/etc/pki/ciao/CAcert-server-localhost.pem",
+	"cert": "/etc/pki/ciao/cert-client-localhost.pem",
+	"compute-net":  "",
+	"mgmt-net":  "",
+	"hard-reset": false,
+	"disk-limit": true,
+	"mem-limit": true,
+	"simulation": false
+    }
+}


### PR DESCRIPTION
In order to make it more easy to use in a production server environment and
make it ready for OS init systems like systemd or sysvinit, here are the new
proposed features:

  - "config" module for handling the CIAO config files parsing
    - This module would contain all modules default structs
  - New CIAO config sample file at etc/ciao/ciao.json
    - We'll have the following sections:
      - launcher
      - scheduler
      - controller
      - cnci-agent
  - If you don't have any configuration file, services will start with
    defaults that were set in config module
  - Once you have the /etc/ciao/ciao.json file and you edited as needed,
    you can start ciao-launcher as compute node:
    	$ ./cioa-launcher --network=cn
    - Parameters reading priorities are (first has higher priority):
      1. Values from In-command parameters (It overwrites below specified values)
      2. Values from /etc/ciao (It overwrites below specified values)
      3. Values from /usr/share/default/ciao/

Signed-off-by: Munoz, Obed N <obed.n.munoz@intel.com>