### PR TITLE
Fix all outstanding golint errors in payloads.

### DIFF
--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -698,7 +698,7 @@ func listClusterEvents(tenant string) {
 
 	fmt.Printf("%d Ciao event(s):\n", len(events.Events))
 	for i, event := range events.Events {
-		fmt.Printf("\t[%d] %v: %s:%s (Tenant %s)\n", i+1, event.Timestamp, event.EventType, event.Message, event.TenantId)
+		fmt.Printf("\t[%d] %v: %s:%s (Tenant %s)\n", i+1, event.Timestamp, event.EventType, event.Message, event.TenantID)
 	}
 
 }

--- a/ciao-controller/compute.go
+++ b/ciao-controller/compute.go
@@ -1325,7 +1325,7 @@ func listEvents(w http.ResponseWriter, r *http.Request, context *controller) {
 
 		event := payloads.CiaoEvent{
 			Timestamp: l.Timestamp,
-			TenantId:  l.TenantID,
+			TenantID:  l.TenantID,
 			EventType: l.EventType,
 			Message:   l.Message,
 		}

--- a/ciao-controller/compute_test.go
+++ b/ciao-controller/compute_test.go
@@ -604,7 +604,7 @@ func TestListEventsTenant(t *testing.T) {
 
 		event := payloads.CiaoEvent{
 			Timestamp: l.Timestamp,
-			TenantId:  l.TenantID,
+			TenantID:  l.TenantID,
 			EventType: l.EventType,
 			Message:   l.Message,
 		}
@@ -921,7 +921,7 @@ func TestListEvents(t *testing.T) {
 	for _, l := range logs {
 		event := payloads.CiaoEvent{
 			Timestamp: l.Timestamp,
-			TenantId:  l.TenantID,
+			TenantID:  l.TenantID,
 			EventType: l.EventType,
 			Message:   l.Message,
 		}

--- a/payloads/assignpublicIP.go
+++ b/payloads/assignpublicIP.go
@@ -16,6 +16,7 @@
 
 package payloads
 
+// PublicIPCommand is reserved for future use.
 type PublicIPCommand struct {
 	ConcentratorUUID string `yaml:"concentrator_uuid"`
 	TenantUUID       string `yaml:"tenant_uuid"`
@@ -25,24 +26,37 @@ type PublicIPCommand struct {
 	VnicMAC          string `yaml:"vnic_mac"`
 }
 
+// CommandAssignPublicIP is reserved for future use.
 type CommandAssignPublicIP struct {
 	AssignIP PublicIPCommand `yaml:"assign_public_ip"`
 }
 
+// CommandReleasePublicIP is reserved for future use.
 type CommandReleasePublicIP struct {
 	ReleaseIP PublicIPCommand `yaml:"release_public_ip"`
 }
 
+// PublicIPFailureReason is reserved for future use.
 type PublicIPFailureReason string
 
 const (
-	PublicIPNoInstance     PublicIPFailureReason = "no_instance"
-	PublicIPInvalidPayload                       = "invalid_payload"
-	PublicIPInvalidData                          = "invalid_data"
-	PublicIPAssignFailure                        = "assign_failure"
-	PublicIPReleaseFailure                       = "release_failure"
+	// PublicIPNoInstance is reserved for future use.
+	PublicIPNoInstance PublicIPFailureReason = "no_instance"
+
+	// PublicIPInvalidPayload is reserved for future use.
+	PublicIPInvalidPayload = "invalid_payload"
+
+	// PublicIPInvalidData is reserved for future use.
+	PublicIPInvalidData = "invalid_data"
+
+	// PublicIPAssignFailure is reserved for future use.
+	PublicIPAssignFailure = "assign_failure"
+
+	// PublicIPReleaseFailure is reserved for future use.
+	PublicIPReleaseFailure = "release_failure"
 )
 
+// ErrorPublicIPFailure is reserved for future use.
 type ErrorPublicIPFailure struct {
 	ConcentratorUUID string                `yaml:"concentrator_uuid"`
 	TenantUUID       string                `yaml:"tenant_uuid"`
@@ -51,16 +65,6 @@ type ErrorPublicIPFailure struct {
 	PrivateIP        string                `yaml:"private_ip"`
 	VnicMAC          string                `yaml:"vnic_mac"`
 	Reason           PublicIPFailureReason `yaml:"reason"`
-}
-
-func (s *ErrorPublicIPFailure) Init() {
-	s.ConcentratorUUID = ""
-	s.TenantUUID = ""
-	s.InstanceUUID = ""
-	s.Reason = ""
-	s.PublicIP = ""
-	s.PrivateIP = ""
-	s.VnicMAC = ""
 }
 
 func (r PublicIPFailureReason) String() string {

--- a/payloads/cnciinstance.go
+++ b/payloads/cnciinstance.go
@@ -16,6 +16,11 @@
 
 package payloads
 
+// CNCIInstanceConfig is used to pass information between a ciao-launcher
+// running on an NN and CNCI instances invoked by that launcher.  This
+// information is marshalled out to a yaml file, stored on an ISO image
+// and made available to the VM running the CNCI agent.
 type CNCIInstanceConfig struct {
+	// SchedulerAddr is the IP address of the scheduler.
 	SchedulerAddr string `yaml:"scheduler_addr"`
 }

--- a/payloads/compute.go
+++ b/payloads/compute.go
@@ -354,7 +354,7 @@ type CiaoTraceData struct {
 // in a ciao cluster.
 type CiaoEvent struct {
 	Timestamp time.Time `json:"time_stamp"`
-	TenantId  string    `json:"tenant_id"`
+	TenantID  string    `json:"tenant_id"`
 	EventType string    `json:"type"`
 	Message   string    `json:"message"`
 }

--- a/payloads/compute.go
+++ b/payloads/compute.go
@@ -20,6 +20,8 @@ import (
 	"time"
 )
 
+// PrivateAddresses contains information about a single instance network
+// interface.
 type PrivateAddresses struct {
 	Addr               string `json:"addr"`
 	OSEXTIPSMACMacAddr string `json:"OS-EXT-IPS-MAC:mac_addr"`
@@ -27,35 +29,49 @@ type PrivateAddresses struct {
 	Version            int    `json:"version"`
 }
 
+// Addresses contains information about an instance's networks.
 type Addresses struct {
 	Private []PrivateAddresses `json:"private"`
 }
 
+// Link is reserved for future use.
 type Link struct {
 	Href string `json:"href"`
 	Rel  string `json:"rel"`
 }
 
+// Flavor identifies the flavour (workload) of an instance.
 type Flavor struct {
 	ID    string `json:"id"`
 	Links []Link `json:"links"`
 }
 
+// Image identifies the base image of the instance.
 type Image struct {
 	ID    string `json:"id"`
 	Links []Link `json:"links"`
 }
 
+// SecurityGroup represents the security group of an instance.
 type SecurityGroup struct {
 	Name string `json:"name"`
 }
 
 const (
+	// ComputeStatusPending is a filter that used to select pending
+	// instances in requests to the controller.
 	ComputeStatusPending = "pending"
+
+	// ComputeStatusRunning is a filter that used to select running
+	// instances in requests to the controller.
 	ComputeStatusRunning = "running"
+
+	// ComputeStatusStopped is a filter that used to select exited
+	// instances in requests to the controller.
 	ComputeStatusStopped = "exited"
 )
 
+// Server contains information about a specific instance within a ciao cluster.
 type Server struct {
 	Addresses                        Addresses       `json:"addresses"`
 	Created                          time.Time       `json:"created"`
@@ -91,15 +107,24 @@ type Server struct {
 	SSHPort                          int             `json:"ssh_port"`
 }
 
+// ComputeServers represents the unmarshalled version of the contents of a
+// /v2.1/{tenant}/servers/detail response.  It contains information about a
+// set of instances within a ciao cluster.
 type ComputeServers struct {
 	TotalServers int      `json:"total_servers"`
 	Servers      []Server `json:"servers"`
 }
 
+// ComputeServer represents the unmarshalled version of the contents of a
+// /v2.1/{tenant}/servers/{server} response.  It contains information about a
+// specific instance within a ciao cluster.
 type ComputeServer struct {
 	Server Server `json:"server"`
 }
 
+// ComputeFlavors represents the unmarshalled version of the contents of a
+// /v2.1/{tenant}/flavors response.  It contains information about all the
+// flavors in a cluster.
 type ComputeFlavors struct {
 	Flavors []struct {
 		ID    string `json:"id"`
@@ -108,6 +133,7 @@ type ComputeFlavors struct {
 	} `json:"flavors"`
 }
 
+// FlavorDetails contains information about a specific flavor.
 type FlavorDetails struct {
 	OSFLVDISABLEDDisabled  bool   `json:"OS-FLV-DISABLED:disabled"`
 	Disk                   string `json:"disk"` /* OpenStack API says this is an int */
@@ -121,10 +147,16 @@ type FlavorDetails struct {
 	Vcpus                  int    `json:"vcpus"`
 }
 
+// ComputeFlavorDetails represents the unmarshalled version of the contents of a
+// /v2.1/{tenant}/flavors/{flavor} response.  It contains information about a
+// specific flavour.
 type ComputeFlavorDetails struct {
 	Flavor FlavorDetails `json:"flavor"`
 }
 
+// ComputeCreateServer represents the unmarshalled version of the contents of a
+// /v2.1/{tenant}/servers request.  It contains the information needed to start
+// one or more instances.
 type ComputeCreateServer struct {
 	Server struct {
 		Name         string `json:"name"`
@@ -135,6 +167,9 @@ type ComputeCreateServer struct {
 	} `json:"server"`
 }
 
+// CiaoComputeTenants represents the unmarshalled version of the contents of a
+// /v2.1/tenants response.  It contains information about the tenants in a ciao
+// cluster.
 type CiaoComputeTenants struct {
 	Tenants []struct {
 		ID   string `json:"id"`
@@ -142,6 +177,8 @@ type CiaoComputeTenants struct {
 	} `json:"tenants"`
 }
 
+// CiaoComputeNode contains status and statistic information for an individual
+// node.
 type CiaoComputeNode struct {
 	ID                    string    `json:"id"`
 	Timestamp             time.Time `json:"updated"`
@@ -158,10 +195,16 @@ type CiaoComputeNode struct {
 	TotalPausedInstances  int       `json:"total_paused_instances"`
 }
 
+// CiaoComputeNodes represents the unmarshalled version of the contents of a
+// /v2.1/nodes response.  It contains status and statistics information
+// for a set of nodes.
 type CiaoComputeNodes struct {
 	Nodes []CiaoComputeNode `json:"nodes"`
 }
 
+// CiaoTenantResources represents the unmarshalled version of the contents of a
+// /v2.1/{tenant}/quotas response.  It contains the current resource usage
+// information for a tenant.
 type CiaoTenantResources struct {
 	ID            string    `json:"id"`
 	Timestamp     time.Time `json:"updated"`
@@ -175,6 +218,7 @@ type CiaoTenantResources struct {
 	DiskUsage     int       `json:"disk_usage"`
 }
 
+// CiaoUsage contains a snapshot of resource consumption for a tenant.
 type CiaoUsage struct {
 	VCPU      int       `json:"cpus_usage"`
 	Memory    int       `json:"ram_usage"`
@@ -182,14 +226,19 @@ type CiaoUsage struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
+// CiaoUsageHistory represents the unmarshalled version of the contents of a
+// /v2.1/{tenant}/resources response.  It contains snapshots of usage information
+// for a given tenant over a given period of time.
 type CiaoUsageHistory struct {
 	Usages []CiaoUsage `json:"usage"`
 }
 
+// CiaoCNCISubnet contains subnet information for a CNCI.
 type CiaoCNCISubnet struct {
 	Subnet string `json:"subnet_cidr"`
 }
 
+// CiaoCNCI contains information about an individual CNCI.
 type CiaoCNCI struct {
 	ID        string           `json:"id"`
 	TenantID  string           `json:"tenant_id"`
@@ -198,14 +247,20 @@ type CiaoCNCI struct {
 	Subnets   []CiaoCNCISubnet `json:"subnets"`
 }
 
+// CiaoCNCIDetail represents the unmarshalled version of the contents of a
+// v2.1/cncis/{cnci}/detail response.  It contains information about a CNCI.
 type CiaoCNCIDetail struct {
 	CiaoCNCI `json:"cnci"`
 }
 
+// CiaoCNCIs represents the unmarshalled version of the contents of a
+// v2.1/cncis response.  It contains information about all the CNCIs
+// in the ciao cluster.
 type CiaoCNCIs struct {
 	CNCIs []CiaoCNCI `json:"cncis"`
 }
 
+// CiaoServerStats contains status information about a CN or a NN.
 type CiaoServerStats struct {
 	ID        string    `json:"id"`
 	NodeID    string    `json:"node_id"`
@@ -218,11 +273,17 @@ type CiaoServerStats struct {
 	DiskUsage int       `json:"disk_usage"`
 }
 
+// CiaoServersStats represents the unmarshalled version of the contents of a
+// v2.1/nodes/{node}/servers/detail response.  It contains general information
+// about a group of instances.
 type CiaoServersStats struct {
 	TotalServers int               `json:"total_servers"`
 	Servers      []CiaoServerStats `json:"servers"`
 }
 
+// CiaoClusterStatus represents the unmarshalled version of the contents of a
+// v2.1/nodes/summary response.  It contains information about the nodes that
+// make up a ciao cluster.
 type CiaoClusterStatus struct {
 	Status struct {
 		TotalNodes            int `json:"total_nodes"`
@@ -233,24 +294,33 @@ type CiaoClusterStatus struct {
 	} `json:"cluster"`
 }
 
+// CNCIDetail is reserved for future use.
 type CNCIDetail struct {
 	IPv4 string `json:"IPv4"`
 }
 
+// CiaoServersAction represents the unmarshalled version of the contents of a
+// v2.1/servers/action request.  It contains an action to be performed on
+// one or more instances.
 type CiaoServersAction struct {
 	Action    string   `json:"action"`
 	ServerIDs []string `json:"servers"`
 }
 
+// CiaoTraceSummary contains information about a specific SSNTP Trace label.
 type CiaoTraceSummary struct {
 	Label     string `json:"label"`
 	Instances int    `json:"instances"`
 }
 
+// CiaoTracesSummary represents the unmarshalled version of the response to a
+// v2.1/traces request.  It contains a list of all trace labels and the
+// number of instances associated with them.
 type CiaoTracesSummary struct {
 	Summaries []CiaoTraceSummary `json:"summaries"`
 }
 
+// CiaoFrameStat is reserved for future use
 type CiaoFrameStat struct {
 	ID               string  `json:"node_id"`
 	TotalElapsedTime float64 `json:"total_elapsed_time"`
@@ -259,6 +329,7 @@ type CiaoFrameStat struct {
 	SchedulerTime    float64 `json:"total_scheduler_time"`
 }
 
+// CiaoBatchFrameStat contains frame statisitics for a ciao cluster.
 type CiaoBatchFrameStat struct {
 	NumInstances             int     `json:"num_instances"`
 	TotalElapsed             float64 `json:"total_elapsed"`
@@ -271,11 +342,16 @@ type CiaoBatchFrameStat struct {
 	VarianceScheduler        float64 `json:"scheduler_variance"`
 }
 
+// CiaoTraceData represents the unmarshalled version of the response to a
+// v2.1/traces/{label} request.  It contains statistics computed from the trace
+// information of SSNTP commands sent within a ciao cluster.
 type CiaoTraceData struct {
 	Summary    CiaoBatchFrameStat `json:"summary"`
 	FramesStat []CiaoFrameStat    `json:"frames"`
 }
 
+// CiaoEvent contains information about an individual event generated
+// in a ciao cluster.
 type CiaoEvent struct {
 	Timestamp time.Time `json:"time_stamp"`
 	TenantId  string    `json:"tenant_id"`
@@ -283,6 +359,8 @@ type CiaoEvent struct {
 	Message   string    `json:"message"`
 }
 
+// CiaoEvents represents the unmarshalled version of the response to a
+// v2.1/{tenant}/event or v2.1/event request.
 type CiaoEvents struct {
 	Events []CiaoEvent `json:"events"`
 }

--- a/payloads/concentratorinstanceadded.go
+++ b/payloads/concentratorinstanceadded.go
@@ -16,6 +16,8 @@
 
 package payloads
 
+// ConcentratorInstanceAddedEvent contains information about a newly added
+// CNCI instance.
 type ConcentratorInstanceAddedEvent struct {
 	InstanceUUID    string `yaml:"instance_uuid"`
 	TenantUUID      string `yaml:"tenant_uuid"`
@@ -23,6 +25,9 @@ type ConcentratorInstanceAddedEvent struct {
 	ConcentratorMAC string `yaml:"concentrator_mac"`
 }
 
+// EventConcentratorInstanceAdded represents the unmarshalled version of the
+// contents of an SSNTP ssntp.ConcentratorInstanceAdded event.  This event is
+// sent by the cnci-agent to the controller when it connects to the scheduler.
 type EventConcentratorInstanceAdded struct {
 	CNCIAdded ConcentratorInstanceAddedEvent `yaml:"concentrator_instance_added"`
 }

--- a/payloads/configure.go
+++ b/payloads/configure.go
@@ -16,17 +16,26 @@
 
 package payloads
 
+// ServiceType is reserved for future use.
 type ServiceType string
+
+// StorageType is reserved for future use.
 type StorageType string
 
 const (
-	Glance   ServiceType = "glance"
+	// Glance is reserved for future use.
+	Glance ServiceType = "glance"
+
+	// Keystone is reserved for future use.
 	Keystone ServiceType = "keystone"
 )
 
 const (
+	// Filesystem is reserved for future use.
 	Filesystem StorageType = "file"
-	Etcd       StorageType = "etcd"
+
+	// Etcd is reserved for future use.
+	Etcd StorageType = "etcd"
 )
 
 func (s ServiceType) String() string {
@@ -51,11 +60,13 @@ func (s StorageType) String() string {
 	return ""
 }
 
+// ConfigureScheduler is reserved for future use.
 type ConfigureScheduler struct {
 	ConfigStorageType StorageType `yaml:"storage_type"`
 	ConfigStorageURI  string      `yaml:"storage_uri"`
 }
 
+// ConfigureController is reserved for future use.
 type ConfigureController struct {
 	ComputePort      int    `yaml:"compute_port"`
 	ComputeCACert    string `yaml:"compute_ca"`
@@ -64,6 +75,7 @@ type ConfigureController struct {
 	IdentityPassword string `yaml:"identity_password"`
 }
 
+// ConfigureLauncher is reserved for future use.
 type ConfigureLauncher struct {
 	ComputeNetwork    string `yaml:"compute_net"`
 	ManagementNetwork string `yaml:"mgmt_net"`
@@ -71,11 +83,13 @@ type ConfigureLauncher struct {
 	MemoryLimit       bool   `yaml:"mem_limit"`
 }
 
+// ConfigureService is reserved for future use.
 type ConfigureService struct {
 	Type ServiceType `yaml:"type"`
 	URL  string      `yaml:"url"`
 }
 
+// ConfigurePayload is reserved for future use.
 type ConfigurePayload struct {
 	Scheduler       ConfigureScheduler  `yaml:"scheduler"`
 	Controller      ConfigureController `yaml:"controller"`
@@ -84,6 +98,7 @@ type ConfigurePayload struct {
 	IdentityService ConfigureService    `yaml:"identity_service"`
 }
 
+// Configure is reserved for future use.
 type Configure struct {
 	Configure ConfigurePayload `yaml:"configure"`
 }

--- a/payloads/configure_test.go
+++ b/payloads/configure_test.go
@@ -86,7 +86,7 @@ func TestConfigureUnmarshal(t *testing.T) {
 	}
 
 	if cfg.Configure.Controller.ComputePort != computePort {
-		t.Errorf("Wrong controller compute port [%s]", cfg.Configure.Controller.ComputePort)
+		t.Errorf("Wrong controller compute port [%d]", cfg.Configure.Controller.ComputePort)
 	}
 }
 

--- a/payloads/evacuate.go
+++ b/payloads/evacuate.go
@@ -16,10 +16,12 @@
 
 package payloads
 
+// EvacuateCmd is reserved for future use.
 type EvacuateCmd struct {
 	WorkloadAgentUUID string `yaml:"workload_agent_uuid"`
 }
 
+// Evacuate is reserved for future use.
 type Evacuate struct {
 	Evacuate EvacuateCmd `yaml:"evacuate"`
 }

--- a/payloads/instancedeleted.go
+++ b/payloads/instancedeleted.go
@@ -16,10 +16,15 @@
 
 package payloads
 
+// InstanceDeletedEvent contains the UUID of an instance that has just been
+// deleted.
 type InstanceDeletedEvent struct {
 	InstanceUUID string `yaml:"instance_uuid"`
 }
 
+// EventInstanceDeleted represents the unmarshalled version of the contents of
+// an SSNTP ssntp.InstanceDeleted event. This event is sent by ciao-launcher
+// when it successfully deletes an instance.
 type EventInstanceDeleted struct {
 	InstanceDeleted InstanceDeletedEvent `yaml:"instance_deleted"`
 }

--- a/payloads/nodeconnected.go
+++ b/payloads/nodeconnected.go
@@ -16,15 +16,26 @@
 
 package payloads
 
+// NodeConnectedEvent contains information about a node that has either
+// just connected or disconnected.
 type NodeConnectedEvent struct {
-	NodeUUID string   `yaml:"node_uuid"`
+	// SSNTP UUID of the agent running on that node.
+	NodeUUID string `yaml:"node_uuid"`
+
+	// The type of the node, e.g., NetworkNode or ComputeNode.
 	NodeType Resource `yaml:"node_type"`
 }
 
+// NodeConnected represents the unmarshalled version of the contents of an
+// SSNTP ssntp.NodeConnected event payload.   This event is sent by the
+// scheduler to the controller to inform it that a node has just connected.
 type NodeConnected struct {
 	Connected NodeConnectedEvent `yaml:"node_connected"`
 }
 
+// NodeDisconnected represents the unmarshalled version of the contents of an
+// SSNTP ssntp.NodeDisconnected event payload.   This event is sent by the
+// scheduler to the controller to inform it that a node has just disconnected.
 type NodeDisconnected struct {
 	Disconnected NodeConnectedEvent `yaml:"node_disconnected"`
 }

--- a/payloads/publicIPassigned.go
+++ b/payloads/publicIPassigned.go
@@ -16,6 +16,7 @@
 
 package payloads
 
+// PublicIPEvent is reserved for future use.
 type PublicIPEvent struct {
 	ConcentratorUUID string `yaml:"concentrator_uuid"`
 	InstanceUUID     string `yaml:"instance_uuid"`
@@ -23,6 +24,7 @@ type PublicIPEvent struct {
 	PrivateIP        string `yaml:"private_ip"`
 }
 
+// EventPublicIPAssigned is reserved for future use.
 type EventPublicIPAssigned struct {
 	AssignedIP PublicIPEvent `yaml:"public_ip_assigned"`
 }

--- a/payloads/ready.go
+++ b/payloads/ready.go
@@ -16,16 +16,37 @@
 
 package payloads
 
+// Ready represents the unmarshalled version of the contents of an SSNTP READY
+// payload.  The structure contains information about the state of an NN or a CN
+// on which ciao-launcher is running.
 type Ready struct {
-	NodeUUID        string `yaml:"node_uuid"`
-	MemTotalMB      int    `yaml:"mem_total_mb"`
-	MemAvailableMB  int    `yaml:"mem_available_mb"`
-	DiskTotalMB     int    `yaml:"disk_total_mb"`
-	DiskAvailableMB int    `yaml:"disk_available_mb"`
-	Load            int    `yaml:"load"`
-	CpusOnline      int    `yaml:"cpus_online"`
+	// NodeUUID is the SSNTP UUID assigned to the ciao-launcher instance
+	// that transmitted the READY frame.
+	NodeUUID string `yaml:"node_uuid"`
+
+	// Total amount of RAM available on a CN or NN
+	MemTotalMB int `yaml:"mem_total_mb"`
+
+	// Memory currently available on a CN or NN, computed from
+	// proc/meminfo:MemFree + Active(file) + Inactive(file)
+	MemAvailableMB int `yaml:"mem_available_mb"`
+
+	// Size of the CN/NN RootFS in MB
+	DiskTotalMB int `yaml:"disk_total_mb"`
+
+	// MBs available in the RootFS of the CN/NN
+	DiskAvailableMB int `yaml:"disk_available_mb"`
+
+	// Load of CN/NN, taken from /proc/loadavg (Average over last minute
+	// reported).
+	Load int `yaml:"load"`
+
+	// Number of CPUs present in the CN/NN.  Derived from the number of
+	// cpu[0-9]+ entries in /proc/stat.
+	CpusOnline int `yaml:"cpus_online"`
 }
 
+// Init initialises the Ready structure.
 func (s *Ready) Init() {
 	s.NodeUUID = ""
 	s.MemTotalMB = -1

--- a/payloads/tenantadded.go
+++ b/payloads/tenantadded.go
@@ -16,20 +16,45 @@
 
 package payloads
 
+// TenantAddedEvent is populated by ciao-launcher whenever it creates
+// or removes a local tunnel for a tennant on a CN.  This information is
+// sent to a CNCI instance, via the scheduler.  The cnci-agent then does
+// its magic.
 type TenantAddedEvent struct {
-	AgentUUID        string `yaml:"agent_uuid"`
-	AgentIP          string `yaml:"agent_ip"`
-	TenantUUID       string `yaml:"tenant_uuid"`
-	TenantSubnet     string `yaml:"tenant_subnet"`
+	// The UUID of the ciao-launcher that generated the event.
+	AgentUUID string `yaml:"agent_uuid"`
+
+	// The IP address of the CN on which the originating agent runs.
+	AgentIP string `yaml:"agent_ip"`
+
+	// The UUID of the tennant.
+	TenantUUID string `yaml:"tenant_uuid"`
+
+	// The subnet of the Tenant.
+	TenantSubnet string `yaml:"tenant_subnet"`
+
+	// The UUID of the concentrator.
 	ConcentratorUUID string `yaml:"concentrator_uuid"`
-	ConcentratorIP   string `yaml:"concentrator_ip"`
-	SubnetKey        int    `yaml:"subnet_key"`
+
+	// The IP address of the concentrator.
+	ConcentratorIP string `yaml:"concentrator_ip"`
+
+	// The UUID of the subnet.
+	SubnetKey int `yaml:"subnet_key"`
 }
 
+// EventTenantAdded represents the unmarshalled version of the contents of an
+// SSNTP ssntp.TenantAdded event payload. The structure contains all the
+// information needed by an CNCI instance to add a remote tunnel for a
+// CN
 type EventTenantAdded struct {
 	TenantAdded TenantAddedEvent `yaml:"tenant_added"`
 }
 
+// EventTenantRemoved represents the unmarshalled version of the contents of an
+// SSNTP ssntp.TenantRemoved event payload. The structure contains all the
+// information needed by an CNCI instance to remove a remote tunnel for a
+// CN
 type EventTenantRemoved struct {
 	TenantRemoved TenantAddedEvent `yaml:"tenant_removed"`
 }

--- a/payloads/trace.go
+++ b/payloads/trace.go
@@ -16,6 +16,8 @@
 
 package payloads
 
+// SSNTPNode contains information about a node through which a SSNTP frame
+// has passed.
 type SSNTPNode struct {
 	SSNTPUUID   string `yaml:"ssntp_node_uuid"`
 	SSNTPRole   string `yaml:"ssntp_role"`
@@ -23,6 +25,8 @@ type SSNTPNode struct {
 	RxTimestamp string `yaml:"rx_timestamp"`
 }
 
+// FrameTrace captures trace information for an SSNTP frame
+// as it makes its way through a SSNTP cluster.
 type FrameTrace struct {
 	Label          string `yaml:"label"`
 	Type           string `yaml:"type"`
@@ -32,6 +36,9 @@ type FrameTrace struct {
 	Nodes          []SSNTPNode
 }
 
+// Trace represents the unmarshalled version of the contents of an SSNTP
+// ssntp.TraceReport event.  The structure contains tracing information
+// for an SSNTP frame.
 type Trace struct {
 	Frames []FrameTrace
 }

--- a/test-cases/test-cases.go
+++ b/test-cases/test-cases.go
@@ -36,27 +36,57 @@ import (
 	"text/template"
 )
 
+// PackageInfo contains information about a package under test.
 type PackageInfo struct {
-	Name   string   `json:"name"`
-	Path   string   `json:"path"`
-	Files  []string `json:"files"`
+	// Name is the name of the package.
+	Name string `json:"name"`
+
+	// Path is the import path of the package.
+	Path string `json:"path"`
+
+	// File contains a list of all the test files associated with a package.
+	Files []string `json:"files"`
+
+	// XFiles contains a list of all the external test files associated with
+	// a package.
 	XFiles []string `json:"xfiles"`
 }
 
+// TestInfo contains information about an individual executed test case.
 type TestInfo struct {
-	Name           string
-	Summary        string
-	Description    string
+	// Name is the name of the test case.
+	Name string
+
+	// Summary provides a brief one line description of the test case.
+	Summary string
+
+	// Description contains a detailed description of the test case.
+	Description string
+
+	// ExpectedResult outlines the success criteria for the test case.
 	ExpectedResult string
-	Pass           bool
-	Result         string
-	TimeTaken      string
+
+	// Pass indicates whether the test case passed or not.
+	Pass bool
+
+	// Result provides the result of the test case.
+	Result string
+
+	// TimeTaken is a description of the time taken to run the test case.
+	TimeTaken string
 }
 
+// PackageTests contains information about the tests that have been executed for
+// an individual package
 type PackageTests struct {
-	Name     string
+	// Name is the name of the package.
+	Name string
+
+	// Coverage is the amount of package code covered by the test cases.
 	Coverage string
-	Tests    []*TestInfo
+
+	// Tests is an array containing information about the specific test cases.
+	Tests []*TestInfo
 }
 
 type testResults struct {


### PR DESCRIPTION
Pretty much all of these errors were documentation errors.  One was a badly named variable.

Documentation has been added for all exported types.  Some types which have been added but are not yet really used have been documented, reserved for future use.