### PR TITLE
ciao-controller: instances: update usage synchronously for cache

### DIFF
--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -86,7 +86,7 @@ func newInstance(context *controller, tenantID string, workload *types.Workload)
 func (i *instance) Add() error {
 	if i.CNCI == false {
 		ds := i.context.ds
-		go ds.AddInstance(&i.Instance)
+		ds.AddInstance(&i.Instance)
 	} else {
 		i.context.ds.AddTenantCNCI(i.TenantID, i.ID, i.MACAddress)
 	}

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -770,7 +770,10 @@ func (ds *Datastore) AddInstance(instance *types.Instance) error {
 
 	ds.tenantsLock.Unlock()
 
-	return ds.db.addInstance(instance)
+	// update database asynchronously
+	go ds.db.addInstance(instance)
+
+	return nil
 }
 
 // RestartFailure logs a RestartFailure in the datastore


### PR DESCRIPTION
Rather than add instance information asynchronously to the cache,
update the cache synchronously and only update the database
asynchronously.  This change prevents the case where a user
may be able to request workload starts over their limit because
the cache isn't done updating.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>