### PR TITLE
testutil: add a new testutil package with fake identity service

### DIFF
--- a/ciao-cert/main.go
+++ b/ciao-cert/main.go
@@ -122,27 +122,27 @@ func pemBlockForKey(priv interface{}) *pem.Block {
 }
 
 func addOIDs(role ssntp.Role, oids []asn1.ObjectIdentifier) []asn1.ObjectIdentifier {
-	if role&ssntp.AGENT == ssntp.AGENT {
+	if role.IsAgent() {
 		oids = append(oids, ssntp.RoleAgentOID)
 	}
 
-	if role&ssntp.SCHEDULER == ssntp.SCHEDULER {
+	if role.IsScheduler() {
 		oids = append(oids, ssntp.RoleSchedulerOID)
 	}
 
-	if role&ssntp.Controller == ssntp.Controller {
+	if role.IsController() {
 		oids = append(oids, ssntp.RoleControllerOID)
 	}
 
-	if role&ssntp.NETAGENT == ssntp.NETAGENT {
+	if role.IsNetAgent() {
 		oids = append(oids, ssntp.RoleNetAgentOID)
 	}
 
-	if role&ssntp.SERVER == ssntp.SERVER {
+	if role.IsServer() {
 		oids = append(oids, ssntp.RoleServerOID)
 	}
 
-	if role&ssntp.CNCIAGENT == ssntp.CNCIAGENT {
+	if role.IsCNCIAgent() {
 		oids = append(oids, ssntp.RoleCNCIAgentOID)
 	}
 

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/01org/ciao/ciao-controller/types"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp"
+	"github.com/01org/ciao/testutil"
 	"github.com/docker/distribution/uuid"
 	"gopkg.in/yaml.v2"
 	"math/rand"
@@ -1450,7 +1451,12 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	id := startIdentityTestServer()
+	testIdentityConfig := testutil.TestIdentityConfig{
+		ComputeURL: computeURL,
+		ProjectID:  computeTestUser,
+	}
+
+	id := testutil.StartIdentityTestServer(testIdentityConfig)
 	defer id.Close()
 
 	idConfig := identityConfig{

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -58,7 +58,7 @@ func (server *ssntpTestServer) addCmdChan(cmd ssntp.Command, c chan cmdResult) {
 	server.cmdChansLock.Unlock()
 }
 
-func (server *ssntpTestServer) ConnectNotify(uuid string, role uint32) {
+func (server *ssntpTestServer) ConnectNotify(uuid string, role ssntp.Role) {
 	switch role {
 	case ssntp.AGENT:
 		server.clients = append(server.clients, uuid)
@@ -71,7 +71,7 @@ func (server *ssntpTestServer) ConnectNotify(uuid string, role uint32) {
 
 }
 
-func (server *ssntpTestServer) DisconnectNotify(uuid string, role uint32) {
+func (server *ssntpTestServer) DisconnectNotify(uuid string, role ssntp.Role) {
 	for index := range server.clients {
 		if server.clients[index] == uuid {
 			server.clients = append(server.clients[:index], server.clients[index+1:]...)

--- a/ciao-launcher/tests/ciao-launcher-server/server.go
+++ b/ciao-launcher/tests/ciao-launcher-server/server.go
@@ -63,11 +63,11 @@ var server = struct {
 
 type testServer struct{}
 
-func (ts *testServer) ConnectNotify(uuid string, role uint32) {
+func (ts *testServer) ConnectNotify(uuid string, role ssntp.Role) {
 	server.Lock()
 	defer server.Unlock()
 
-	if !(role == ssntp.AGENT || role == ssntp.NETAGENT) {
+	if !(role.IsAgent() || role.IsNetAgent()) {
 		return
 	}
 
@@ -78,7 +78,7 @@ func (ts *testServer) ConnectNotify(uuid string, role uint32) {
 	server.clients[uuid] = new(client)
 }
 
-func (ts *testServer) DisconnectNotify(uuid string, role uint32) {
+func (ts *testServer) DisconnectNotify(uuid string, role ssntp.Role) {
 	server.Lock()
 	defer server.Unlock()
 

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -320,30 +320,32 @@ func disconnectNetworkNode(sched *ssntpSchedulerServer, uuid string) {
 
 	sched.sendNodeDisconnectedEvents(uuid, payloads.NetworkNode)
 }
-func (sched *ssntpSchedulerServer) ConnectNotify(uuid string, role uint32) {
-	switch role {
-	case ssntp.Controller:
+func (sched *ssntpSchedulerServer) ConnectNotify(uuid string, role ssntp.Role) {
+	if role.IsController() {
 		connectController(sched, uuid)
-	case ssntp.AGENT:
+	}
+	if role.IsAgent() {
 		connectComputeNode(sched, uuid)
-	case ssntp.NETAGENT:
+	}
+	if role.IsNetAgent() {
 		connectNetworkNode(sched, uuid)
 	}
 
-	glog.V(2).Infof("Connect (role 0x%x, uuid=%s)\n", role, uuid)
+	glog.V(2).Infof("Connect (role=%s, uuid=%s)\n", role.String(), uuid)
 }
 
-func (sched *ssntpSchedulerServer) DisconnectNotify(uuid string, role uint32) {
-	switch role {
-	case ssntp.Controller:
+func (sched *ssntpSchedulerServer) DisconnectNotify(uuid string, role ssntp.Role) {
+	if role.IsController() {
 		disconnectController(sched, uuid)
-	case ssntp.AGENT:
+	}
+	if role.IsAgent() {
 		disconnectComputeNode(sched, uuid)
-	case ssntp.NETAGENT:
+	}
+	if role.IsNetAgent() {
 		disconnectNetworkNode(sched, uuid)
 	}
 
-	glog.V(2).Infof("Connect (role 0x%x, uuid=%s)\n", role, uuid)
+	glog.V(2).Infof("Disconnect (role=%s, uuid=%s)\n", role.String(), uuid)
 }
 
 func (sched *ssntpSchedulerServer) updateNodeStat(node *nodeStat, status ssntp.Status, frame *ssntp.Frame) {

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -346,35 +346,8 @@ func (sched *ssntpSchedulerServer) DisconnectNotify(uuid string, role uint32) {
 	glog.V(2).Infof("Connect (role 0x%x, uuid=%s)\n", role, uuid)
 }
 
-func (sched *ssntpSchedulerServer) StatusNotify(uuid string, status ssntp.Status, frame *ssntp.Frame) {
+func (sched *ssntpSchedulerServer) updateNodeStat(node *nodeStat, status ssntp.Status, frame *ssntp.Frame) {
 	payload := frame.Payload
-
-	// for now only pay attention to READY status
-
-	glog.V(2).Infof("STATUS %v from %s\n", status, uuid)
-
-	sched.controllerMutex.RLock()
-	defer sched.controllerMutex.RUnlock()
-	if sched.controllerMap[uuid] != nil {
-		glog.Warningf("Ignoring STATUS change from Controller uuid=%s\n", uuid)
-		return
-	}
-
-	sched.cnMutex.RLock()
-	defer sched.cnMutex.RUnlock()
-
-	sched.nnMutex.RLock()
-	defer sched.nnMutex.RUnlock()
-
-	var node *nodeStat
-	if sched.cnMap[uuid] != nil {
-		node = sched.cnMap[uuid]
-	} else if sched.nnMap[uuid] != nil {
-		node = sched.nnMap[uuid]
-	} else {
-		glog.Warningf("STATUS error: no connected ssntp client with uuid=%s\n", uuid)
-		return
-	}
 
 	node.mutex.Lock()
 	defer node.mutex.Unlock()
@@ -386,7 +359,7 @@ func (sched *ssntpSchedulerServer) StatusNotify(uuid string, status ssntp.Status
 		var stats payloads.Ready
 		err := yaml.Unmarshal(payload, &stats)
 		if err != nil {
-			glog.Errorf("Bad READY yaml for node %s\n", uuid)
+			glog.Errorf("Bad READY yaml for node %s\n", node.uuid)
 			return
 		}
 		node.memTotalMB = stats.MemTotalMB
@@ -394,6 +367,38 @@ func (sched *ssntpSchedulerServer) StatusNotify(uuid string, status ssntp.Status
 		node.load = stats.Load
 		node.cpus = stats.CpusOnline
 		//TODO pull in other types of payloads.Ready struct data
+	}
+}
+
+func (sched *ssntpSchedulerServer) StatusNotify(uuid string, status ssntp.Status, frame *ssntp.Frame) {
+	// for now only pay attention to READY status
+
+	role, err := sched.ssntp.ClientRole(uuid)
+	if err != nil {
+		glog.Errorf("STATUS ignored from disconnected client %s", uuid)
+		return
+	}
+
+	glog.V(2).Infof("STATUS %v from %s (%s)\n", status, uuid, role.String())
+
+	if role.IsAgent() {
+		var cn *nodeStat
+		sched.cnMutex.RLock()
+		defer sched.cnMutex.RUnlock()
+		if sched.cnMap[uuid] != nil {
+			cn = sched.cnMap[uuid]
+			sched.updateNodeStat(cn, status, frame)
+		}
+	}
+
+	if role.IsNetAgent() {
+		var nn *nodeStat
+		sched.nnMutex.RLock()
+		defer sched.nnMutex.RUnlock()
+		if sched.nnMap[uuid] != nil {
+			nn = sched.nnMap[uuid]
+			sched.updateNodeStat(nn, status, frame)
+		}
 	}
 }
 

--- a/networking/ciao-cnci-agent/test_cnci_server/server.go
+++ b/networking/ciao-cnci-agent/test_cnci_server/server.go
@@ -130,13 +130,13 @@ func (l logger) Warningf(format string, args ...interface{}) {
 	fmt.Printf("WARNING: Test Server: "+format, args...)
 }
 
-func (server *ssntpTestServer) ConnectNotify(uuid string, role uint32) {
+func (server *ssntpTestServer) ConnectNotify(uuid string, role ssntp.Role) {
 	server.nConnections++
-	fmt.Printf("%s: %s connected (role 0x%x, current connections %d)\n", server.name, uuid, role, server.nConnections)
+	fmt.Printf("%s: %s connected (role %s, current connections %d)\n", server.name, uuid, role.String(), server.nConnections)
 
 	//Send out the command and events right here
 	//Also create a table to drive this with type, type, payload
-	if role == ssntp.CNCIAGENT {
+	if role.IsCNCIAgent() {
 		payload, _ := tenantAddedMarshal()
 		_, _ = server.ssntp.SendEvent(uuid, ssntp.TenantAdded, payload)
 		time.Sleep(time.Second)
@@ -160,7 +160,7 @@ func (server *ssntpTestServer) ConnectNotify(uuid string, role uint32) {
 
 }
 
-func (server *ssntpTestServer) DisconnectNotify(uuid string, role uint32) {
+func (server *ssntpTestServer) DisconnectNotify(uuid string, role ssntp.Role) {
 	server.nConnections--
 	fmt.Printf("%s: %s disconnected (current connections %d)\n", server.name, uuid, server.nConnections)
 }

--- a/ssntp/client.go
+++ b/ssntp/client.go
@@ -64,7 +64,7 @@ type Client struct {
 	uuid      uuid.UUID
 	lUUID     lockedUUID
 	uris      []string
-	role      uint32
+	role      Role
 	tls       *tls.Config
 	ntf       ClientNotifier
 	transport string

--- a/ssntp/example_server_test.go
+++ b/ssntp/example_server_test.go
@@ -39,11 +39,11 @@ type ssntpDumpServer struct {
 	name  string
 }
 
-func (server *ssntpDumpServer) ConnectNotify(uuid string, role uint32) {
+func (server *ssntpDumpServer) ConnectNotify(uuid string, role Role) {
 	fmt.Printf("%s: %s connected (role 0x%x)\n", server.name, uuid, role)
 }
 
-func (server *ssntpDumpServer) DisconnectNotify(uuid string, role uint32) {
+func (server *ssntpDumpServer) DisconnectNotify(uuid string, role Role) {
 	fmt.Printf("%s: %s disconnected (role 0x%x)\n", server.name, uuid, role)
 }
 

--- a/ssntp/examples/server.go
+++ b/ssntp/examples/server.go
@@ -48,12 +48,12 @@ func (l logger) Warningf(format string, args ...interface{}) {
 	fmt.Printf("WARNING: Server example: "+format, args...)
 }
 
-func (server *ssntpEchoServer) ConnectNotify(uuid string, role uint32) {
+func (server *ssntpEchoServer) ConnectNotify(uuid string, role Role) {
 	server.nConnections++
 	fmt.Printf("%s: %s connected (role 0x%x, current connections %d)\n", server.name, uuid, role, server.nConnections)
 }
 
-func (server *ssntpEchoServer) DisconnectNotify(uuid string, role uint32) {
+func (server *ssntpEchoServer) DisconnectNotify(uuid string, role Role) {
 	server.nConnections--
 	fmt.Printf("%s: %s disconnected (role 0x%x, current connections %d)\n", server.name, uuid, role, server.nConnections)
 }

--- a/ssntp/forward.go
+++ b/ssntp/forward.go
@@ -186,19 +186,19 @@ func (f *frameForward) addForwardDestination(session *session) {
 
 		switch op := r.Operand.(type) {
 		case Command:
-			if session.destRole&(uint32)(r.Dest) == (uint32)(r.Dest) {
+			if session.destRole.HasRole(r.Dest) {
 				f.forwardCommandDest[op] = append(f.forwardCommandDest[op], session)
 			}
 		case Status:
-			if session.destRole&(uint32)(r.Dest) == (uint32)(r.Dest) {
+			if session.destRole.HasRole(r.Dest) {
 				f.forwardStatusDest[op] = append(f.forwardStatusDest[op], session)
 			}
 		case Error:
-			if session.destRole&(uint32)(r.Dest) == (uint32)(r.Dest) {
+			if session.destRole.HasRole(r.Dest) {
 				f.forwardErrorDest[op] = append(f.forwardErrorDest[op], session)
 			}
 		case Event:
-			if session.destRole&(uint32)(r.Dest) == (uint32)(r.Dest) {
+			if session.destRole.HasRole(r.Dest) {
 				f.forwardEventDest[op] = append(f.forwardEventDest[op], session)
 			}
 		}

--- a/ssntp/frame.go
+++ b/ssntp/frame.go
@@ -44,7 +44,7 @@ type TraceConfig struct {
 // Node represent an SSNTP networking node.
 type Node struct {
 	UUID        []byte
-	Role        uint32
+	Role        Role
 	TxTimestamp time.Time
 	RxTimestamp time.Time
 }
@@ -77,7 +77,7 @@ type ConnectFrame struct {
 	Minor       uint8
 	Type        Type
 	Operand     uint8
-	Role        uint32
+	Role        Role
 	Source      []byte
 	Destination []byte
 }
@@ -88,7 +88,7 @@ type ConnectedFrame struct {
 	Minor         uint8
 	Type          Type
 	Operand       uint8
-	Role          uint32
+	Role          Role
 	Source        []byte
 	Destination   []byte
 	PayloadLength uint32
@@ -184,7 +184,7 @@ func (f ConnectFrame) String() string {
 	copy(dest[:], f.Destination[:16])
 
 	return fmt.Sprintf("\tMajor %d\n\tMinor %d\n\tType %s\n\tOp %s\n\tRole %s\n\tSource %s\n\tDestination %s\n",
-		f.Major, f.Minor, (Type)(f.Type), op, (*Role)(&f.Role), src, dest)
+		f.Major, f.Minor, (Type)(f.Type), op, f.Role.String(), src, dest)
 }
 
 func (f ConnectedFrame) String() string {
@@ -205,7 +205,7 @@ func (f ConnectedFrame) String() string {
 	copy(dest[:], f.Destination[:16])
 
 	return fmt.Sprintf("\tMajor %d\n\tMinor %d\n\tType %s\n\tOp %s\n\tRole %s\n\tSource %s\n\tDestination %s\n",
-		f.Major, f.Minor, (Type)(f.Type), op, (*Role)(&f.Role), src, dest)
+		f.Major, f.Minor, (Type)(f.Type), op, f.Role.String(), src, dest)
 }
 
 func (f *Frame) addPathNode(session *session) {
@@ -275,7 +275,7 @@ func (f Frame) DumpTrace() (*payloads.FrameTrace, error) {
 		copy(node[:], n.UUID[:16])
 		sNode := payloads.SSNTPNode{
 			SSNTPUUID: node.String(),
-			SSNTPRole: (*Role)(&n.Role).String(),
+			SSNTPRole: n.Role.String(),
 		}
 
 		if n.TxTimestamp.IsZero() == false {

--- a/ssntp/server.go
+++ b/ssntp/server.go
@@ -413,3 +413,14 @@ func (server *Server) SendTracedError(uuid string, error Error, payload []byte, 
 func (server *Server) UUID() string {
 	return server.uuid.String()
 }
+
+// ClientRole returns the role of the ssntp session peer with the specified uuid.
+func (server *Server) ClientRole(uuid string) (uint32, error) {
+	server.sessionMutex.RLock()
+	session := server.sessions[uuid]
+	defer server.sessionMutex.RUnlock()
+	if session == nil {
+		return (uint32)(UNKNOWN), fmt.Errorf("SSNTP session missing for uuid %s", uuid)
+	}
+	return session.destRole, nil
+}

--- a/ssntp/session.go
+++ b/ssntp/session.go
@@ -42,8 +42,8 @@ func clearWriteTimeout(conn net.Conn) {
 type session struct {
 	src      uuid.UUID
 	dest     uuid.UUID
-	srcRole  uint32
-	destRole uint32
+	srcRole  Role
+	destRole Role
 	conn     net.Conn
 
 	encoder *gob.Encoder
@@ -53,7 +53,7 @@ type session struct {
 /*
  * session methods
  */
-func newSession(src *uuid.UUID, srcRole uint32, destRole uint32, netConn net.Conn) *session {
+func newSession(src *uuid.UUID, srcRole Role, destRole Role, netConn net.Conn) *session {
 	var session session
 
 	if src != nil {
@@ -74,7 +74,7 @@ func (session *session) setDest(uuid []byte) {
 	copy(session.dest[:], uuid[:16])
 }
 
-func (session *session) connectedFrame(serverRole uint32, payload []byte) (f *ConnectedFrame) {
+func (session *session) connectedFrame(serverRole Role, payload []byte) (f *ConnectedFrame) {
 	f = &ConnectedFrame{
 		Major:         major,
 		Minor:         minor,

--- a/testutil/identity.go
+++ b/testutil/identity.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"fmt"
+	"github.com/gorilla/mux"
+	"github.com/rackspace/gophercloud"
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+// TestIdentityConfig contains the URL of the ciao compute service, and the TenantID of
+// the tenant you want tokens to be sent for.  The test Identity service only supports
+// authentication of a single tenant, and gives the token an admin role.
+type TestIdentityConfig struct {
+	ComputeURL string
+	ProjectID  string
+}
+
+var computeURL string
+var testIdentityURL string
+var computeTestUser string
+
+func authHandler(w http.ResponseWriter, r *http.Request) {
+	token := `
+		{
+			"token": {
+				"methods": [
+					"password"
+				],
+				"roles": [
+					{
+						"id" : "12345",
+						"name" : "admin"
+					}
+				],
+				"expires_at": "%s",
+				"project": {
+					"domain": {
+						"id": "default",
+						"name": "Default"
+					},
+					"id": "%s",
+					"name": "admin"
+				},
+				"catalog": [
+					{
+						"endpoints": [
+							{
+								"region_id": "RegionOne",
+								"url": "%s/v3",
+								"region": "RegionOne",
+								"interface": "public",
+								"id": "068d1b359ee84b438266cb736d81de97"
+							},
+							{
+								"region_id": "RegionOne",
+								"url": "%s/v3",
+								"region": "RegionOne",
+								"interface": "admin",
+								"id": "8bfc846841ab441ca38471be6d164ced"
+							},
+							{
+								"region_id": "RegionOne",
+								"url": "%s/v3",
+								"region": "RegionOne",
+								"interface": "internal",
+								"id": "beb6d358c3654b4bada04d4663b640b9"
+							}
+						],
+						"type": "identity",
+						"id": "050726f278654128aba89757ae25950c",
+						"name": "keystone"
+					}
+				],
+			       "extras": {},
+			       "user": {
+				       "domain": {
+				               "id": "default",
+				               "name": "Default"
+				        },
+				       "id": "ee4dfb6e5540447cb3741905149d9b6e",
+			               "name": "admin"
+			        },
+			        "audit_ids": [
+				        "3T2dc1CGQxyJsHdDu1xkcw"
+			        ],
+			        "issued_at": "%s"
+			}
+		}`
+
+	t := []byte(fmt.Sprintf(token,
+		time.Now().Add(1*time.Hour).Format(gophercloud.RFC3339Milli),
+		computeTestUser, testIdentityURL, testIdentityURL,
+		testIdentityURL, time.Now().Format(gophercloud.RFC3339Milli)))
+	w.Header().Set("X-Subject-Token", "imavalidtoken")
+	w.WriteHeader(http.StatusCreated)
+	w.Write(t)
+}
+
+func validateHandler(w http.ResponseWriter, r *http.Request) {
+	tenantURL := computeURL + "/v2.1/" + computeTestUser
+	token := `
+	{
+		"token": {
+		        "methods": [
+		                "token"
+		        ],
+		        "expires_at": "%s",
+		        "extras": {},
+		        "user": {
+				"domain": {
+					"id": "default",
+					"name": "Default"
+				},
+				"id": "10a2e6e717a245d9acad3e5f97aeca3d",
+				"name": "admin"
+			},
+			"roles": [
+				{
+					"id" : "12345",
+					"name" : "admin"
+				}
+			],
+			"project": {
+				"domain": {
+					"id": "default",
+					"name": "Default"
+				},
+				"id": "%s",
+				"name": "admin"
+			},
+			"catalog": [
+				{
+					"endpoints": [
+						{
+							"region_id": "RegionOne",
+							"url": "%s/v3",
+							"region": "RegionOne",
+							"interface": "public",
+							"id": "068d1b359ee84b438266cb736d81de97"
+						},
+						{
+							"region_id": "RegionOne",
+							"url": "%s/v3",
+							"region": "RegionOne",
+							"interface": "admin",
+							"id": "8bfc846841ab441ca38471be6d164ced"
+						},
+						{
+							"region_id": "RegionOne",
+							"url": "%s/v3",
+							"region": "RegionOne",
+							"interface": "internal",
+							"id": "beb6d358c3654b4bada04d4663b640b9"
+						}
+					],
+					"type": "identity",
+					"id": "050726f278654128aba89757ae25950c",
+					"name": "keystone"
+				},
+				{
+			                "endpoints": [
+					         {
+							"region_id": "RegionOne",
+							"url": "%s",
+							"region": "RegionOne",
+							"interface": "admin",
+							"id": "2511589f262a407bb0071a814a480af4"
+						},
+						{
+							"region_id": "RegionOne",
+							"url": "%s",
+							"region": "RegionOne",
+							"interface": "internal",
+							"id": "9cf9209ae4fc4673a7295611001cf0ae"
+						},
+						{
+							"region_id": "RegionOne",
+							"url": "%s",
+							"region": "RegionOne",
+							"interface": "public",
+							"id": "d200b2509e1343e3887dcc465b4fa534"
+						}
+					],
+					"type": "compute",
+					"id": "a226b3eeb5594f50bf8b6df94636ed28",
+					"name": "ciao"
+				}
+			],
+			"audit_ids": [
+			        "mAjXQhiYRyKwkB4qygdLVg"
+			],
+			"issued_at": "%s"
+		}
+	}`
+
+	t := []byte(fmt.Sprintf(token,
+		time.Now().Add(1*time.Hour).Format(gophercloud.RFC3339Milli),
+		computeTestUser, testIdentityURL, testIdentityURL,
+		testIdentityURL, tenantURL, tenantURL,
+		tenantURL, time.Now().Format(gophercloud.RFC3339Milli)))
+	w.WriteHeader(http.StatusOK)
+	w.Write(t)
+}
+
+func identityHandlers() *mux.Router {
+	r := mux.NewRouter()
+
+	r.HandleFunc("/v3/auth/tokens", authHandler).Methods("POST")
+	r.HandleFunc("/v3/auth/tokens", validateHandler).Methods("GET")
+
+	return r
+}
+
+// StartIdentityTestServer starts a fake keystone service for unit testing ciao.
+func StartIdentityTestServer(config TestIdentityConfig) *httptest.Server {
+	id := httptest.NewServer(identityHandlers())
+
+	computeURL = config.ComputeURL
+	testIdentityURL = id.URL
+	computeTestUser = config.ProjectID
+
+	return id
+}

--- a/testutil/identity_test.go
+++ b/testutil/identity_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"testing"
+)
+
+func TestStartIdentityServer(t *testing.T) {
+	config := TestIdentityConfig{
+		ComputeURL: "https://localhost:8888",
+		ProjectID:  "30dedd5c-48d9-45d3-8b44-f973e4f35e48",
+	}
+
+	id := StartIdentityTestServer(config)
+	defer id.Close()
+}


### PR DESCRIPTION
This new package will container helper functions that allow an
individual component to simulate other components in the cluster
during unit testing.

Add a fake identity service which will hand out fake tokens for
a single tenant with an admin role.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>