### PR TITLE
scheduler locking (issue #120) fixes

### DIFF
--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -486,8 +486,8 @@ func (sched *ssntpSchedulerServer) decrementResourceUsage(node *nodeStat, worklo
 }
 
 func (sched *ssntpSchedulerServer) pickComputeNode(controllerUUID string, workload *workResources) (node *nodeStat) {
-	sched.cnMutex.Lock()
-	defer sched.cnMutex.Unlock()
+	sched.cnMutex.RLock()
+	defer sched.cnMutex.RUnlock()
 
 	if len(sched.cnList) == 0 {
 		sched.sendStartFailureError(controllerUUID, workload.instanceUUID, payloads.NoComputeNodes)


### PR DESCRIPTION
This is a series of cleanups found while looking at gocyclo's complaint about the scheduler's console heartbeat. Testing a refactor of the heartbeat highlighted that connect/disconnect races exist. Locking then became a part of what started as a much simpler refactor. Code runtime tests good manually, passes travis CI automation and gocyclo is now happier too.

This PR replaces PR #122.