### PR TITLE
ciao-controller: rename cloudinit user

### DIFF
--- a/ciao-controller/workloads/test.yaml
+++ b/ciao-controller/workloads/test.yaml
@@ -1,11 +1,11 @@
 ---
 #cloud-config
 users:
-  - name: ciao
-    gecos: CIAO Rules
+  - name: demouser
+    gecos: CIAO Demo User
     lock-passwd: false
     passwd: $6$rounds=4096$w9I3hR4g/hu$AnYjaC2DfznbPSG3vxsgtgAS4mJwWBkcR74Y/KHNB5OsfAlA4gpU5j6CHWMOkkt9j.9d7OYJXJ4icXHzKXTAO.
-    sudo: ciao ALL=(ALL) NOPASSWD:ALL
+    sudo: demouser ALL=(ALL) NOPASSWD:ALL
     ssh-authorized-keys:
     - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDerQfD+qkb0V0XdQs8SBWqy4sQmqYFP96n/kI4Cq162w4UE8pTxy0ozAPldOvBJjljMvgaNKSAddknkhGcrNUvvJsUcZFm2qkafi32WyBdGFvIc45A+8O7vsxPXgHEsS9E3ylEALXAC3D0eX7pPtRiAbasLlY+VcACRqr3bPDSZTfpCmIkV2334uZD9iwOvTVeR+FjGDqsfju4DyzoAIqpPasE0+wk4Vbog7osP+qvn1gj5kQyusmr62+t0wx+bs2dF5QemksnFOswUrv9PGLhZgSMmDQrRYuvEfIAC7IdN/hfjTn0OokzljBiuWQ4WIIba/7xTYLVujJV65qH3heaSMxJJD7eH9QZs9RdbbdTXMFuJFsHV2OF6wZRp18tTNZZJMqiHZZSndC5WP1WrUo3Au/9a+ighSaOiVddHsPG07C/TOEnr3IrwU7c9yIHeeRFHmcQs9K0+n9XtrmrQxDQ9/mLkfje80Ko25VJ/QpAQPzCKh2KfQ4RD+/PxBUScx/lHIHOIhTSCh57ic629zWgk0coSQDi4MKSa5guDr3cuDvt4RihGviDM6V68ewsl0gh6Z9c0Hw7hU0vky4oxak5AiySiPz0FtsOnAzIL0UON+yMuKzrJgLjTKodwLQ0wlBXu43cD+P8VXwQYeqNSzfrhBnHqsrMf4lTLtc7kDDTcw== ciao@ciao
 ...

--- a/ciao-launcher/tests/examples/start_efi.yaml
+++ b/ciao-launcher/tests/examples/start_efi.yaml
@@ -23,8 +23,8 @@ start:
 runcmd:
   - [ touch, "/etc/bootdone" ]
 users:
-  - name: ciao
-    gecos: CIAO Rules
+  - name: demouser
+    gecos: CIAO Demo User
     lock-passwd: false
     passwd: \\$1\\$vzmNmLLD\\$04bivxcjdXRzZLUd.enRl1
     sudo: ALL=(ALL) NOPASSWD:ALL

--- a/ciao-launcher/tests/examples/start_legacy.yaml
+++ b/ciao-launcher/tests/examples/start_legacy.yaml
@@ -24,8 +24,8 @@ start:
 runcmd:
   - [ touch, "/etc/bootdone" ]
 users:
-  - name: ciao
-    gecos: CIAO Rules
+  - name: demouser
+    gecos: CIAO Demo User
     lock-passwd: false
     passwd: $1$vzmNmLLD$04bivxcjdXRzZLUd.enRl1
     sudo: ALL=(ALL) NOPASSWD:ALL

--- a/ciao-launcher/tests/examples/stress/efi.sh
+++ b/ciao-launcher/tests/examples/stress/efi.sh
@@ -33,8 +33,8 @@ start:
 runcmd:
   - [ touch, "/etc/bootdone" ]
 users:
-  - name: ciao
-    gecos: CIAO Rules
+  - name: demouser
+    gecos: CIAO Demo User
     lock-passwd: false
     passwd: \\$1\\$vzmNmLLD\\$04bivxcjdXRzZLUd.enRl1
     sudo: ALL=(ALL) NOPASSWD:ALL

--- a/ciao-launcher/tests/examples/stress/legacy.sh
+++ b/ciao-launcher/tests/examples/stress/legacy.sh
@@ -34,8 +34,8 @@ start:
 runcmd:
   - [ touch, "/etc/bootdone" ]
 users:
-  - name: ciao
-    gecos: CIAO Rules
+  - name: demouser
+    gecos: CIAO Demo User
     lock-passwd: false
     passwd: \\$1\\$vzmNmLLD\\$04bivxcjdXRzZLUd.enRl1
     sudo: ALL=(ALL) NOPASSWD:ALL

--- a/networking/cnci_agent/scripts/README.md
+++ b/networking/cnci_agent/scripts/README.md
@@ -57,7 +57,7 @@ be successfully launched within this VM
 ```
  sudo ./run_cnci_vm.sh
 ```
-2. Log into the VM using the cloud-init provisioned user/password (default ciao/ciao)
+2. Log into the VM using the cloud-init provisioned user/password (default demouser/ciao)
 3. Verify the successful launch of the CNCI using
    systemctl status cnci-agent
 
@@ -65,7 +65,7 @@ An output of the form shown below indicates a successful provisioning of
 the agent.
 
 ```
-ciao@cncihostname ~ $ systemctl status cnci-agent -l
+demouser@cncihostname ~ $ systemctl status cnci-agent -l
 ● cnci-agent.service - Ciao CNCI Agent
    Loaded: loaded (/usr/lib/systemd/system/cnci-agent.service; enabled; vendor preset: disabled)
    Active: active (running) since Thu 2016-04-07 20:34:40 UTC; 27s ago

--- a/networking/cnci_agent/scripts/seed/openstack/latest/user_data
+++ b/networking/cnci_agent/scripts/seed/openstack/latest/user_data
@@ -2,10 +2,10 @@
 runcmd:
   - [ touch, "/etc/bootdone" ]
 users:
-  - name: ciao
-    gecos: ciaogecos
+  - name: demouser
+    gecos: CIAO Demo User
     lock-passwd: false
     #Temporary password for debugging the image, set to ciao
     passwd: "$6$rounds=4096$5UnuSTz7u$3uzCRd62GSgVnmYkGPTpX9BWKLU3rf4jYdpOf22J/OWJqbdsVgudq.l7zRmcq9XAfKJr3pyzpb41lH/y6SrEo1"
-    sudo: ciao ALL=(ALL) NOPASSWD:ALL
+    sudo: demouser ALL=(ALL) NOPASSWD:ALL
     #- ssh-rsa PLAC_YOURKEY_HERE


### PR DESCRIPTION
- ciao user already exist as a system user, this changes
renames it to demouser
- Update ciao-launchers examles to use demouser
- Update networking scripts to use demouser
- Update Documentation to use demouser/ciao to login
in vms

Closes https://github.com/01org/ciao/issues/131

Signed-off-by: Alberto Murillo <alberto.murillo.silva@intel.com>