### PR TITLE
documentation: push vs pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ which communicate over the "Simple and Secure Node Transfer Protocol
 is responsible for policy choices around tenant workloads.
 
 [Scheduler](https://github.com/01org/ciao/blob/master/ciao-scheduler)
-implements a push scheduling, finding a first fit on cluster compute
-nodes for a controller approved workload instance.
+implements a "push/pull" scheduling algorithm.  In response to a
+controller approved workload instance arriving at the scheduler, it
+finds a first fit among cluster compute nodes currently requesting work.
 
 [Launcher](https://github.com/01org/ciao/blob/master/ciao-launcher)
 abstracts the specific launching details for the different workload


### PR DESCRIPTION
The scheduler is a pull scheduler more than a push scheduler, or now I'm
hearing people say "push/pull".  The scheduler does not simply push work,
looking for a place to land it.  Compute nodes check in and request work,
with the scheduler handing the work to a node that has requested work.
It's not strictly pull arguably because the compute nodes aren't checking
in and immediately bidding for or pulling work off a work queue.

Signed-off-by: Tim Pepper <timothy.c.pepper@intel.com>