### PR TITLE
Travis: Use test-cases instead of go test to run unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ script:
    - sudo docker pull debian
    - sudo ip link add testdummy type dummy
    - sudo ip addr add 198.51.100.1/24 dev testdummy
-   - export SNNET_ENV=198.51.100.0/24 && sudo -E $GOROOT/bin/go test -v -short --tags travis github.com/01org/ciao/networking/libsnnet
+   - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -text -short -tags travis github.com/01org/ciao/networking/libsnnet

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_script:
 
 script:
    - go env
-   - go test -v github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/payloads github.com/01org/ciao/ciao-controller
-   - export GOROOT=`go env GOROOT` && sudo -E $GOROOT/bin/go test -v github.com/01org/ciao/ssntp
+   - test-cases -text github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/ciao-controller github.com/01org/ciao/payloads
+   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -text github.com/01org/ciao/ssntp
    - docker --version
    - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine
    - docker --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ before_script:
 
 script:
    - go env
-   - test-cases -text github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/ciao-controller github.com/01org/ciao/payloads
-   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -text github.com/01org/ciao/ssntp
    - docker --version
    - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine
    - docker --version
    - sudo docker pull debian
    - sudo ip link add testdummy type dummy
    - sudo ip addr add 198.51.100.1/24 dev testdummy
+   - test-cases -text github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/ciao-controller github.com/01org/ciao/payloads
+   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -text github.com/01org/ciao/ssntp
    - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -text -short -tags travis github.com/01org/ciao/networking/libsnnet

--- a/test-cases/test-cases.go
+++ b/test-cases/test-cases.go
@@ -100,10 +100,14 @@ var coverageRegexp *regexp.Regexp
 
 var cssPath string
 var textOutput bool
+var short bool
+var tags string
 
 func init() {
 	flag.StringVar(&cssPath, "css", "", "Full path to CSS file")
 	flag.BoolVar(&textOutput, "text", false, "Output text instead of HTML")
+	flag.BoolVar(&short, "short", false, "If true -short is passed to go test")
+	flag.StringVar(&tags, "tags", "", "Build tags to pass to go test")
 	resultRegexp = regexp.MustCompile(`--- (FAIL|PASS): ([^\s]+) \(([^\)]+)\)`)
 	coverageRegexp = regexp.MustCompile(`^coverage: ([^\s]+)`)
 }
@@ -230,8 +234,15 @@ func runPackageTests(p *PackageTests) int {
 
 	exitCode := 0
 	results := make(map[string]*testResults)
+	args := []string{"test", p.Name, "-v", "-cover"}
+	if short {
+		args = append(args, "-short")
+	}
+	if tags != "" {
+		args = append(args, "-tags", tags)
+	}
 
-	cmd := exec.Command("go", "test", p.Name, "-v", "-cover")
+	cmd := exec.Command("go", args...)
 	cmd.Stdout = &output
 	_ = cmd.Run()
 


### PR DESCRIPTION
The output from go test is really messy and verbose.  There's so much output that it's hard to tell which test is causing a build failure.  Test-cases on the other hand generates a nice tabular output.  Compare the output of this build using go test

https://travis-ci.org/01org/ciao/jobs/126794144

to this build using test-cases

https://travis-ci.org/markdryan/ciao/jobs/126948990

The test-cases build is almost 900 lines shorter.

A few changes were made to test-cases to get this to work.  I added the -text option which causes test-cases to output the test results in text rather than HTML and -tags and -short which are passed directly to go test.  Test-cases can also now accept multiple packages on the command line, and it exits with an error code if any of the tests it runs fails.