### PR TITLE
Networking: Code refactoring to reduce complexity

### DIFF
--- a/networking/libsnnet/cn.go
+++ b/networking/libsnnet/cn.go
@@ -465,11 +465,7 @@ func (cn *ComputeNode) DbRebuild(links []netlink.Link) error {
 	//Now build the vnic maps, inefficient but simple
 	//This allows us to check if the bridges and tunnels are all present
 	err = cn.rebuildVnicMap(links)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (cn *ComputeNode) dbUpdate(bridge string, vnic string, op dbOp) (int, error) {

--- a/networking/libsnnet/cn.go
+++ b/networking/libsnnet/cn.go
@@ -237,10 +237,7 @@ func (cn *ComputeNode) findPhyNwInterface() error {
 	for _, link := range links {
 
 		if !validPhysicalLink(link) {
-			//Allow all types of links under travisCI
-			if !travisCI {
-				continue
-			}
+			continue
 		}
 
 		addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)

--- a/networking/libsnnet/cn_container_test.go
+++ b/networking/libsnnet/cn_container_test.go
@@ -43,9 +43,7 @@ func dockerRestart() error {
 	_, err := exec.Command("service", "docker", "restart").CombinedOutput()
 	if err != nil {
 		_, err = exec.Command("systemctl", "restart", "docker").CombinedOutput()
-		if err != nil {
-			return err
-		}
+		return err
 	}
 	return err
 }
@@ -86,9 +84,6 @@ func dockerContainerDelete(name string) error {
 	}
 
 	_, err = exec.Command("docker", "rm", name).CombinedOutput()
-	if err != nil {
-		return err
-	}
 	return err
 }
 
@@ -99,10 +94,7 @@ func dockerContainerInfo(name string) error {
 	}
 
 	_, err = exec.Command("docker", "inspect", name).CombinedOutput()
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 //Will be replaced by Docker API's in launcher
@@ -117,10 +109,6 @@ func dockerNetCreate(subnet net.IPNet, gw net.IP, bridge string, subnetID string
 		"--opt", "bridge="+bridge, subnetID)
 
 	_, err := cmd.CombinedOutput()
-
-	if err != nil {
-		return err
-	}
 	return err
 }
 
@@ -128,24 +116,15 @@ func dockerNetCreate(subnet net.IPNet, gw net.IP, bridge string, subnetID string
 // docker network rm ContainerInfo.SubnetID
 func dockerNetDelete(subnetID string) error {
 	_, err := exec.Command("docker", "network", "rm", subnetID).CombinedOutput()
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 func dockerNetList() error {
 	_, err := exec.Command("docker", "network", "ls").CombinedOutput()
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func dockerNetInfo(subnetID string) error {
 	_, err := exec.Command("docker", "network", "inspect", subnetID).CombinedOutput()
-	if err != nil {
-		return err
-	}
 	return err
 }
 

--- a/networking/libsnnet/cnci.go
+++ b/networking/libsnnet/cnci.go
@@ -318,11 +318,7 @@ func (cnci *Cnci) RebuildTopology() error {
 
 	//Ensure that all tunnels have the associated bridges
 	err = cnci.verifyTopology(links)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func subnetToString(subnet net.IPNet) string {

--- a/networking/libsnnet/cnci.go
+++ b/networking/libsnnet/cnci.go
@@ -106,15 +106,10 @@ func (cnci *Cnci) findPhyNwInterface() error {
 	cnci.ComputeLink = nil
 
 	for _, link := range links {
-
-		if link.Type() != "device" {
+		if !validPhysicalLink(link) {
 			if !travisCI {
 				continue
 			}
-		}
-
-		if link.Attrs().Name == "lo" {
-			continue
 		}
 
 		addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)

--- a/networking/libsnnet/cnci.go
+++ b/networking/libsnnet/cnci.go
@@ -141,9 +141,7 @@ func (cnci *Cnci) findPhyNwInterface() error {
 
 	for _, link := range links {
 		if !validPhysicalLink(link) {
-			if !travisCI {
-				continue
-			}
+			continue
 		}
 
 		addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)

--- a/networking/libsnnet/tests/parallel/parallel_test.go
+++ b/networking/libsnnet/tests/parallel/parallel_test.go
@@ -72,9 +72,8 @@ func logTime(t *testing.T, start time.Time, fn string) {
 func pickRandomRole(input int) libsnnet.VnicRole {
 	if input%2 == 1 {
 		return libsnnet.TenantContainer
-	} else {
-		return libsnnet.TenantVM
 	}
+	return libsnnet.TenantVM
 }
 
 func CNAPIParallel(t *testing.T, role libsnnet.VnicRole, modelCancel bool) {

--- a/networking/libsnnet/tests/parallel/parallel_test.go
+++ b/networking/libsnnet/tests/parallel/parallel_test.go
@@ -28,6 +28,8 @@ import (
 	"time"
 
 	"github.com/01org/ciao/networking/libsnnet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var cnNetEnv string
@@ -67,7 +69,16 @@ func logTime(t *testing.T, start time.Time, fn string) {
 	t.Logf("function %s took %s", fn, elapsedTime)
 }
 
+func pickRandomRole(input int) libsnnet.VnicRole {
+	if input%2 == 1 {
+		return libsnnet.TenantContainer
+	} else {
+		return libsnnet.TenantVM
+	}
+}
+
 func CNAPIParallel(t *testing.T, role libsnnet.VnicRole, modelCancel bool) {
+	assert := assert.New(t)
 
 	var sem = make(chan int, cnMaxOutstanding)
 
@@ -90,15 +101,9 @@ func CNAPIParallel(t *testing.T, role libsnnet.VnicRole, modelCancel bool) {
 	cn.ManagementNet = mgtNet
 	cn.ComputeNet = mgtNet
 
-	if err := cn.Init(); err != nil {
-		t.Fatal("ERROR: cn.Init failed", err)
-	}
-	if err := cn.ResetNetwork(); err != nil {
-		t.Error("ERROR: cn.ResetNetwork failed", err)
-	}
-	if err := cn.DbRebuild(nil); err != nil {
-		t.Fatal("ERROR: cn.dbRebuild failed")
-	}
+	require.Nil(t, cn.Init())
+	require.Nil(t, cn.ResetNetwork())
+	require.Nil(t, cn.DbRebuild(nil))
 
 	//From YAML on instance init
 	tenantID := "tenantuuid"
@@ -135,11 +140,7 @@ func CNAPIParallel(t *testing.T, role libsnnet.VnicRole, modelCancel bool) {
 
 			role := role
 			if role == allRoles {
-				if s4%2 == 1 {
-					role = libsnnet.TenantContainer
-				} else {
-					role = libsnnet.TenantVM
-				}
+				role = pickRandomRole(s4)
 			}
 
 			vnicCfg := &libsnnet.VnicConfig{
@@ -159,7 +160,6 @@ func CNAPIParallel(t *testing.T, role libsnnet.VnicRole, modelCancel bool) {
 			if modelCancel {
 				vnicCfg.CancelChan = make(chan interface{})
 			}
-
 			createCh <- vnicCfg
 			destroyCh <- vnicCfg
 			cancelCh <- vnicCfg.CancelChan
@@ -183,7 +183,6 @@ func CNAPIParallel(t *testing.T, role libsnnet.VnicRole, modelCancel bool) {
 	}
 
 	for vnicCfg := range createCh {
-
 		sem <- 1
 		go func(vnicCfg *libsnnet.VnicConfig) {
 			defer wg.Done()
@@ -191,20 +190,16 @@ func CNAPIParallel(t *testing.T, role libsnnet.VnicRole, modelCancel bool) {
 				<-sem
 			}()
 
-			if vnicCfg == nil {
-				t.Errorf("WARNING: VNIC nil")
+			if !assert.NotNil(vnicCfg) {
 				return
 			}
-
 			defer logTime(t, time.Now(), "Create VNIC")
 
-			if _, _, _, err := cn.CreateVnic(vnicCfg); err != nil {
-				if !modelCancel {
-					//We expect failures only when we have cancellations
-					t.Error("ERROR: cn.CreateVnic  failed", vnicCfg, err)
-				}
+			_, _, _, err := cn.CreateVnic(vnicCfg)
+			if !modelCancel {
+				//We expect failures only when we have cancellations
+				assert.Nil(err)
 			}
-
 		}(vnicCfg)
 	}
 
@@ -219,16 +214,14 @@ func CNAPIParallel(t *testing.T, role libsnnet.VnicRole, modelCancel bool) {
 				<-sem
 			}()
 
-			if vnicCfg == nil {
-				t.Errorf("WARNING: VNIC nil")
+			if !assert.NotNil(vnicCfg) {
 				return
 			}
 			defer logTime(t, time.Now(), "Destroy VNIC")
-			if _, _, err := cn.DestroyVnic(vnicCfg); err != nil {
-				if !modelCancel {
-					//We expect failures only when we have cancellations
-					t.Error("ERROR: cn.DestroyVnic failed event", vnicCfg, err)
-				}
+			_, _, err := cn.DestroyVnic(vnicCfg)
+			if !modelCancel {
+				//We expect failures only when we have cancellations
+				assert.Nil(err)
 			}
 		}(vnicCfg)
 	}
@@ -268,19 +261,16 @@ func dockerRestart(t *testing.T) error {
 //Will be replaced by Docker API's in launcher
 //docker run -it --net=none debian ip addr show lo
 func dockerRunNetNone(t *testing.T, name string, ip net.IP, mac net.HardwareAddr, subnetID string) error {
+	assert := assert.New(t)
 	defer logTime(t, time.Now(), "dockerRunNetNone")
 
 	cmd := exec.Command("docker", "run", "--name", ip.String(), "--net=none",
 		"debian", "ip", "addr", "show", "lo")
 	out, err := cmd.CombinedOutput()
 
-	if err != nil {
-		t.Error("docker run failed", cmd, string(out), err)
-	}
-
-	if err := dockerContainerInfo(t, name); err != nil {
-		t.Error("docker container inspect failed", name, err.Error())
-	}
+	assert.Nil(err, out)
+	err = dockerContainerInfo(t, name)
+	assert.Nil(err)
 
 	return err
 }
@@ -288,19 +278,16 @@ func dockerRunNetNone(t *testing.T, name string, ip net.IP, mac net.HardwareAddr
 //Will be replaced by Docker API's in launcher
 //docker run -it debian ip addr show lo
 func dockerRunNetDocker(t *testing.T, name string, ip net.IP, mac net.HardwareAddr, subnetID string) error {
+	assert := assert.New(t)
 	defer logTime(t, time.Now(), "dockerRunNetDocker")
 
 	cmd := exec.Command("docker", "run", "--name", ip.String(),
 		"debian", "ip", "addr", "show", "lo")
 	out, err := cmd.CombinedOutput()
 
-	if err != nil {
-		t.Error("docker run failed", cmd, string(out), err)
-	}
-
-	if err := dockerContainerInfo(t, name); err != nil {
-		t.Error("docker container inspect failed", name, err.Error())
-	}
+	assert.Nil(err, string(out))
+	err = dockerContainerInfo(t, name)
+	assert.Nil(err)
 
 	return err
 }
@@ -309,16 +296,14 @@ func dockerRunNetDocker(t *testing.T, name string, ip net.IP, mac net.HardwareAd
 //docker run -it --net=<subnet.Name> --ip=<instance.IP> --mac-address=<instance.MacAddresss>
 //debian ip addr show eth0 scope global
 func dockerRunVerify(t *testing.T, name string, ip net.IP, mac net.HardwareAddr, subnetID string) error {
+	assert := assert.New(t)
 	defer logTime(t, time.Now(), "dockerRunVerify")
 
 	cmd := exec.Command("docker", "run", "--name", ip.String(), "--net="+subnetID,
 		"--ip="+ip.String(), "--mac-address="+mac.String(),
 		"debian", "ip", "addr", "show", "eth0", "scope", "global")
 	out, err := cmd.CombinedOutput()
-
-	if err != nil {
-		t.Error("docker run failed", cmd, string(out), err)
-	}
+	assert.Nil(err)
 
 	if !strings.Contains(string(out), ip.String()) {
 		t.Error("docker container IP not setup ", ip.String())
@@ -330,37 +315,29 @@ func dockerRunVerify(t *testing.T, name string, ip net.IP, mac net.HardwareAddr,
 		t.Error("docker container MTU not setup ")
 	}
 
-	if err := dockerContainerInfo(t, name); err != nil {
-		t.Error("docker container inspect failed", name, err.Error())
-	}
+	err = dockerContainerInfo(t, name)
+	assert.Nil(err)
 	return err
 }
 
 func dockerContainerDelete(t *testing.T, name string) error {
+	assert := assert.New(t)
 	defer logTime(t, time.Now(), "dockerContainerDelete")
 	out, err := exec.Command("docker", "stop", name).CombinedOutput()
-	if err != nil {
-		t.Error("docker container stop failed", name, string(out), err)
-	}
 
 	out, err = exec.Command("docker", "rm", name).CombinedOutput()
-	if err != nil {
-		t.Error("docker container delete failed", name, string(out), err)
-	}
+	assert.Nil(err, string(out))
 	return err
 }
 
 func dockerContainerInfo(t *testing.T, name string) error {
+	assert := assert.New(t)
 	defer logTime(t, time.Now(), "dockerContainerInfo")
 	out, err := exec.Command("docker", "ps", "-a").CombinedOutput()
-	if err != nil {
-		t.Error("docker ps -a", string(out), err)
-	}
+	assert.Nil(err)
 
 	out, err = exec.Command("docker", "inspect", name).CombinedOutput()
-	if err != nil {
-		t.Error("docker network inspect", name, string(out), err)
-	}
+	assert.Nil(err, string(out))
 	return err
 }
 
@@ -371,45 +348,40 @@ func dockerContainerInfo(t *testing.T, name string) error {
 //The IPAM driver needs top of the tree Docker (which needs special build)
 //is not tested yet
 func dockerNetCreate(t *testing.T, subnet net.IPNet, gw net.IP, bridge string, subnetID string) error {
+	assert := assert.New(t)
 	defer logTime(t, time.Now(), "dockerNetCreate")
 	cmd := exec.Command("docker", "network", "create", "-d=ciao",
 		"--subnet="+subnet.String(), "--gateway="+gw.String(),
 		"--opt", "bridge="+bridge, subnetID)
 
 	out, err := cmd.CombinedOutput()
-
-	if err != nil {
-		t.Error("docker network create failed", string(out), err)
-	}
+	assert.Nil(err, string(out))
 	return err
 }
 
 //Will be replaced by Docker API's in launcher
 // docker network rm ContainerInfo.SubnetID
 func dockerNetDelete(t *testing.T, subnetID string) error {
+	assert := assert.New(t)
 	defer logTime(t, time.Now(), "dockerNetDelete")
 	out, err := exec.Command("docker", "network", "rm", subnetID).CombinedOutput()
-	if err != nil {
-		t.Error("docker network delete failed", string(out), err)
-	}
+	assert.Nil(err, string(out))
 	return err
 }
 
 func dockerNetList(t *testing.T) error {
+	assert := assert.New(t)
 	defer logTime(t, time.Now(), "dockerNetList")
 	out, err := exec.Command("docker", "network", "ls").CombinedOutput()
-	if err != nil {
-		t.Error("docker network ls", string(out), err)
-	}
+	assert.Nil(err, string(out))
 	return err
 }
 
 func dockerNetInfo(t *testing.T, subnetID string) error {
+	assert := assert.New(t)
 	defer logTime(t, time.Now(), "dockerNetInfo")
 	out, err := exec.Command("docker", "network", "inspect", subnetID).CombinedOutput()
-	if err != nil {
-		t.Error("docker network inspect", string(out), err)
-	}
+	assert.Nil(err, string(out))
 	return err
 }
 
@@ -429,6 +401,7 @@ const (
 //
 //Test is expected to pass
 func DockerSerial(netType dockerNetType, t *testing.T) {
+	assert := assert.New(t)
 	defer logTime(t, time.Now(), "TestDockerSerial")
 	cn := &libsnnet.ComputeNode{}
 
@@ -448,32 +421,21 @@ func DockerSerial(netType dockerNetType, t *testing.T) {
 	cn.ManagementNet = mgtNet
 	cn.ComputeNet = mgtNet
 
-	if err := cn.Init(); err != nil {
-		t.Fatal("ERROR: cn.Init failed", err)
-	}
-	if err := cn.ResetNetwork(); err != nil {
-		t.Error("ERROR: cn.ResetNetwork failed", err)
-	}
-	if err := cn.DbRebuild(nil); err != nil {
-		t.Fatal("ERROR: cn.dbRebuild failed")
-	}
+	require.Nil(t, cn.Init())
+	require.Nil(t, cn.ResetNetwork())
+	require.Nil(t, cn.DbRebuild(nil))
 
 	dockerPlugin := libsnnet.NewDockerPlugin()
-	if err := dockerPlugin.Init(); err != nil {
-		t.Fatal("ERROR: Docker Init failed ", err)
-	}
+	require.Nil(t, dockerPlugin.Init())
+
 	defer func() { _ = dockerPlugin.Close() }()
 
-	if err := dockerPlugin.Start(); err != nil {
-		t.Fatal("ERROR: Docker start failed ", err)
-	}
+	require.Nil(t, dockerPlugin.Start())
 	defer func() { _ = dockerPlugin.Stop() }()
 
 	//Restarting docker here so the the plugin will
 	//be picked up without modifing the boot scripts
-	if err := dockerRestart(t); err != nil {
-		t.Fatal("ERROR: Docker restart failed ", err)
-	}
+	require.Nil(t, dockerRestart(t))
 
 	//From YAML on instance init
 	tenantID := "tenantuuid"
@@ -517,37 +479,38 @@ func DockerSerial(netType dockerNetType, t *testing.T) {
 			}
 
 			// Create a VNIC: Should create bridge and tunnels
-			if _, _, cInfo, err := cn.CreateVnic(vnicCfg); err != nil {
-				t.Error(err)
-			} else {
+			_, _, cInfo, err := cn.CreateVnic(vnicCfg)
+			if assert.Nil(err) {
 				defer func() { _, _, _ = cn.DestroyVnic(vnicCfg) }()
 
 				if cInfo.CNContainerEvent == libsnnet.ContainerNetworkAdd {
-					if err := dockerNetCreate(t, cInfo.Subnet, cInfo.Gateway,
-						cInfo.Bridge, cInfo.SubnetID); err != nil {
-						t.Error("ERROR: docker network", cInfo, err)
-					} else {
+					err := dockerNetCreate(t, cInfo.Subnet, cInfo.Gateway,
+						cInfo.Bridge, cInfo.SubnetID)
+					if assert.Nil(err) {
 						defer func() { _ = dockerNetDelete(t, cInfo.SubnetID) }()
 					}
 				}
 
-				switch netType {
-				case netCiao:
-					if err := dockerRunVerify(t, vnicCfg.VnicIP.String(), vnicCfg.VnicIP, vnicCfg.VnicMAC, cInfo.SubnetID); err != nil {
-						t.Error("ERROR: docker run", cInfo, err)
-					}
-				case netDockerNone:
-					if err := dockerRunNetNone(t, vnicCfg.VnicIP.String(), vnicCfg.VnicIP, vnicCfg.VnicMAC, cInfo.SubnetID); err != nil {
-						t.Error("ERROR: docker run", cInfo, err)
-					}
-				case netDockerDefault:
-					if err := dockerRunNetDocker(t, vnicCfg.VnicIP.String(), vnicCfg.VnicIP, vnicCfg.VnicMAC, cInfo.SubnetID); err != nil {
-						t.Error("ERROR: docker run", cInfo, err)
-					}
-				}
+				runNetworkTest(t, netType, vnicCfg.VnicIP.String(), vnicCfg.VnicIP, vnicCfg.VnicMAC, cInfo.SubnetID)
 				defer func() { _ = dockerContainerDelete(t, vnicCfg.VnicIP.String()) }()
 			}
 		}
+	}
+}
+
+func runNetworkTest(t *testing.T, netType dockerNetType, name string, ip net.IP, mac net.HardwareAddr, subnetID string) {
+	assert := assert.New(t)
+
+	switch netType {
+	case netCiao:
+		err := dockerRunVerify(t, name, ip, mac, subnetID)
+		assert.Nil(err)
+	case netDockerNone:
+		err := dockerRunNetNone(t, name, ip, mac, subnetID)
+		assert.Nil(err)
+	case netDockerDefault:
+		err := dockerRunNetDocker(t, name, ip, mac, subnetID)
+		assert.Nil(err)
 	}
 }
 

--- a/networking/libsnnet/utils.go
+++ b/networking/libsnnet/utils.go
@@ -127,10 +127,5 @@ func validPhysicalLink(link netlink.Link) bool {
 	case "vlan":
 		return true
 	}
-
-	if link.Attrs().Name == "lo" {
-		return false
-	}
-
 	return false
 }

--- a/networking/libsnnet/utils.go
+++ b/networking/libsnnet/utils.go
@@ -117,3 +117,20 @@ func genIface(device interface{}, unique bool) (string, error) {
 	// The chances of the failure are remote
 	return "", fmt.Errorf("unable to create unique interface name")
 }
+
+func validPhysicalLink(link netlink.Link) bool {
+	switch link.Type() {
+	case "device":
+		return true
+	case "bond":
+		return true
+	case "vlan":
+		return true
+	}
+
+	if link.Attrs().Name == "lo" {
+		return false
+	}
+
+	return false
+}

--- a/networking/libsnnet/utils.go
+++ b/networking/libsnnet/utils.go
@@ -19,6 +19,7 @@ package libsnnet
 import (
 	"fmt"
 	"math/rand"
+	"net"
 	"strings"
 	"time"
 
@@ -119,13 +120,22 @@ func genIface(device interface{}, unique bool) (string, error) {
 }
 
 func validPhysicalLink(link netlink.Link) bool {
+	phyDevice := true
+
 	switch link.Type() {
 	case "device":
-		return true
 	case "bond":
-		return true
 	case "vlan":
+	default:
+		phyDevice = false
+	}
+
+	if (link.Attrs().Flags & net.FlagLoopback) != 0 {
+		return false
+	}
+
+	if travisCI {
 		return true
 	}
-	return false
+	return phyDevice
 }

--- a/networking/libsnnet/vnic.go
+++ b/networking/libsnnet/vnic.go
@@ -127,13 +127,6 @@ func (v *Vnic) create() error {
 		return netError(v, "create cannot create an unnamed vnic")
 	}
 
-	switch v.Role {
-	case TenantVM:
-	case TenantContainer:
-	default:
-		return netError(v, "invalid vnic role specified")
-	}
-
 	if v.LinkName == "" {
 		if v.LinkName, err = genIface(v, true); err != nil {
 			return netError(v, "create geniface %v %v", v.GlobalID, err)
@@ -190,6 +183,8 @@ func (v *Vnic) create() error {
 		}
 
 		v.Link = vl
+	default:
+		return netError(v, "invalid vnic role specified")
 	}
 
 	if err := v.setAlias(v.GlobalID); err != nil {


### PR DESCRIPTION
The PR implements significant refactoring of the networking code base to reduce complexity.
However some unit tests and integration tests still have higher complexity.

Key changes included are
- Separating  the topology handling from the interface creation the case of CN and CNCI APIs
- Unification of the physical interface detection logic between CN and CNCI APIs
- Fixing of gometalinter flagged issues