### PR TITLE
travis: Fix travis builds for github forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
     - 1.6
     - tip
 
-#go_import_path: github.com/01org/ciao
+go_import_path: github.com/01org/ciao
 
 # We need to create and install SSNTP certs for the SSNTP and controller tests
 before_script:


### PR DESCRIPTION
We need to add back in the go_import_path statement.  Otherwise forks of ciao
will fail to build in Travis CI.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>