### PR TITLE
payloads: Add documentation to fix golint errors

### DIFF
--- a/payloads/deletefailure.go
+++ b/payloads/deletefailure.go
@@ -16,22 +16,35 @@
 
 package payloads
 
+// DeleteFailureReason denotes the underlying error that prevented
+// an SSNTP DELETE command from deleting a running instance.
 type DeleteFailureReason string
 
 const (
-	DeleteNoInstance     DeleteFailureReason = "no_instance"
-	DeleteInvalidPayload                     = "invalid_payload"
-	DeleteInvalidData                        = "invalid_data"
+	// DeleteNoInstance indicates that an instance could not be deleted
+	// as it does not exist on the node to which the DELETE command was
+	// sent.
+	DeleteNoInstance DeleteFailureReason = "no_instance"
+
+	// DeleteInvalidPayload indicates that the payload of the SSNTP
+	// DELETE command was corrupt and could not be unmarshalled.
+	DeleteInvalidPayload = "invalid_payload"
+
+	// DeleteInvalidData is returned by ciao-launcher if the contents
+	// of the DELETE payload are incorrect, e.g., the instance_uuid
+	// is missing.
+	DeleteInvalidData = "invalid_data"
 )
 
+// ErrorDeleteFailure represents the unmarshalled version of the contents of a
+// SSNTP ERROR frame whose type is set to ssntp.DeleteFailure.
 type ErrorDeleteFailure struct {
-	InstanceUUID string              `yaml:"instance_uuid"`
-	Reason       DeleteFailureReason `yaml:"reason"`
-}
+	// InstanceUUID is the UUID of the instance that could not be deleted.
+	InstanceUUID string `yaml:"instance_uuid"`
 
