### PR TITLE
ciao-launcher: specify media type for ciao.iso and seed.iso

### DIFF
--- a/ciao-launcher/qemu.go
+++ b/ciao-launcher/qemu.go
@@ -475,15 +475,14 @@ func (q *qemu) startVM(vnicName, ipAddress string) error {
 	vmImage := path.Join(q.instanceDir, "image.qcow2")
 	qmpSocket := path.Join(q.instanceDir, "socket")
 	fileParam := fmt.Sprintf("file=%s,if=virtio,aio=threads,format=qcow2", vmImage)
-	//BUG(markus): Should specify media type here
-	isoParam := fmt.Sprintf("file=%s,if=virtio", q.isoPath)
+	isoParam := fmt.Sprintf("file=%s,if=virtio,media=cdrom", q.isoPath)
 	qmpParam := fmt.Sprintf("unix:%s,server,nowait", qmpSocket)
 
 	params := make([]string, 0, 32)
 	params = append(params, "-drive", fileParam)
 	params = append(params, "-drive", isoParam)
 	if q.cfg.NetworkNode {
-		ciaoParam := fmt.Sprintf("file=%s,if=virtio", q.ciaoISOPath)
+		ciaoParam := fmt.Sprintf("file=%s,if=virtio,media=cdrom", q.ciaoISOPath)
 		params = append(params, "-drive", ciaoParam)
 	}
 

--- a/networking/cnci_agent/scripts/run_cnci_vm.sh
+++ b/networking/cnci_agent/scripts/run_cnci_vm.sh
@@ -48,5 +48,5 @@ qemu-system-x86_64 \
 	-vga none -nographic \
 	-drive file="$IMAGE",if=virtio,aio=threads \
 	-net nic,model=virtio,macaddr=$(< /sys/class/net/$MACVTAP/address) -net tap,fd=3 3<>$tapdev \
-	-drive file=seed.iso,if=virtio -drive file=ciao.iso,if=virtio \
+	-drive file=seed.iso,if=virtio,media=cdrom -drive file=ciao.iso,if=virtio,media=cdrom \
 	-debugcon file:debug.log -global isa-debugcon.iobase=0x402


### PR DESCRIPTION
qemu presents a warning when the media type is not specfied.
This change supresses those warnings and closes issue#5
https://github.com/01org/ciao/issues/5

Signed-off-by: Alberto Murillo <alberto.murillo.silva@intel.com>