### PR TITLE
Use test-cases to generate coverage data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,9 @@ script:
    - go list ./... | grep -v vendor | xargs -t go vet
 #  - go list ./... | grep -v vendor | xargs -tL 1 golint -set_exit_status
    - if [[ "$TRAVIS_GO_VERSION" != "tip" ]] ; then go list ./... | grep -v vendor | xargs -tL 1 golint -set_exit_status ; fi
-   - test-cases -text github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/ciao-controller/... github.com/01org/ciao/payloads
-   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -text github.com/01org/ciao/ssntp
-   - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -text -short -tags travis github.com/01org/ciao/networking/libsnnet
-   - $GOPATH/bin/gotestcover -v -coverprofile=cover.out github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/ciao-controller/... github.com/01org/ciao/payloads
+   - test-cases -text -coverprofile /tmp/cover.out github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/ciao-controller/... github.com/01org/ciao/payloads
+   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -text -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/ssntp
+   - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -text -short -tags travis -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/networking/libsnnet
 
 after_success:
-   - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=cover.out
+   - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=/tmp/cover.out


### PR DESCRIPTION
This should improve travis build times as we no longer need to compute the coverage data twice.  Previously coverage anaylsis was being done by both test-cases and gotestcover.  This change also allows us to generate coverage data for the unit tests that need to be run as root.

Some changes were required to test-cases to make this possible.  In short two new command line options, coverprofile and append-profile, were added to allow coverage data to be generated.