-func (s *ErrorDeleteFailure) Init() {
-	s.InstanceUUID = ""
-	s.Reason = ""
+	// Reason provides the reason for the delete failure, e.g.,
+	// DeleteNoInstance.
+	Reason DeleteFailureReason `yaml:"reason"`
 }
 
 func (r DeleteFailureReason) String() string {

--- a/payloads/restartfailure.go
+++ b/payloads/restartfailure.go
@@ -16,26 +16,53 @@
 
 package payloads
 
+// RestartFailureReason denotes the underlying error that prevented
+// an SSNTP RESTART command from booting up an existing instance on a CN
+// or a NN.
 type RestartFailureReason string
 
 const (
-	RestartNoInstance      RestartFailureReason = "no_instance"
-	RestartInvalidPayload                       = "invalid_payload"
-	RestartInvalidData                          = "invalid_data"
-	RestartAlreadyRunning                       = "already_running"
-	RestartInstanceCorrupt                      = "instance_corrupt"
-	RestartLaunchFailure                        = "launch_failure"
-	RestartNetworkFailure                       = "network_failure"
+	// RestartNoInstance indicates that an instance could not be restarted
+	// as it does not exist on the node to which the RESTART command was
+	// sent.
+	RestartNoInstance RestartFailureReason = "no_instance"
+
+	// RestartInvalidPayload indicates that the payload of the SSNTP
+	// RESTART command was corrupt and could not be unmarshalled.
+	RestartInvalidPayload = "invalid_payload"
+
+	// RestartInvalidData is returned by ciao-launcher if the contents
+	// of the RESTART payload are incorrect, e.g., the instance_uuid
+	// is missing.
+	RestartInvalidData = "invalid_data"
+
+	// RestartAlreadyRunning indicates that an attempt was made to restart
+	// a running instance.
+	RestartAlreadyRunning = "already_running"
+
+	// RestartInstanceCorrupt indicates that it was impossible to restart
+	// an instance as the state of that instance stored on the node has
+	// become corrupted.
+	RestartInstanceCorrupt = "instance_corrupt"
+
+	// RestartLaunchFailure indicates that it was not possible to restart
+	// the instance, for example, the call to docker start fails.
+	RestartLaunchFailure = "launch_failure"
+
+	// RestartNetworkFailure indicates that it was not possible to
+	// initialise networking for the instance before restarting it.
+	RestartNetworkFailure = "network_failure"
 )
 
+// ErrorRestartFailure represents the unmarshalled version of the contents of a
+// SSNTP ERROR frame whose type is set to ssntp.RestartFailure.
 type ErrorRestartFailure struct {
-	InstanceUUID string               `yaml:"instance_uuid"`
-	Reason       RestartFailureReason `yaml:"reason"`
-}
+	// InstanceUUID is the UUID of the instance that could not be started.
+	InstanceUUID string `yaml:"instance_uuid"`
 
-func (s *ErrorRestartFailure) Init() {
-	s.InstanceUUID = ""
-	s.Reason = ""
+	// Reason provides the reason for the restart failure, e.g.,
+	// RestartLaunchFailure.
+	Reason RestartFailureReason `yaml:"reason"`
 }
 
 func (r RestartFailureReason) String() string {

--- a/payloads/start.go
+++ b/payloads/start.go
@@ -16,87 +16,215 @@
 
 package payloads
 
+// Persistence represents the persistency of an instance, i.e., whether that
+// instance should be restarted after certain events have occurred, e.g., the
+// node on which the instance runs is rebooted. It's not currently implemented
+// in ciao-launcher.
 type Persistence string
+
+// Firmware represents the type of firmware used to boot a VM
 type Firmware string
+
+// Resource represents the name of a resource in a StartCmd structure
 type Resource string
+
+// Hypervisor indicates the type of hypervisor used to run a given instance
 type Hypervisor string
 
 const (
-	All  Persistence = "all"
-	VM               = "vm"
-	Host             = "host"
+	// All is reserved for future usage.
+	All Persistence = "all"
+
+	// VM is reserved for future usage.
+	VM = "vm"
+
+	// Host is reserved for future usage.
+	Host = "host"
 )
 
 const (
-	EFI    Firmware = "efi"
-	Legacy          = "legacy"
+	// EFI indicates that EFI firmware, e.g., OVMF.fd, should be used to
+	// boot a VM
+	EFI Firmware = "efi"
+
+	// Legacy indicates that legacy firmware, e.g., BIOS should be used
+	// to boot a VM
+	Legacy = "legacy"
 )
 
 const (
-	VCPUs       Resource = "vcpus"
-	MemMB                = "mem_mb"
-	DiskMB               = "disk_mb"
-	NetworkNode          = "network_node"
-	ComputeNode          = "compute_node"
+	// VCPUs indicates that a particular resource struct contains a count
+	// of VCPUs
+	VCPUs Resource = "vcpus"
+
+	// MemMB indicates that a resource struct specifies a quantity of memory
+	// in MBs
+	MemMB = "mem_mb"
+
+	// DiskMB indicates that a resource struct specifies a quantity of disk
+	// space in MBs
+	DiskMB = "disk_mb"
+
+	// NetworkNode indicates that a resource struct specifies whether the
+	// command in which it is embedded applies to a network node.
+	NetworkNode = "network_node"
+
+	// ComputeNode indicates that a resource struct specifies whether the
+	// command in which it is embedded applies to a compute node.
+	ComputeNode = "compute_node"
 )
 
 const (
-	QEMU   Hypervisor = "qemu"
-	Docker            = "docker"
+	// QEMU specifies that an instance is to be booted on QEMU KVM VM.
+	QEMU Hypervisor = "qemu"
+
+	// Docker specifies that an instance is to be launched inside a Docker
+	// container.
+	Docker = "docker"
 )
 
+// RequestedResource is used to specify an individual resource contained within
+// a Start or Restart command.  Example of resources include number of VCPUs or
+// MBs of RAM to assign to an instance
 type RequestedResource struct {
-	Type      Resource `yaml:"type"`
-	Value     int      `yaml:"value"`
-	Mandatory bool     `yaml:"mandatory"`
+	// Type specifies the type of the resource, e.g., VCPUs.
+	Type Resource `yaml:"type"`
+
+	// Value specifies the integer value associated with that resource.
+	Value int `yaml:"value"`
+
+	// Mandatory indicates whether a resource is mandatory or not.
+	Mandatory bool `yaml:"mandatory"`
 }
 
+// EstimatedResource is reserved for future usage.
 type EstimatedResource struct {
-	Type  Resource `yaml:"type"`
-	Value int      `yaml:"value"`
+	// Type is reserved for future usage.
+	Type Resource `yaml:"type"`
+
+	// Value is reserved for future usage.
+	Value int `yaml:"value"`
 }
 
+// NetworkResources contains all the networking information for an instance
 type NetworkResources struct {
-	VnicMAC          string `yaml:"vnic_mac"`
-	VnicUUID         string `yaml:"vnic_uuid"`
+
+	// VnicMAC contains the MAC address of an instance's VNIC
+	VnicMAC string `yaml:"vnic_mac"`
+
+	// VnicUUID is a cluster unique UUID assigned to an instance's VNIC
+	VnicUUID string `yaml:"vnic_uuid"`
+
+	// ConcentratorUUID is the UUID of the CNCI instance.  Only specified
+	// when creating CN instances.
 	ConcentratorUUID string `yaml:"concentrator_uuid"`
-	ConcentratorIP   string `yaml:"concentrator_ip"`
-	Subnet           string `yaml:"subnet"`
-	SubnetKey        string `yaml:"subnet_key"`
-	SubnetUUID       string `yaml:"subnet_uuid"`
-	PrivateIP        string `yaml:"private_ip"`
-	PublicIP         bool   `yaml:"public_ip"`
+
+	// ConcentratorIP is the IP address of the CNCI.  Only specified
+	// when creating CN instances.
+	ConcentratorIP string `yaml:"concentrator_ip"`
+
+	// Subnet is the subnet to which the instance is assigned.  Only
+	// specified when creating CN instances.
+	Subnet string `yaml:"subnet"`
+
+	// SubnetKey is reserved for future usage.
+	SubnetKey string `yaml:"subnet_key"`
+
+	// SubnetUUID is reserved for future usage.
+	SubnetUUID string `yaml:"subnet_uuid"`
+
+	// PrivateIP represents the private IP address of an instance.  Only
+	// specified when creating CN instances.
+	PrivateIP string `yaml:"private_ip"`
+
+	// PublicIP is  reserved for future usage.
+	PublicIP bool `yaml:"public_ip"`
 }
 
+// StartCmd contains the information needed to start a new instance.
 type StartCmd struct {
-	TenantUUID          string              `yaml:"tenant_uuid"`
-	InstanceUUID        string              `yaml:"instance_uuid"`
-	ImageUUID           string              `yaml:"image_uuid"`
-	DockerImage         string              `yaml:"docker_image"`
-	FWType              Firmware            `yaml:"fw_type"`
-	InstancePersistence Persistence         `yaml:"persistence"`
-	VMType              Hypervisor          `yaml:"vm_type"`
-	RequestedResources  []RequestedResource `yaml:"requested_resources"`
-	EstimatedResources  []EstimatedResource `yaml:"estimated_resources"`
-	Networking          NetworkResources    `yaml:"networking"`
+	// TenantUUID is the UUID of the tennant to which the new instance will
+	// belong.
+	TenantUUID string `yaml:"tenant_uuid"`
+
+	// InstanceUUID is the UUID of the instance itself.
+	InstanceUUID string `yaml:"instance_uuid"`
+
+	// ImageUUID is the UUID of the image upon which the RootFS of this
+	// instance will be based.  Only used for qemu instances.
+	ImageUUID string `yaml:"image_uuid"`
+
+	// DockerImage is the name of the docker base image from which the
+	// container will be created.  It should match the name of an
+	// existing image in the docker registry.  Only used for docker
+	// instances.
+	DockerImage string `yaml:"docker_image"`
+
+	// FWType indicates the type of firmware needed to boot the instance.
+	// Only used for qemu instances.
+	FWType Firmware `yaml:"fw_type"`
+
+	// InstancePersistence is reserved for future use.
+	InstancePersistence Persistence `yaml:"persistence"`
+
+	// VMType indicates whether we are creating a qemu or docker instance.
+	VMType Hypervisor `yaml:"vm_type"`
+
+	// RequestedResources contains a list of the resources that are to be
+	// assigned to the new instance.
+	RequestedResources []RequestedResource `yaml:"requested_resources"`
+
+	// EstimatedResources is reserved for future usage.
+	EstimatedResources []EstimatedResource `yaml:"estimated_resources"`
+
+	// Networking contains all the information required to set up networking
+	// for the new instance.
+	Networking NetworkResources `yaml:"networking"`
 }
 
+// Start represents the unmarshalled version of the contents of a SSNTP START
+// payload.  The structure contains enough information to create and launch a
+// new CN or NN instance.
 type Start struct {
+	// Start contains information about the instance to create.
 	Start StartCmd `yaml:"start"`
 }
 
+// RestartCmd contains information needed to restart an instance.
 type RestartCmd struct {
-	TenantUUID          string              `yaml:"tenant_uuid"`
-	InstanceUUID        string              `yaml:"instance_uuid"`
-	ImageUUID           string              `yaml:"image_uuid"`
-	WorkloadAgentUUID   string              `yaml:"workload_agent_uuid"`
-	FWType              Firmware            `yaml:"fw_type"`
-	InstancePersistence Persistence         `yaml:"persistence"`
-	RequestedResources  []RequestedResource `yaml:"requested_resources"`
-	EstimatedResources  []EstimatedResource `yaml:"estimated_resources"`
-	Networking          NetworkResources    `yaml:"networking"`
+	// TenantUUID is reserved for future usage.
+	TenantUUID string `yaml:"tenant_uuid"`
+
+	// InstanceUUID is the UUID of the instance to restart
+	InstanceUUID string `yaml:"instance_uuid"`
+
+	// ImageUUID  is reserved for future usage.
+	ImageUUID string `yaml:"image_uuid"`
+
+	// WorkloadAgentUUID identifies the node on which the instance is
+	// running.  This information is needed by the scheduler to route
+	// the command to the correct CN/NN.
+	WorkloadAgentUUID string `yaml:"workload_agent_uuid"`
+
+	// FWType is reserved for future usage.
+	FWType Firmware `yaml:"fw_type"`
+
+	// InstancePersistence is reserved for future usage.
+	InstancePersistence Persistence `yaml:"persistence"`
+
+	// RequestedResources is reserved for future usage.
+	RequestedResources []RequestedResource `yaml:"requested_resources"`
+
+	// EstimatedResourcse is reserved for future usage.
+	EstimatedResources []EstimatedResource `yaml:"estimated_resources"`
+
+	// Networking is reserved for future usage.
+	Networking NetworkResources `yaml:"networking"`
 }
 
+// Restart represents the unmarshalled version of the contents of a SSNTP
+// RESTART payload.  The structure contains enough information to restart a CN
+// or NN instance.
 type Restart struct {
 	Restart RestartCmd `yaml:"restart"`
 }

--- a/payloads/startfailure.go
+++ b/payloads/startfailure.go
@@ -16,30 +16,73 @@
 
 package payloads
 
+// StartFailureReason denotes the underlying error that prevented
+// an SSNTP START command from launching a new instance on a CN
+// or a NN.  Most, but not all, of these errors are returned by
+// ciao-launcher
 type StartFailureReason string
 
 const (
-	FullCloud       StartFailureReason = "full_cloud"
-	FullComputeNode                    = "full_cn"
-	NoComputeNodes                     = "no_cn"
-	NoNetworkNodes                     = "no_net_cn"
-	InvalidPayload                     = "invalid_payload"
-	InvalidData                        = "invalid_data"
-	AlreadyRunning                     = "already_running"
-	InstanceExists                     = "instance_exists"
-	ImageFailure                       = "image_failure"
-	LaunchFailure                      = "launch_failure"
-	NetworkFailure                     = "network_failure"
+	// FullCloud is returned by the scheduler when all nodes in the cluster
+	// are FULL and it is unable to satisfy a START request.
+	FullCloud StartFailureReason = "full_cloud"
+
+	// FullComputeNode indicates that the node to which the START command
+	// was sent had insufficient resources to start the requested instance.
+	FullComputeNode = "full_cn"
+
+	// NoComputeNodes is returned by the scheduler if no compute nodes are
+	// running in the cluster upon which the instance can be started.
+	NoComputeNodes = "no_cn"
+
+	// NoNetworkNodes is returned by the scheduler if no network nodes are
+	// running in the cluster upon which the instance can be started.
+	NoNetworkNodes = "no_net_cn"
+
+	// InvalidPayload indicates that the contents of the START payload are
+	// corrupt
+	InvalidPayload = "invalid_payload"
+
+	// InvalidData indicates that the start section of the payload is
+	// corrupt or missing information such as image-id
+	InvalidData = "invalid_data"
+
+	// AlreadyRunning is returned when an attempt is made to start an
+	// instance on a node upon which that very same instance is already
+	// running.
+	AlreadyRunning = "already_running"
+
+	// InstanceExists is returned when an attempt is made to start an
+	// instance on a node upon which that very same instance already
+	// exists but is not currently running.
+	InstanceExists = "instance_exists"
+
+	// ImageFailure indicates that ciao-launcher is unable to prepare
+	// the rootfs for the instance, e.g., the image_uuid refers to an
+	// non-existent backing image
+	ImageFailure = "image_failure"
+
+	// LaunchFailure indicates that the instance has been successfully
+	// created but could not be launched.  Actually, this is sort of an
+	// odd situation as the START command partially succeeded.
+	// ciao-launcher returns an error code, but the instance has been
+	// created and could be booted a later stage via the RESTART command.
+	LaunchFailure = "launch_failure"
+
+	// NetworkFailure indicates that it was not possible to initialise
+	// networking for the instance.
+	NetworkFailure = "network_failure"
 )
 
+// ErrorStartFailure represents the unmarshalled version of the contents of a
+// SSNTP ERROR frame whose type is set to ssntp.StartFailure.
 type ErrorStartFailure struct {
-	InstanceUUID string             `yaml:"instance_uuid"`
-	Reason       StartFailureReason `yaml:"reason"`
-}
+	// InstanceUUID is the UUID of the instance that could not be started.
+	InstanceUUID string `yaml:"instance_uuid"`
 
-func (s *ErrorStartFailure) Init() {
-	s.InstanceUUID = ""
-	s.Reason = ""
+	// Reason provides the reason for the start failure, e.g.,
+	// LaunchFailure.
+	Reason StartFailureReason `yaml:"reason"`
 }
 
 func (r StartFailureReason) String() string {

--- a/payloads/stats.go
+++ b/payloads/stats.go
@@ -16,9 +16,15 @@
 
 package payloads
 
+// InstanceStat contains information about the state of an indiviual
+// instance in a ciao cluster.
 type InstanceStat struct {
+
+	// UUID of the instance to which this stats structure pertains
 	InstanceUUID string `yaml:"instance_uuid"`
-	State        string `yaml:"state"`
+
+	// State of the instance, e.g., running, pending, exited
+	State string `yaml:"state"`
 
 	// IP address to use to connect to instance via SSH.  This
 	// is actually the IP address of the CNCI VM.
@@ -45,33 +51,78 @@ type InstanceStat struct {
 	CPUUsage int `yaml:"cpu_usage"`
 }
 
+// NetworkStat contains information about a single network interface present on
+// a ciao compute or network node.
 type NetworkStat struct {
 	NodeIP  string `yaml:"ip"`
 	NodeMAC string `yaml:"mac"`
 }
 
+// Stat represents a snapshot of the state of a compute or a network node.  This
+// information is sent periodically by ciao-launcher to the scheduler.
 type Stat struct {
-	NodeUUID        string `yaml:"node_uuid"`
-	Status          string `yaml:"status"`
-	MemTotalMB      int    `yaml:"mem_total_mb"`
-	MemAvailableMB  int    `yaml:"mem_available_mb"`
-	DiskTotalMB     int    `yaml:"disk_total_mb"`
-	DiskAvailableMB int    `yaml:"disk_available_mb"`
-	Load            int    `yaml:"load"`
-	CpusOnline      int    `yaml:"cpus_online"`
-	NodeHostName    string `yaml:"hostname"`
-	Networks        []NetworkStat
-	Instances       []InstanceStat
+	// The UUID of the launcher instance from which the Stats structure
+	// originated
+	NodeUUID string `yaml:"node_uuid"`
+
+	// The Status of the node, e.g., READY or FULL
+	Status string `yaml:"status"`
+
+	// Total amount of RAM available on a CN or NN
+	MemTotalMB int `yaml:"mem_total_mb"`
+
+	// Memory currently available on a CN or NN, computed from
+	// proc/meminfo:MemFree + Active(file) + Inactive(file)
+	MemAvailableMB int `yaml:"mem_available_mb"`
+
+	// Size of the CN/NN RootFS in MB
+	DiskTotalMB int `yaml:"disk_total_mb"`
+
+	// MBs available in the RootFS of the CN/NN
+	DiskAvailableMB int `yaml:"disk_available_mb"`
+
+	// Load of CN/NN, taken from /proc/loadavg (Average over last minute
+	// reported
+	Load int `yaml:"load"`
+
+	// Number of CPUs present in the CN/NN.  Derived from the number of
+	// cpu[0-9]+ entries in /proc/stat
+	CpusOnline int `yaml:"cpus_online"`
+
+	// Hostname of the CN/NN
+	NodeHostName string `yaml:"hostname"`
+
+	// Array containing one entry for each network interface present on the
+	// CN/NN
+	Networks []NetworkStat
+
+	// Array containing statistics information for each instance hosted by
+	// the CN/NN
+	Instances []InstanceStat
 }
 
 const (
-	Pending    = "pending"
-	Running    = "running"
-	Exited     = "exited"
+	// Pending indicates that ciao-launcher has not yet ascertained the
+	// state of a given instance.  This can happen, either because the
+	// instance is in the process of being created, or ciao-launcher itself
+	// has just started and is still gathering information about the
+	// existing instances.
+	Pending = "pending"
+
+	// Running indicates an instance is running
+	Running = "running"
+
+	// Exited indicates that an instance has been successfully created but
+	// is not currently running, either because it failed to start or was
+	// explicitly stopped by a STOP command or perhaps by a CN reboot.
+	Exited = "exited"
+	// ExitFailed is not currently used
 	ExitFailed = "exit_failed"
+	// ExitPaused is not currently used
 	ExitPaused = "exit_paused"
 )
 
+// Init initialises instances of the Stat structure.
 func (s *Stat) Init() {
 	s.NodeUUID = ""
 	s.MemTotalMB = -1

--- a/payloads/stop.go
+++ b/payloads/stop.go
@@ -16,15 +16,29 @@
 
 package payloads
 
+// StopCmd contains the information needed to stop a running instance.
 type StopCmd struct {
-	InstanceUUID      string `yaml:"instance_uuid"`
+	// InstanceUUID is the UUID of the instance to stop
+	InstanceUUID string `yaml:"instance_uuid"`
+
+	// WorkloadAgentUUID identifies the node on which the instance is
+	// running.  This information is needed by the scheduler to route
+	// the command to the correct CN/NN.
 	WorkloadAgentUUID string `yaml:"workload_agent_uuid"`
 }
 
+// Stop represents the unmarshalled version of the contents of a SSNTP STOP
+// payload.  The structure contains enough information to stop a CN or NN
+// instance.
 type Stop struct {
+	// Stop contains information about the instance to stop.
 	Stop StopCmd `yaml:"stop"`
 }
 
+// Delete represents the unmarshalled version of the contents of a SSNTP DELETE
+// payload.  The structure contains enough information to delete a CN or NN
+// instance.
 type Delete struct {
+	// Delete contains information about the instance to delete.
 	Delete StopCmd `yaml:"delete"`
 }

--- a/payloads/stopfailure.go
+++ b/payloads/stopfailure.go
@@ -16,23 +16,41 @@
 
 package payloads
 
+// StopFailureReason denotes the underlying error that prevented
+// an SSNTP STOP command from stopping a running instance.
 type StopFailureReason string
 
 const (
-	StopNoInstance     StopFailureReason = "no_instance"
-	StopInvalidPayload                   = "invalid_payload"
-	StopInvalidData                      = "invalid_data"
-	StopAlreadyStopped                   = "already_stopped"
+	// StopNoInstance indicates that an instance could not be stopped
+	// as it does not exist on the node to which the STOP command was
+	// sent.
+	StopNoInstance StopFailureReason = "no_instance"
+
+	// StopInvalidPayload indicates that the payload of the SSNTP
+	// STOP command was corrupt and could not be unmarshalled.
+	StopInvalidPayload = "invalid_payload"
+
+	// StopInvalidData is returned by ciao-launcher if the contents
+	// of the STOP payload are incorrect, e.g., the instance_uuid
+	// is missing.
+	StopInvalidData = "invalid_data"
+
+	// StopAlreadyStopped indicates that the instance does exist on the
+	// node to which the STOP command was sent, but that it
+	// is not currently running, e.g., it's status is either exited or
+	// pending.
+	StopAlreadyStopped = "already_stopped"
 )
 
+// ErrorStopFailure represents the unmarshalled version of the contents of a
+// SSNTP ERROR frame whose type is set to ssntp.StopFailure.
 type ErrorStopFailure struct {
-	InstanceUUID string            `yaml:"instance_uuid"`
-	Reason       StopFailureReason `yaml:"reason"`
-}
+	// InstanceUUID is the UUID of the instance that could not be stopped.
+	InstanceUUID string `yaml:"instance_uuid"`
 
-func (s *ErrorStopFailure) Init() {
-	s.InstanceUUID = ""
-	s.Reason = ""
+	// Reason provides the reason for the stop failure, e.g.,
+	// StopAlreadyStopped.
+	Reason StopFailureReason `yaml:"reason"`
 }
 
 func (r StopFailureReason) String() string {


### PR DESCRIPTION
All exported types and fields in the following files have now been
documented, thereby fixing the golint errors reported in these files.

 - deletefailure.go
 - restartfailure.go
 - start.go
 - startfailure.go
 - stats.go
 - stop.go
 - stopfailure.go

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>