### PR TITLE
payloads: finish off coverage

### DIFF
--- a/payloads/assignpublicIP_test.go
+++ b/payloads/assignpublicIP_test.go
@@ -19,6 +19,7 @@ package payloads
 import (
 	"testing"
 
+	"github.com/docker/distribution/uuid"
 	"gopkg.in/yaml.v2"
 )
 
@@ -147,5 +148,33 @@ func TestReleasePublicIPMarshal(t *testing.T) {
 
 	if string(y) != releaseIPYaml {
 		t.Errorf("ReleasePublicIP marshalling failed\n[%s]\n vs\n[%s]", string(y), releaseIPYaml)
+	}
+}
+
+func TestPublicIPFailureString(t *testing.T) {
+	var stringTests = []struct {
+		r        PublicIPFailureReason
+		expected string
+	}{
+		{PublicIPNoInstance, "Instance does not exist"},
+		{PublicIPInvalidPayload, "YAML payload is corrupt"},
+		{PublicIPInvalidData, "Command section of YAML payload is corrupt or missing required information"},
+		{PublicIPAssignFailure, "Public IP assignment operation_failed"},
+		{PublicIPReleaseFailure, "Public IP release operation_failed"},
+	}
+	error := ErrorPublicIPFailure{
+		ConcentratorUUID: uuid.Generate().String(),
+		TenantUUID:       uuid.Generate().String(),
+		InstanceUUID:     uuid.Generate().String(),
+		PublicIP:         "10.1.2.3",
+		PrivateIP:        "192.168.1.2",
+		VnicMAC:          "aa:bb:cc:01:02:03",
+	}
+	for _, test := range stringTests {
+		error.Reason = test.r
+		s := error.Reason.String()
+		if s != test.expected {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expected, s)
+		}
 	}
 }

--- a/payloads/configure_test.go
+++ b/payloads/configure_test.go
@@ -122,3 +122,37 @@ func TestConfigureMarshal(t *testing.T) {
 		t.Errorf("CONFIGURE marshalling failed\n[%s]\n vs\n[%s]", string(y), configureYaml)
 	}
 }
+
+func TestConfigureStorageTypeString(t *testing.T) {
+	var stringTests = []struct {
+		s        StorageType
+		expected string
+	}{
+		{Filesystem, "file"},
+		{Etcd, "etcd"},
+	}
+	for _, test := range stringTests {
+		obj := test.s
+		out := obj.String()
+		if out != test.expected {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expected, out)
+		}
+	}
+}
+
+func TestConfigureServiceTypeString(t *testing.T) {
+	var stringTests = []struct {
+		s        ServiceType
+		expected string
+	}{
+		{Glance, "glance"},
+		{Keystone, "keystone"},
+	}
+	for _, test := range stringTests {
+		obj := test.s
+		out := obj.String()
+		if out != test.expected {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expected, out)
+		}
+	}
+}

--- a/payloads/deletefailure_test.go
+++ b/payloads/deletefailure_test.go
@@ -55,3 +55,24 @@ func TestDeleteFailureMarshal(t *testing.T) {
 	}
 	fmt.Println(string(y))
 }
+
+func TestDeleteFailureString(t *testing.T) {
+	var stringTests = []struct {
+		r        DeleteFailureReason
+		expected string
+	}{
+		{DeleteNoInstance, "Instance does not exist"},
+		{DeleteInvalidPayload, "YAML payload is corrupt"},
+		{DeleteInvalidData, "Command section of YAML payload is corrupt or missing required information"},
+	}
+	error := ErrorDeleteFailure{
+		InstanceUUID: uuid.Generate().String(),
+	}
+	for _, test := range stringTests {
+		error.Reason = test.r
+		s := error.Reason.String()
+		if s != test.expected {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expected, s)
+		}
+	}
+}

