### PR TITLE
Add configuration file support to ciao-launcher

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,58 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path"
+	"syscall"
+)
+
+func loadConfigFile(confPath, filename string, ciaoConf interface{}) error {
+	filePath := path.Join(confPath, filename)	
+	file,err := ioutil.ReadFile(filePath)
+	if err != nil {
+		err, ok := err.(*os.PathError)
+		if ok && err.Err == syscall.ENOENT {
+			return nil
+		} else {
+			return err
+		}
+	}
+	err = json.Unmarshal(file, &ciaoConf)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func InitConfig(config interface{}) error {
+	configPaths := [...]string{
+		"/usr/share/defaults/ciao",
+		"/etc/ciao"}
+	configFile := "ciao.json"
+
+	for _, path := range configPaths {
+		err := loadConfigFile(path, configFile, &config)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/etc/ciao/ciao.json
+++ b/etc/ciao/ciao.json
@@ -1,0 +1,9 @@
+{
+    "server": "localhost3",
+    "cacert": "/etc/pki/ciao/CAcert-server-localhost.pem",
+    "cert": "/etc/pki/ciao/cert-client-localhost.pem",
+    "compute-net":  "",
+    "mgmt-net":  "",
+    "disk-limit": true,
+    "mem-limit": true
+}


### PR DESCRIPTION
In order to make it more easy to use in a production server environment and
make it ready for OS init systems like systemd or sysvinit, here are the new
proposed features:

  - "config" package for handling the CIAO config files parsing
      - This package is generic for all CIAO services' confs
  - New CIAO config sample file at etc/ciao/ciao.json
  - If you don't have any configuration file, services will start with
    defaults that were set on each service
  - Once you have the /etc/ciao/ciao.json file and you edited as needed,
    you can start ciao-launcher as compute node:
    	$ ./cioa-launcher --network=cn
  - Parameters reading priorities are (first has higher priority):
    1. Values from In-command parameters (It overwrites below specified values)
    2. Values from /etc/ciao (It overwrites below specified values)
    3. Values from /usr/share/default/ciao/

Signed-off-by: Munoz, Obed N <obed.n.munoz@intel.com>