### PR TITLE
ciao-scheduler: yet more lock fixing

### DIFF
--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -550,8 +550,7 @@ func pickComputeNode(sched *ssntpSchedulerServer, controllerUUID string, workloa
 		node := sched.cnList[0]
 		node.mutex.Lock()
 		if sched.workloadFits(sched.cnList[0], workload) == true {
-			node.mutex.Unlock()
-			return node
+			return node // locked nodeStat
 		}
 		node.mutex.Unlock()
 		return nil
@@ -569,8 +568,7 @@ func pickComputeNode(sched *ssntpSchedulerServer, controllerUUID string, workloa
 			if sched.workloadFits(node, workload) == true {
 				sched.cnMRUIndex = sched.cnMRUIndex + 1 + i
 				sched.cnMRU = node
-				node.mutex.Unlock()
-				return node
+				return node // locked nodeStat
 			}
 			node.mutex.Unlock()
 		}
@@ -582,8 +580,7 @@ func pickComputeNode(sched *ssntpSchedulerServer, controllerUUID string, workloa
 		if sched.workloadFits(node, workload) == true {
 			sched.cnMRUIndex = i
 			sched.cnMRU = node
-			node.mutex.Unlock()
-			return node
+			return node // locked nodeStat
 		}
 		node.mutex.Unlock()
 	}
@@ -608,8 +605,7 @@ func (sched *ssntpSchedulerServer) pickNetworkNode(controllerUUID string, worklo
 		if (len(sched.nnMap) <= 1 || ((len(sched.nnMap) > 1) && (node.uuid != sched.nnMRU))) &&
 			sched.workloadFits(node, workload) {
 			sched.nnMRU = node.uuid
-			node.mutex.Unlock()
-			return node
+			return node // locked nodeStat
 		}
 	}
 


### PR DESCRIPTION
I apparently mismerged/misrebased a change.  The earlier code was supposed
to be leaving nodeStat's locked once picked for dispatching.  I left some
Unlock() calls in the code.  So the later code that's supposed to unlock
the locked node was unlocking an unlocked node, which nicely results in a
very obvious panic from golang.

Signed-off-by: Tim Pepper <timothy.c.pepper@intel.com>