--- a/payloads/restartfailure_test.go
+++ b/payloads/restartfailure_test.go
@@ -55,3 +55,28 @@ func TestRestartFailureMarshal(t *testing.T) {
 	}
 	fmt.Println(string(y))
 }
+
+func TestRestartFailureString(t *testing.T) {
+	var stringTests = []struct {
+		r        RestartFailureReason
+		expected string
+	}{
+		{RestartNoInstance, "Instance does not exist"},
+		{RestartInvalidPayload, "YAML payload is corrupt"},
+		{RestartInvalidData, "Command section of YAML payload is corrupt or missing required information"},
+		{RestartAlreadyRunning, "Instance is already running"},
+		{RestartInstanceCorrupt, "Instance is corrupt"},
+		{RestartLaunchFailure, "Failed to launch instance"},
+		{RestartNetworkFailure, "Failed to locate VNIC for instance"},
+	}
+	error := ErrorRestartFailure{
+		InstanceUUID: uuid.Generate().String(),
+	}
+	for _, test := range stringTests {
+		error.Reason = test.r
+		s := error.Reason.String()
+		if s != test.expected {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expected, s)
+		}
+	}
+}

--- a/payloads/start_test.go
+++ b/payloads/start_test.go
@@ -18,37 +18,14 @@ package payloads
 
 import (
 	"fmt"
+	"github.com/01org/ciao/testutil"
 	"gopkg.in/yaml.v2"
 	"testing"
 )
 
 func TestStartUnmarshal(t *testing.T) {
-	startYaml := `start:
-  instance_uuid: 3390740c-dce9-48d6-b83a-a717417072ce
-  image_uuid: 59460b8a-5f53-4e3e-b5ce-b71fed8c7e64
-  fw_type: efi
-  persistence: host
-  vm_type: qemu
-  requested_resources:
-    - type: vcpus
-      value: 2
-      mandatory: true
-    - type: mem_mb
-      value: 1014
-      mandatory: true
-    - type: disk_mb
-      value: 10000
-      mandatory: true
-  estimated_resources:
-    - type: vcpus
-      value: 1
-    - type: mem_mb
-      value: 128
-    - type: disk_mb
-      value: 4096
-`
 	var cmd Start
-	err := yaml.Unmarshal([]byte(startYaml), &cmd)
+	err := yaml.Unmarshal([]byte(testutil.StartYaml), &cmd)
 	if err != nil {
 		t.Error(err)
 	}
@@ -108,20 +85,8 @@ func TestStartMarshal(t *testing.T) {
 // make sure the yaml can be unmarshaled into the Start struct with
 // optional data not present
 func TestStartUnmarshalPartial(t *testing.T) {
-	startYaml := `start:
-  instance_uuid: 923d1f2b-aabe-4a9b-9982-8664b0e52f93
-  image_uuid: 53cdd9ef-228f-4ce1-911d-706c2b41454a
-  docker_image: ubuntu/latest
-  fw_type: efi
-  persistence: host
-  vm_type: qemu
-  requested_resources:
-    - type: vcpus
-      value: 2
-      mandatory: true
-`
 	var cmd Start
-	err := yaml.Unmarshal([]byte(startYaml), &cmd)
+	err := yaml.Unmarshal([]byte(testutil.PartialStartYaml), &cmd)
 	if err != nil {
 		t.Error(err)
 	}

--- a/payloads/startfailure_test.go
+++ b/payloads/startfailure_test.go
@@ -54,3 +54,32 @@ func TestStartFailureMarshal(t *testing.T) {
 	}
 	fmt.Println(string(y))
 }
+
+func TestStartFailureString(t *testing.T) {
+	var stringTests = []struct {
+		r        StartFailureReason
+		expected string
+	}{
+		{FullCloud, "Cloud is full"},
+		{FullComputeNode, "Compute node is full"},
+		{NoComputeNodes, "No compute node available"},
+		{NoNetworkNodes, "No network node available"},
+		{InvalidPayload, "YAML payload is corrupt"},
+		{InvalidData, "Command section of YAML payload is corrupt or missing required information"},
+		{AlreadyRunning, "Instance is already running"},
+		{InstanceExists, "Instance already exists"},
+		{ImageFailure, "Failed to create instance image"},
+		{LaunchFailure, "Failed to launch instance"},
+		{NetworkFailure, "Failed to create VNIC for instance"},
+	}
+	error := ErrorStartFailure{
+		InstanceUUID: uuid.Generate().String(),
+	}
+	for _, test := range stringTests {
+		error.Reason = test.r
+		s := error.Reason.String()
+		if s != test.expected {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expected, s)
+		}
+	}
+}

--- a/payloads/stopfailure_test.go
+++ b/payloads/stopfailure_test.go
@@ -55,3 +55,25 @@ func TestStopFailureMarshal(t *testing.T) {
 	}
 	fmt.Println(string(y))
 }
