### PR TITLE
ciao-controller: compute: sort instances by ID

### DIFF
--- a/ciao-controller/compute.go
+++ b/ciao-controller/compute.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -778,6 +779,8 @@ func listServerDetails(w http.ResponseWriter, r *http.Request, context *controll
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	sort.Sort(types.SortedInstancesByID(instances))
 
 	pager := serverPager{
 		context:   context,

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -46,6 +46,13 @@ type Instance struct {
 	Usage      map[string]int `json:"-"`
 }
 
+// SortedInstancesByID implements sort.Interface for Instance by ID string
+type SortedInstancesByID []*Instance
+
+func (s SortedInstancesByID) Len() int           { return len(s) }
+func (s SortedInstancesByID) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s SortedInstancesByID) Less(i, j int) bool { return s[i].ID < s[j].ID }
+
 type Tenant struct {
 	ID        string
 	Name      string


### PR DESCRIPTION
Modify listServerDetails() to sort the instances it retrieves
from the datastore prior to sending to the user.  Modify types
to add a sorted instance type which implements a sort interface
to sort by instance ID.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>