### PR TITLE
Sameo/topic/simulation

### DIFF
--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -528,11 +528,11 @@ func setLimits() {
 
 func main() {
 
-	if getLock() != nil {
+	flag.Parse()
+
+	if simulate == false && getLock() != nil {
 		os.Exit(1)
 	}
-
-	flag.Parse()
 
 	if err := initLogger(); err != nil {
 		log.Fatalf("Unable to initialise logs: %v", err)

--- a/ciao-launcher/simulation.go
+++ b/ciao-launcher/simulation.go
@@ -39,12 +39,6 @@ type simulation struct {
 	disk int
 }
 
-var simulationMap map[string]simulation
-
-func init() {
-	simulationMap = make(map[string]simulation)
-}
-
 func (s *simulation) init(cfg *vmConfig, instanceDir string) {
 	s.cpus = cfg.Cpus
 	s.mem = cfg.Mem
@@ -107,8 +101,6 @@ func (s *simulation) startVM(vnicName, ipAddress string) error {
 	glog.Infof("startVM\n")
 
 	s.killCh = make(chan struct{})
-
-	simulationMap[s.instanceDir] = *s
 
 	return nil
 }

--- a/ciao-launcher/simulation.go
+++ b/ciao-launcher/simulation.go
@@ -88,6 +88,7 @@ VM:
 		case <-ticker.C:
 			ticker.Stop()
 			close(s.connectedCh)
+			ticker.C = nil
 		}
 	}
 


### PR DESCRIPTION
- Allow multiple launcher instances to run in simulation mode
- Remove useless instance map in the simulation.go code. We do not even need to track instances in simulation mode.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>