+
+func TestStopFailureString(t *testing.T) {
+	var stringTests = []struct {
+		r        StopFailureReason
+		expected string
+	}{
+		{StopNoInstance, "Instance does not exist"},
+		{StopInvalidPayload, "YAML payload is corrupt"},
+		{StopInvalidData, "Command section of YAML payload is corrupt or missing required information"},
+		{StopAlreadyStopped, "Instance has already shut down"},
+	}
+	error := ErrorStopFailure{
+		InstanceUUID: uuid.Generate().String(),
+	}
+	for _, test := range stringTests {
+		error.Reason = test.r
+		s := error.Reason.String()
+		if s != test.expected {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expected, s)
+		}
+	}
+}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -1,0 +1,17 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package testutil

--- a/testutil/yaml.go
+++ b/testutil/yaml.go
@@ -1,0 +1,76 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package testutil
+
+// StartYaml is a sample workload Start command payload for test usage
+var StartYaml = `start:
+  instance_uuid: 3390740c-dce9-48d6-b83a-a717417072ce
+  image_uuid: 59460b8a-5f53-4e3e-b5ce-b71fed8c7e64
+  fw_type: efi
+  persistence: host
+  vm_type: qemu
+  requested_resources:
+    - type: vcpus
+      value: 2
+      mandatory: true
+    - type: mem_mb
+      value: 1014
+      mandatory: true
+    - type: disk_mb
+      value: 10000
+      mandatory: true
+  estimated_resources:
+    - type: vcpus
+      value: 1
+    - type: mem_mb
+      value: 128
+    - type: disk_mb
+      value: 4096
+`
+
+// CNCIStartYaml is a sample CNCI workload Start command payload for test cases
+var CNCIStartYaml = `start:
+  instance_uuid: fb3e089c-62bd-476c-b22a-9d6d09599306
+  image_uuid: eba04826-62a5-48bd-876f-9119667b1487,
+  fw_type: efi
+  persistence: host
+  vm_type: qemu
+  requested_resources:
+    - type: vcpus
+      value: 4
+      mandatory: true
+    - type: mem_mb
+      value: 4096
+      mandatory: true
+    - type: network_node
+      value: 1
+      mandatory: true
+`
+
+// PartialStartYaml is a sample minimal workload Start command payload for test cases
+var PartialStartYaml = `start:
+  instance_uuid: 923d1f2b-aabe-4a9b-9982-8664b0e52f93
+  image_uuid: 53cdd9ef-228f-4ce1-911d-706c2b41454a
+  docker_image: ubuntu/latest
+  fw_type: efi
+  persistence: host
+  vm_type: qemu
+  requested_resources:
+    - type: vcpus
+      value: 2
+      mandatory: true
+`


### PR DESCRIPTION
I needed practice making a table based test and the coverage report is
annoying in its outliers such as these couple little things in payloads.

I'm starting to move commonly used definitions to the testutil package,
so they can be used by multiple subcomponents' unit tests without
duplicating efforts.

Signed-off-by: Tim Pepper <timothy.c.pepper@intel.com>