### PR TITLE
Networking: Use Testify for all Networking Unit test cases

### DIFF
--- a/networking/libsnnet/bridge_test.go
+++ b/networking/libsnnet/bridge_test.go
@@ -17,9 +17,20 @@
 package libsnnet
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func performBridgeOps(shouldPass bool, assert *assert.Assertions, bridge *Bridge) {
+	a := assert.Nil
+	if !shouldPass {
+		a = assert.NotNil
+	}
+	a(bridge.enable())
+	a(bridge.disable())
+	a(bridge.destroy())
+}
 
 //Test all Bridge primitives
 //
@@ -29,34 +40,20 @@ import (
 //
 //Test is expected to pass
 func TestBridge_Basic(t *testing.T) {
+	assert := assert.New(t)
 
-	bridge, _ := newBridge("go_testbr")
+	bridge, err := newBridge("go_testbr")
+	assert.Nil(err)
 
-	if err := bridge.create(); err != nil {
-		t.Errorf("Bridge creation failed: %v", err)
-	}
+	assert.Nil(bridge.create())
 
-	bridge1, _ := newBridge("go_testbr")
+	bridge1, err := newBridge("go_testbr")
+	assert.Nil(err)
 
-	if err := bridge1.getDevice(); err != nil {
-		t.Errorf("Bridge Get Device failed: %v", err)
-	}
+	assert.Nil(bridge1.getDevice())
+	performBridgeOps(true, assert, bridge)
 
-	if err := bridge.enable(); err != nil {
-		t.Errorf("Bridge enable failed: %v", err)
-	}
-
-	if err := bridge.disable(); err != nil {
-		t.Errorf("Bridge enable failed: %v", err)
-	}
-
-	if err := bridge.destroy(); err != nil {
-		t.Errorf("Bridge deletion failed: %v", err)
-	}
-
-	if err := bridge.destroy(); err == nil {
-		t.Errorf("Bridge deletion should have failed")
-	}
+	assert.NotNil(bridge.destroy())
 
 }
 
@@ -67,19 +64,16 @@ func TestBridge_Basic(t *testing.T) {
 //
 //Test is expected to pass
 func TestBridge_Dup(t *testing.T) {
-	bridge, _ := newBridge("go_testbr")
+	assert := assert.New(t)
+	bridge, err := newBridge("go_testbr")
+	assert.Nil(err)
 
-	if err := bridge.create(); err != nil {
-		t.Errorf("Bridge creation failed: %v", err)
-	}
-
+	assert.Nil(bridge.create())
 	defer func() { _ = bridge.destroy() }()
 
-	bridge1, _ := newBridge("go_testbr")
-	if err := bridge1.create(); err == nil {
-		t.Errorf("Duplicate Bridge creation: %v", err)
-	}
-
+	bridge1, err := newBridge("go_testbr")
+	assert.Nil(err)
+	assert.NotNil(bridge1.create())
 }
 
 //Negative test cases for bridge primitives
@@ -89,39 +83,14 @@ func TestBridge_Dup(t *testing.T) {
 //
 //Test is expected to pass
 func TestBridge_Invalid(t *testing.T) {
+	assert := assert.New(t)
+
 	bridge, err := newBridge("go_testbr")
+	assert.Nil(err)
 
-	if err = bridge.getDevice(); err == nil {
-		t.Errorf("Non existing bridge: %v", bridge)
-	}
+	assert.NotNil(bridge.getDevice())
 
-	if !strings.HasPrefix(err.Error(), "bridge error") {
-		t.Errorf("Invalid error format %v", err)
-	}
-
-	if err = bridge.destroy(); err == nil {
-		t.Errorf("Uninitialized call: %v", err)
-	}
-
-	if !strings.HasPrefix(err.Error(), "bridge error") {
-		t.Errorf("Invalid error format %v", err)
-	}
-
-	if err = bridge.enable(); err == nil {
-		t.Errorf("Uninitialized call: %v", err)
-	}
-
-	if !strings.HasPrefix(err.Error(), "bridge error") {
-		t.Errorf("Invalid error format %v", err)
-	}
-
-	if err = bridge.disable(); err == nil {
-		t.Errorf("Uninitialized call: %v", err)
-	}
-
-	if !strings.HasPrefix(err.Error(), "bridge error") {
-		t.Errorf("Invalid error format %v", err)
-	}
+	performBridgeOps(false, assert, bridge)
 }
 
 //Tests attaching to an existing bridge
@@ -131,27 +100,15 @@ func TestBridge_Invalid(t *testing.T) {
 //
 //Test is expected to pass
 func TestBridge_GetDevice(t *testing.T) {
-	bridge, _ := newBridge("go_testbr")
+	assert := assert.New(t)
+	bridge, err := newBridge("go_testbr")
+	assert.Nil(err)
 
-	if err := bridge.create(); err != nil {
-		t.Errorf("Bridge creation failed: %v", err)
-	}
+	assert.Nil(bridge.create())
 
-	bridge1, _ := newBridge("go_testbr")
+	bridge1, err := newBridge("go_testbr")
+	assert.Nil(err)
 
-	if err := bridge1.getDevice(); err != nil {
-		t.Errorf("Bridge Get Device failed: %v", err)
-	}
-
-	if err := bridge1.enable(); err != nil {
-		t.Errorf("Uninitialized call: %v", err)
-	}
-
-	if err := bridge1.disable(); err != nil {
-		t.Errorf("Uninitialized call: %v", err)
-	}
-
-	if err := bridge1.destroy(); err != nil {
-		t.Errorf("Bridge destroy failed: %v", err)
-	}
+	assert.Nil(bridge1.getDevice())
+	performBridgeOps(true, assert, bridge1)
 }

--- a/networking/libsnnet/cn_container_test.go
+++ b/networking/libsnnet/cn_container_test.go
@@ -214,6 +214,8 @@ func stopDockerPlugin(dockerPlugin *DockerPlugin) error {
 //
 //Test is expected to pass
 func TestCNContainer_Base(t *testing.T) {
+	assert := assert.New(t)
+
 	cn, err := cnTestInit()
 	require.Nil(t, err)
 
@@ -264,45 +266,45 @@ func TestCNContainer_Base(t *testing.T) {
 		t.Error(err)
 	} else {
 		// expected SSNTP Event
-		if assert.NotNil(t, ssntpEvent) {
-			assert.Equal(t, ssntpEvent.Event, SsntpTunAdd)
+		if assert.NotNil(ssntpEvent) {
+			assert.Equal(ssntpEvent.Event, SsntpTunAdd)
 		}
 		// expected Container Event
-		if assert.NotNil(t, cInfo) {
-			assert.Equal(t, cInfo.CNContainerEvent, ContainerNetworkAdd)
-			assert.NotEqual(t, cInfo.SubnetID, "")
-			assert.NotEqual(t, cInfo.Subnet.String(), "")
-			assert.NotEqual(t, cInfo.Gateway.String(), "")
-			assert.NotEqual(t, cInfo.Bridge, "")
+		if assert.NotNil(cInfo) {
+			assert.Equal(cInfo.CNContainerEvent, ContainerNetworkAdd)
+			assert.NotEqual(cInfo.SubnetID, "")
+			assert.NotEqual(cInfo.Subnet.String(), "")
+			assert.NotEqual(cInfo.Gateway.String(), "")
+			assert.NotEqual(cInfo.Bridge, "")
 		}
-		assert.Nil(t, validSsntpEvent(ssntpEvent, vnicCfg))
+		assert.Nil(validSsntpEvent(ssntpEvent, vnicCfg))
 
 		//Cache the first subnet ID we see. All subsequent should have the same
 		subnetID = cInfo.SubnetID
 		iface = vnic.interfaceName()
-		assert.NotEqual(t, iface, "")
+		assert.NotEqual(iface, "")
 
 		//Launcher will attach to this name and send out the event
 		//Launcher will also create the logical docker network
 		debugPrint(t, "VNIC created =", vnic.LinkName, ssntpEvent, cInfo)
-		assert.Nil(t, linkDump(t))
+		assert.Nil(linkDump(t))
 
 		//Now kick off the docker commands
-		assert.Nil(t, dockerNetCreate(cInfo.Subnet, cInfo.Gateway, cInfo.Bridge, cInfo.SubnetID))
-		assert.Nil(t, dockerNetInfo(cInfo.SubnetID))
-		assert.Nil(t, dockerRunVerify(vnicCfg.VnicIP.String(), vnicCfg.VnicIP, vnicCfg.VnicMAC, cInfo.SubnetID))
-		assert.Nil(t, dockerContainerDelete(vnicCfg.VnicIP.String()))
+		assert.Nil(dockerNetCreate(cInfo.Subnet, cInfo.Gateway, cInfo.Bridge, cInfo.SubnetID))
+		assert.Nil(dockerNetInfo(cInfo.SubnetID))
+		assert.Nil(dockerRunVerify(vnicCfg.VnicIP.String(), vnicCfg.VnicIP, vnicCfg.VnicMAC, cInfo.SubnetID))
+		assert.Nil(dockerContainerDelete(vnicCfg.VnicIP.String()))
 	}
 
 	//Duplicate VNIC creation
 	if vnic, ssntpEvent, cInfo, err := cn.CreateVnic(vnicCfg); err != nil {
 		t.Error(err)
 	} else {
-		assert.Nil(t, ssntpEvent, "ERROR: DUP unexpected event")
-		if assert.NotNil(t, cInfo) {
-			assert.Equal(t, cInfo.SubnetID, subnetID)
-			assert.Equal(t, cInfo.CNContainerEvent, ContainerNetworkInfo)
-			assert.Equal(t, iface, vnic.interfaceName())
+		assert.Nil(ssntpEvent, "ERROR: DUP unexpected event")
+		if assert.NotNil(cInfo) {
+			assert.Equal(cInfo.SubnetID, subnetID)
+			assert.Equal(cInfo.CNContainerEvent, ContainerNetworkInfo)
+			assert.Equal(iface, vnic.interfaceName())
 		}
 	}
 
@@ -310,27 +312,27 @@ func TestCNContainer_Base(t *testing.T) {
 	if vnic, ssntpEvent, cInfo, err := cn.CreateVnic(vnicCfg2); err != nil {
 		t.Error(err)
 	} else {
-		assert.Nil(t, ssntpEvent)
-		if assert.NotNil(t, cInfo) {
-			assert.Equal(t, cInfo.SubnetID, subnetID)
-			assert.Equal(t, cInfo.CNContainerEvent, ContainerNetworkInfo)
+		assert.Nil(ssntpEvent)
+		if assert.NotNil(cInfo) {
+			assert.Equal(cInfo.SubnetID, subnetID)
+			assert.Equal(cInfo.CNContainerEvent, ContainerNetworkInfo)
 		}
 		iface = vnic.interfaceName()
-		assert.NotEqual(t, iface, "")
-		assert.Nil(t, dockerRunVerify(vnicCfg2.VnicIP.String(), vnicCfg2.VnicIP,
+		assert.NotEqual(iface, "")
+		assert.Nil(dockerRunVerify(vnicCfg2.VnicIP.String(), vnicCfg2.VnicIP,
 			vnicCfg2.VnicMAC, cInfo.SubnetID))
-		assert.Nil(t, dockerContainerDelete(vnicCfg2.VnicIP.String()))
+		assert.Nil(dockerContainerDelete(vnicCfg2.VnicIP.String()))
 	}
 
 	//Duplicate VNIC creation
 	if vnic, ssntpEvent, cInfo, err := cn.CreateVnic(vnicCfg2); err != nil {
 		t.Error(err)
 	} else {
-		assert.Nil(t, ssntpEvent)
-		if assert.NotNil(t, cInfo) {
-			assert.Equal(t, cInfo.SubnetID, subnetID)
-			assert.Equal(t, cInfo.CNContainerEvent, ContainerNetworkInfo)
-			assert.Equal(t, iface, vnic.interfaceName())
+		assert.Nil(ssntpEvent)
+		if assert.NotNil(cInfo) {
+			assert.Equal(cInfo.SubnetID, subnetID)
+			assert.Equal(cInfo.CNContainerEvent, ContainerNetworkInfo)
+			assert.Equal(iface, vnic.interfaceName())
 		}
 	}
 
@@ -338,42 +340,42 @@ func TestCNContainer_Base(t *testing.T) {
 	if ssntpEvent, cInfo, err := cn.DestroyVnic(vnicCfg); err != nil {
 		t.Error(err)
 	} else {
-		assert.Nil(t, ssntpEvent)
-		assert.Nil(t, cInfo)
+		assert.Nil(ssntpEvent)
+		assert.Nil(cInfo)
 	}
 
 	//Destroy it again
 	if ssntpEvent, cInfo, err := cn.DestroyVnic(vnicCfg); err != nil {
 		t.Error(err)
 	} else {
-		assert.Nil(t, ssntpEvent)
-		assert.Nil(t, cInfo)
+		assert.Nil(ssntpEvent)
+		assert.Nil(cInfo)
 	}
 
 	// Try and destroy - should work - cInfo should be reported
 	if ssntpEvent, cInfo, err := cn.DestroyVnic(vnicCfg2); err != nil {
 		t.Error(err)
 	} else {
-		assert.NotNil(t, ssntpEvent)
-		if assert.NotNil(t, cInfo) {
-			assert.Equal(t, cInfo.SubnetID, subnetID)
-			assert.Equal(t, cInfo.CNContainerEvent, ContainerNetworkDel)
+		assert.NotNil(ssntpEvent)
+		if assert.NotNil(cInfo) {
+			assert.Equal(cInfo.SubnetID, subnetID)
+			assert.Equal(cInfo.CNContainerEvent, ContainerNetworkDel)
 		}
 	}
 
 	//Has to be called after the VNIC has been deleted
-	assert.Nil(t, dockerNetDelete(subnetID))
-	assert.Nil(t, dockerNetList())
+	assert.Nil(dockerNetDelete(subnetID))
+	assert.Nil(dockerNetList())
 
 	//Destroy it again
 	if ssntpEvent, cInfo, err := cn.DestroyVnic(vnicCfg2); err != nil {
 		t.Error(err)
 	} else {
-		assert.Nil(t, ssntpEvent)
-		assert.Nil(t, cInfo)
+		assert.Nil(ssntpEvent)
+		assert.Nil(cInfo)
 	}
 
-	assert.Nil(t, stopDockerPlugin(dockerPlugin))
+	assert.Nil(stopDockerPlugin(dockerPlugin))
 }
 
 //Tests connectivity between two node local Containers
@@ -384,6 +386,7 @@ func TestCNContainer_Base(t *testing.T) {
 //
 //Test is expected to pass
 func TestCNContainer_Connectivity(t *testing.T) {
+	assert := assert.New(t)
 	cn, err := cnTestInit()
 	require.Nil(t, err)
 
@@ -428,32 +431,32 @@ func TestCNContainer_Connectivity(t *testing.T) {
 	}
 
 	_, _, cInfo, err := cn.CreateVnic(vnicCfg)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
-	assert.Nil(t, dockerNetCreate(cInfo.Subnet, cInfo.Gateway, cInfo.Bridge, cInfo.SubnetID))
+	assert.Nil(dockerNetCreate(cInfo.Subnet, cInfo.Gateway, cInfo.Bridge, cInfo.SubnetID))
 
 	//Kick off a long running container
 	dockerRunTop(vnicCfg.VnicIP.String(), vnicCfg.VnicIP, vnicCfg.VnicMAC, cInfo.SubnetID)
 
 	_, _, cInfo2, err := cn.CreateVnic(vnicCfg2)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
-	assert.Nil(t, dockerRunPingVerify(vnicCfg2.VnicIP.String(), vnicCfg2.VnicIP,
+	assert.Nil(dockerRunPingVerify(vnicCfg2.VnicIP.String(), vnicCfg2.VnicIP,
 		vnicCfg2.VnicMAC, cInfo2.SubnetID, vnicCfg.VnicIP.String()))
 
 	//Destroy the containers
-	assert.Nil(t, dockerContainerDelete(vnicCfg.VnicIP.String()))
-	assert.Nil(t, dockerContainerDelete(vnicCfg2.VnicIP.String()))
+	assert.Nil(dockerContainerDelete(vnicCfg.VnicIP.String()))
+	assert.Nil(dockerContainerDelete(vnicCfg2.VnicIP.String()))
 
 	//Destroy the VNICs
 	_, _, err = cn.DestroyVnic(vnicCfg)
-	assert.Nil(t, err)
+	assert.Nil(err)
 	_, _, err = cn.DestroyVnic(vnicCfg2)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
 	//Destroy the network, has to be called after the VNIC has been deleted
-	assert.Nil(t, dockerNetDelete(cInfo.SubnetID))
-	assert.Nil(t, stopDockerPlugin(dockerPlugin))
+	assert.Nil(dockerNetDelete(cInfo.SubnetID))
+	assert.Nil(stopDockerPlugin(dockerPlugin))
 }
 
 //Tests VM and Container VNIC Interop
@@ -464,6 +467,8 @@ func TestCNContainer_Connectivity(t *testing.T) {
 //
 //Test is expected to pass
 func TestCNContainer_Interop1(t *testing.T) {
+	assert := assert.New(t)
+
 	cn, err := cnTestInit()
 	require.Nil(t, err)
 
@@ -540,46 +545,46 @@ func TestCNContainer_Interop1(t *testing.T) {
 	}
 
 	_, _, cInfo, err := cn.CreateVnic(vnicCfg)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
 	err = dockerNetCreate(cInfo.Subnet, cInfo.Gateway, cInfo.Bridge, cInfo.SubnetID)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
 	_, _, _, err = cn.CreateVnic(vnicCfg3)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
 	//Kick off a long running container
 	dockerRunTop(vnicCfg.VnicIP.String(), vnicCfg.VnicIP, vnicCfg.VnicMAC, cInfo.SubnetID)
 
 	_, _, cInfo2, err := cn.CreateVnic(vnicCfg2)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
 	_, _, _, err = cn.CreateVnic(vnicCfg4)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
-	assert.Nil(t, dockerRunPingVerify(vnicCfg2.VnicIP.String(), vnicCfg2.VnicIP,
+	assert.Nil(dockerRunPingVerify(vnicCfg2.VnicIP.String(), vnicCfg2.VnicIP,
 		vnicCfg2.VnicMAC, cInfo2.SubnetID, vnicCfg.VnicIP.String()))
 
 	//Destroy the containers
-	assert.Nil(t, dockerContainerDelete(vnicCfg.VnicIP.String()))
-	assert.Nil(t, dockerContainerDelete(vnicCfg2.VnicIP.String()))
+	assert.Nil(dockerContainerDelete(vnicCfg.VnicIP.String()))
+	assert.Nil(dockerContainerDelete(vnicCfg2.VnicIP.String()))
 
 	_, _, err = cn.DestroyVnic(vnicCfg)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
 	_, _, err = cn.DestroyVnic(vnicCfg2)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
 	_, _, err = cn.DestroyVnic(vnicCfg3)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
 	err = dockerNetDelete(cInfo.SubnetID)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
 	_, _, err = cn.DestroyVnic(vnicCfg4)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
-	assert.Nil(t, stopDockerPlugin(dockerPlugin))
+	assert.Nil(stopDockerPlugin(dockerPlugin))
 }
 
 //Tests VM and Container VNIC Interop
@@ -590,6 +595,8 @@ func TestCNContainer_Interop1(t *testing.T) {
 //
 //Test is expected to pass
 func TestCNContainer_Interop2(t *testing.T) {
+	assert := assert.New(t)
+
 	cn, err := cnTestInit()
 	require.Nil(t, err)
 
@@ -666,44 +673,44 @@ func TestCNContainer_Interop2(t *testing.T) {
 	}
 
 	_, _, _, err = cn.CreateVnic(vnicCfg3)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
 	_, _, cInfo, err := cn.CreateVnic(vnicCfg)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
-	assert.Nil(t, dockerNetCreate(cInfo.Subnet, cInfo.Gateway, cInfo.Bridge, cInfo.SubnetID))
+	assert.Nil(dockerNetCreate(cInfo.Subnet, cInfo.Gateway, cInfo.Bridge, cInfo.SubnetID))
 
 	//Kick off a long running container
 	dockerRunTop(vnicCfg.VnicIP.String(), vnicCfg.VnicIP, vnicCfg.VnicMAC, cInfo.SubnetID)
 
 	_, _, cInfo2, err := cn.CreateVnic(vnicCfg2)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
-	assert.Nil(t, dockerRunPingVerify(vnicCfg2.VnicIP.String(), vnicCfg2.VnicIP,
+	assert.Nil(dockerRunPingVerify(vnicCfg2.VnicIP.String(), vnicCfg2.VnicIP,
 		vnicCfg2.VnicMAC, cInfo2.SubnetID, vnicCfg.VnicIP.String()))
 
 	//Destroy the containers
-	assert.Nil(t, dockerContainerDelete(vnicCfg.VnicIP.String()))
-	assert.Nil(t, dockerContainerDelete(vnicCfg2.VnicIP.String()))
+	assert.Nil(dockerContainerDelete(vnicCfg.VnicIP.String()))
+	assert.Nil(dockerContainerDelete(vnicCfg2.VnicIP.String()))
 
 	_, _, _, err = cn.CreateVnic(vnicCfg4)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
 	//Destroy the VNICs
 	_, _, err = cn.DestroyVnic(vnicCfg)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
 	_, _, err = cn.DestroyVnic(vnicCfg2)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
 	//Destroy the network, has to be called after the VNIC has been deleted
-	assert.Nil(t, dockerNetDelete(cInfo.SubnetID))
+	assert.Nil(dockerNetDelete(cInfo.SubnetID))
 
 	_, _, err = cn.DestroyVnic(vnicCfg4)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
 	_, _, err = cn.DestroyVnic(vnicCfg3)
-	assert.Nil(t, err)
+	assert.Nil(err)
 
-	assert.Nil(t, stopDockerPlugin(dockerPlugin))
+	assert.Nil(stopDockerPlugin(dockerPlugin))
 }

--- a/networking/libsnnet/cncivnic_test.go
+++ b/networking/libsnnet/cncivnic_test.go
@@ -19,9 +19,9 @@ package libsnnet
 import (
 	"fmt"
 	"net"
-	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/vishvananda/netlink"
 )
 
@@ -62,37 +62,22 @@ func getFirstPhyDevice() (int, error) {
 //
 //Test is expected to pass
 func TestCnciVnic_Basic(t *testing.T) {
-
-	cnciVnic, _ := newCnciVnic("testcnciVnic")
+	assert := assert.New(t)
 
 	pIndex, err := getFirstPhyDevice()
+	assert.Nil(err)
 
-	if err != nil {
-		t.Errorf("CnciVnic creation failed: %v", err)
-	}
-
+	cnciVnic, _ := newCnciVnic("testcnciVnic")
 	cnciVnic.Link.ParentIndex = pIndex
 	cnciVnic.Link.HardwareAddr, _ = net.ParseMAC("DE:AD:BE:EF:01:02")
 
-	if err := cnciVnic.create(); err != nil {
-		t.Errorf("CnciVnic creation failed: %v", err)
-	}
+	assert.Nil(cnciVnic.create())
 
-	if err := cnciVnic.enable(); err != nil {
-		t.Errorf("CnciVnic enable failed: %v", err)
-	}
+	assert.Nil(cnciVnic.enable())
+	assert.Nil(cnciVnic.disable())
+	assert.Nil(cnciVnic.destroy())
 
-	if err := cnciVnic.disable(); err != nil {
-		t.Errorf("CnciVnic enable failed: %v", err)
-	}
-
-	if err := cnciVnic.destroy(); err != nil {
-		t.Errorf("CnciVnic deletion failed: %v", err)
-	}
-	if err := cnciVnic.destroy(); err == nil {
-		t.Errorf("CnciVnic deletion should have failed")
-	}
-
+	assert.NotNil(cnciVnic.destroy())
 }
 
 //Test duplicate creation
@@ -102,30 +87,23 @@ func TestCnciVnic_Basic(t *testing.T) {
 //
 //Test is expected to pass
 func TestCnciVnic_Dup(t *testing.T) {
-	cnciVnic, _ := newCnciVnic("testcnciVnic")
+	assert := assert.New(t)
 
 	pIndex, err := getFirstPhyDevice()
-	if err != nil {
-		t.Errorf("CnciVnic creation failed: %v", err)
-	}
+	assert.Nil(err)
+
+	cnciVnic, _ := newCnciVnic("testcnciVnic")
 	cnciVnic.Link.ParentIndex = pIndex
 
-	if err := cnciVnic.create(); err != nil {
-		t.Errorf("CnciVnic creation failed: %v", err)
-	}
-	if err := cnciVnic.create(); err == nil {
-		t.Errorf("CnciVnic creation should have failed")
-	}
-
+	assert.Nil(cnciVnic.create())
+	assert.NotNil(cnciVnic.create())
 	defer func() { _ = cnciVnic.destroy() }()
 
 	cnciVnic1, _ := newCnciVnic("testcnciVnic")
 	cnciVnic1.Link.ParentIndex = pIndex
 
-	if err := cnciVnic1.create(); err == nil {
-		t.Errorf("Duplicate CnciVnic creation: %v", err)
-	}
-
+	//Duplicate
+	assert.NotNil(cnciVnic1.create())
 }
 
 //Negative test cases
@@ -135,35 +113,14 @@ func TestCnciVnic_Dup(t *testing.T) {
 //
 //Test is expected to pass
 func TestCnciVnic_Invalid(t *testing.T) {
+	assert := assert.New(t)
 	cnciVnic, err := newCnciVnic("testcnciVnic")
 
-	if err = cnciVnic.getDevice(); err == nil {
-		t.Errorf("Non existent device: %v", cnciVnic)
-	}
-	if !strings.HasPrefix(err.Error(), "cncivnic error") {
-		t.Errorf("Invalid error format %v", err)
-	}
-
-	if err = cnciVnic.enable(); err == nil {
-		t.Errorf("Non existent device: %v", cnciVnic)
-	}
-	if !strings.HasPrefix(err.Error(), "cncivnic error") {
-		t.Errorf("Invalid error format %v", err)
-	}
-
-	if err = cnciVnic.disable(); err == nil {
-		t.Errorf("Non existent device: %v", cnciVnic)
-	}
-	if !strings.HasPrefix(err.Error(), "cncivnic error") {
-		t.Errorf("Invalid error format %v", err)
-	}
-
-	if err = cnciVnic.destroy(); err == nil {
-		t.Errorf("Non existent device: %v", cnciVnic)
-	}
-	if !strings.HasPrefix(err.Error(), "cncivnic error") {
-		t.Errorf("Invalid error format %v", err)
-	}
+	assert.Nil(err)
+	assert.NotNil(cnciVnic.getDevice())
+	assert.NotNil(cnciVnic.enable())
+	assert.NotNil(cnciVnic.disable())
+	assert.NotNil(cnciVnic.destroy())
 
 }
 
@@ -174,33 +131,20 @@ func TestCnciVnic_Invalid(t *testing.T) {
 //
 //Test is expected to pass
 func TestCnciVnic_GetDevice(t *testing.T) {
+	assert := assert.New(t)
 	cnciVnic1, _ := newCnciVnic("testcnciVnic")
 
 	pIndex, err := getFirstPhyDevice()
-	if err != nil {
-		t.Errorf("CnciVnic creation failed: %v", err)
-	}
+	assert.Nil(err)
 	cnciVnic1.Link.ParentIndex = pIndex
 
-	if err := cnciVnic1.create(); err != nil {
-		t.Errorf("CnciVnic creation failed: %v", err)
-	}
+	assert.Nil(cnciVnic1.create())
 
 	cnciVnic, _ := newCnciVnic("testcnciVnic")
 
-	if err := cnciVnic.getDevice(); err != nil {
-		t.Errorf("CnciVnic Get Device failed: %v", err)
-	}
+	assert.Nil(cnciVnic.getDevice())
 
-	if err := cnciVnic.enable(); err != nil {
-		t.Errorf("CnciVnic enable failed: %v", err)
-	}
-
-	if err := cnciVnic.disable(); err != nil {
-		t.Errorf("CnciVnic enable failed: %v", err)
-	}
-
-	if err := cnciVnic.destroy(); err != nil {
-		t.Errorf("CnciVnic deletion failed: %v", err)
-	}
+	assert.Nil(cnciVnic.enable())
+	assert.Nil(cnciVnic.disable())
+	assert.Nil(cnciVnic.destroy())
 }

--- a/networking/libsnnet/internal_test.go
+++ b/networking/libsnnet/internal_test.go
@@ -20,6 +20,8 @@ package libsnnet
 import (
 	"net"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 //Tests the implementation of the db rebuild from aliases
@@ -29,6 +31,7 @@ import (
 //
 //The test is expected to pass
 func TestCN_dbRebuild(t *testing.T) {
+	assert := assert.New(t)
 	mac, _ := net.ParseMAC("CA:FE:00:01:02:03")
 
 	vnicCfg := &VnicConfig{
@@ -52,11 +55,9 @@ func TestCN_dbRebuild(t *testing.T) {
 
 	bridge, _ := newBridge(bridgeAlias)
 
-	if err := bridge.getDevice(); err != nil {
+	if assert.NotNil(bridge.getDevice()) {
 		// First instance to land, create the bridge and tunnel
-		if err := bridge.create(); err != nil {
-			t.Error("Bridge creation failed: ", err)
-		}
+		assert.Nil(bridge.create())
 		defer func(b *Bridge) { _ = b.destroy() }(bridge)
 
 		// Create the tunnel to connect to the CNCI
@@ -66,57 +67,39 @@ func TestCN_dbRebuild(t *testing.T) {
 
 		gre, _ := newGreTunEP(greAlias, local, remote, uint32(subnetKey))
 
-		if err := gre.create(); err != nil {
-			t.Error("GRE Tunnel Creation failed: ", err)
-		}
+		assert.Nil(gre.create())
 		defer func() { _ = gre.destroy() }()
 
-		if err := gre.attach(bridge); err != nil {
-			t.Error("GRE Tunnel attach failed: ", err)
-		}
-
+		assert.Nil(gre.attach(bridge))
 	}
 
 	// Create the VNIC for the instance
 	vnic, _ := newVnic(vnicAlias)
 
-	if err := vnic.create(); err != nil {
-		t.Error("Vnic Create failed: ", err)
-	}
+	assert.Nil(vnic.create())
 	defer func() { _ = vnic.destroy() }()
 
-	if err := vnic.attach(bridge); err != nil {
-		t.Error("Vnic attach failed: ", err)
-	}
+	assert.Nil(vnic.attach(bridge))
 
 	//Add a second vnic
 	vnicCfg.VnicIP = net.IPv4(192, 168, 1, 101)
 	alias1 := genCnVnicAliases(vnicCfg)
 	vnic1, _ := newVnic(alias1.vnic)
 
-	if err := vnic1.create(); err != nil {
-		t.Error("Vnic Create failed: ", err)
-	}
+	assert.Nil(vnic1.create())
 	defer func() { _ = vnic1.destroy() }()
 
-	if err := vnic1.attach(bridge); err != nil {
-		t.Error("Vnic attach failed: ", err)
-	}
+	assert.Nil(vnic1.attach(bridge))
 
 	/* Test negative test cases */
-	if err := cn.DbRebuild(nil); err == nil {
-		t.Error("cn.dbRebuild should have failed")
-	}
-
+	assert.NotNil(cn.DbRebuild(nil))
 	cn.NetworkConfig = &NetworkConfig{
 		ManagementNet: nil,
 		ComputeNet:    nil,
 		Mode:          GreTunnel,
 	}
 
-	if err := cn.DbRebuild(nil); err == nil {
-		t.Error("cn.dbRebuild should have failed")
-	}
+	assert.NotNil(cn.DbRebuild(nil))
 
 	/* Test positive */
 	cn.cnTopology = &cnTopology{
@@ -125,63 +108,42 @@ func TestCN_dbRebuild(t *testing.T) {
 		nameMap:   make(map[string]bool),
 	}
 
-	if err := cn.DbRebuild(nil); err != nil {
-		t.Error("cn.dbRebuild failed", err)
+	assert.Nil(cn.DbRebuild(nil))
+
+	cnt, err := cn.dbUpdate(alias.bridge, alias1.vnic, dbDelVnic)
+	if assert.Nil(err) {
+		assert.Equal(cnt, 1)
 	}
 
-	if cnt, err := cn.dbUpdate(alias.bridge, alias1.vnic, dbDelVnic); err == nil {
-		if cnt != 1 {
-			t.Error("cn.dbUpdate failed", cnt)
-		}
-	} else {
-		t.Error("cn.dbUpdate failed", err)
+	cnt, err = cn.dbUpdate(alias.bridge, alias.vnic, dbDelVnic)
+	if assert.Nil(err) {
+		assert.Equal(cnt, 0)
 	}
 
-	if cnt, err := cn.dbUpdate(alias.bridge, alias.vnic, dbDelVnic); err == nil {
-		if cnt != 0 {
-			t.Error("cn.dbUpdate failed", cnt)
-		}
-	} else {
-		t.Error("cn.dbUpdate failed", err)
+	cnt, err = cn.dbUpdate(alias.bridge, "", dbDelBr)
+	if assert.Nil(err) {
+		assert.Equal(cnt, 0)
 	}
 
-	if cnt, err := cn.dbUpdate(alias.bridge, "", dbDelBr); err == nil {
-		if cnt != 0 {
-			t.Error("cn.dbUpdate failed", cnt)
-		}
-	} else {
-		t.Error("cn.dbUpdate failed", err)
+	cnt, err = cn.dbUpdate(alias.bridge, "", dbInsBr)
+	if assert.Nil(err) {
+		assert.Equal(cnt, 1)
 	}
 
-	if cnt, err := cn.dbUpdate(alias.bridge, "", dbInsBr); err == nil {
-		if cnt != 1 {
-			t.Error("cn.dbUpdate failed", cnt)
-		}
-	} else {
-		t.Error("cn.dbUpdate failed", err)
+	cnt, err = cn.dbUpdate(alias.bridge, alias.vnic, dbInsVnic)
+	if assert.Nil(err) {
+		assert.Equal(cnt, 1)
 	}
 
-	if cnt, err := cn.dbUpdate(alias.bridge, alias.vnic, dbInsVnic); err == nil {
-		if cnt != 1 {
-			t.Error("cn.dbUpdate failed", cnt)
-		}
-	} else {
-		t.Error("cn.dbUpdate failed", err)
-	}
-
-	if cnt, err := cn.dbUpdate(alias.bridge, alias1.vnic, dbInsVnic); err == nil {
-		if cnt != 2 {
-			t.Error("cn.dbUpdate failed", cnt)
-		}
-	} else {
-		t.Error("cn.dbUpdate failed", err)
+	cnt, err = cn.dbUpdate(alias.bridge, alias1.vnic, dbInsVnic)
+	if assert.Nil(err) {
+		assert.Equal(cnt, 2)
 	}
 
 	//Negative tests
-	if cnt, err := cn.dbUpdate(alias.bridge, alias1.vnic, dbInsVnic); err == nil {
-		t.Error("cn.dbUpdate failed", cnt)
-	}
-	if cnt, err := cn.dbUpdate(alias.bridge, "", dbInsBr); err == nil {
-		t.Error("cn.dbUpdate failed", cnt)
-	}
+	_, err = cn.dbUpdate(alias.bridge, alias1.vnic, dbInsVnic)
+	assert.NotNil(err)
+
+	_, err = cn.dbUpdate(alias.bridge, "", dbInsBr)
+	assert.NotNil(err)
 }


### PR DESCRIPTION
Using testify for unit test cases reduces the complexity of the unit test cases.
This reduces the cyclomatic complexity significantly.