### PR TITLE
testutil and unit test framework enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
    - sudo mkdir -p /etc/pki/ciao/
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server -role scheduler
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role agent
+   - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role agent,netagent
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role controller
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role cnciagent
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role netagent

--- a/ciao-controller/compute_test.go
+++ b/ciao-controller/compute_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/01org/ciao/ciao-controller/types"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp"
+	"github.com/01org/ciao/testutil"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -216,7 +217,7 @@ func TestDeleteServer(t *testing.T) {
 
 	// instances have to be assigned to a node to be deleted
 	client := newTestClient(0, ssntp.AGENT)
-	defer client.ssntp.Close()
+	defer client.Ssntp.Close()
 
 	tURL := computeURL + "/v2.1/" + tenant.ID + "/servers/"
 
@@ -227,7 +228,7 @@ func TestDeleteServer(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	client.sendStats()
+	client.SendStats()
 
 	time.Sleep(2 * time.Second)
 
@@ -257,7 +258,7 @@ func TestServersActionStart(t *testing.T) {
 	url := computeURL + "/v2.1/" + tenant.ID + "/servers/action"
 
 	client := newTestClient(0, ssntp.AGENT)
-	defer client.ssntp.Close()
+	defer client.Ssntp.Close()
 
 	servers := testCreateServer(t, 1)
 	if servers.TotalServers != 1 {
@@ -266,7 +267,7 @@ func TestServersActionStart(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	client.sendStats()
+	client.SendStats()
 
 	time.Sleep(1 * time.Second)
 
@@ -276,7 +277,7 @@ func TestServersActionStart(t *testing.T) {
 	}
 
 	time.Sleep(1 * time.Second)
-	client.sendStats()
+	client.SendStats()
 
 	var ids []string
 	ids = append(ids, servers.Servers[0].ID)
@@ -303,7 +304,7 @@ func TestServersActionStop(t *testing.T) {
 	url := computeURL + "/v2.1/" + tenant.ID + "/servers/action"
 
 	client := newTestClient(0, ssntp.AGENT)
-	defer client.ssntp.Close()
+	defer client.Ssntp.Close()
 
 	servers := testCreateServer(t, 1)
 	if servers.TotalServers != 1 {
@@ -312,7 +313,7 @@ func TestServersActionStop(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	client.sendStats()
+	client.SendStats()
 
 	time.Sleep(1 * time.Second)
 
@@ -341,7 +342,7 @@ func TestServerActionStop(t *testing.T) {
 	}
 
 	client := newTestClient(0, ssntp.AGENT)
-	defer client.ssntp.Close()
+	defer client.Ssntp.Close()
 
 	servers := testCreateServer(t, 1)
 	if servers.TotalServers != 1 {
@@ -350,7 +351,7 @@ func TestServerActionStop(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	client.sendStats()
+	client.SendStats()
 
 	time.Sleep(1 * time.Second)
 
@@ -367,7 +368,7 @@ func TestServerActionStart(t *testing.T) {
 	}
 
 	client := newTestClient(0, ssntp.AGENT)
-	defer client.ssntp.Close()
+	defer client.Ssntp.Close()
 
 	servers := testCreateServer(t, 1)
 	if servers.TotalServers != 1 {
@@ -376,12 +377,12 @@ func TestServerActionStart(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	client.sendStats()
+	client.SendStats()
 
 	time.Sleep(1 * time.Second)
 
-	c := make(chan cmdResult)
-	server.addCmdChan(ssntp.STOP, c)
+	c := make(chan testutil.CmdResult)
+	server.AddCmdChan(ssntp.STOP, c)
 
 	err = context.stopInstance(servers.Servers[0].ID)
 	if err != nil {
@@ -390,7 +391,7 @@ func TestServerActionStart(t *testing.T) {
 
 	select {
 	case result := <-c:
-		if result.err != nil {
+		if result.Err != nil {
 			t.Fatal("Error parsing command yaml")
 		}
 
@@ -400,7 +401,7 @@ func TestServerActionStart(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	client.sendStats()
+	client.SendStats()
 
 	time.Sleep(1 * time.Second)
 
@@ -873,9 +874,9 @@ func TestListTraces(t *testing.T) {
 	var expected payloads.CiaoTracesSummary
 
 	client := testStartTracedWorkload(t)
-	defer client.ssntp.Close()
+	defer client.Ssntp.Close()
 
-	client.sendTrace()
+	client.SendTrace()
 
 	time.Sleep(2 * time.Second)
 
@@ -959,9 +960,9 @@ func TestClearEvents(t *testing.T) {
 
 func TestTraceData(t *testing.T) {
 	client := testStartTracedWorkload(t)
-	defer client.ssntp.Close()
+	defer client.Ssntp.Close()
 
-	client.sendTrace()
+	client.SendTrace()
 
 	time.Sleep(2 * time.Second)
 

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/01org/ciao/ciao-controller/types"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp"
+	"github.com/01org/ciao/testutil"
 	"github.com/docker/distribution/uuid"
 	"gopkg.in/yaml.v2"
 	"math/rand"
@@ -1450,7 +1451,12 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	id := startIdentityTestServer()
+	testIdentityConfig := testutil.TestIdentityConfig{
+		ComputeURL: computeURL,
+		ProjectID:  computeTestUser,
+	}
+
+	id := testutil.StartIdentityTestServer(testIdentityConfig)
 	defer id.Close()
 
 	idConfig := identityConfig{

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/01org/ciao/ssntp"
 	"github.com/01org/ciao/testutil"
 	"github.com/docker/distribution/uuid"
-	"gopkg.in/yaml.v2"
-	"math/rand"
 	"net"
 	"os"
 	"strconv"
@@ -34,352 +32,6 @@ import (
 	"testing"
 	"time"
 )
-
-type ssntpTestServer struct {
-	ssntp        ssntp.Server
-	clients      []string
-	cmdChans     map[ssntp.Command]chan cmdResult
-	cmdChansLock *sync.Mutex
-
-	netClients     map[string]bool
-	netClientsLock *sync.RWMutex
-}
-
-type cmdResult struct {
-	instanceUUID string
-	err          error
-	nodeUUID     string
-	tenantUUID   string
-	cnci         bool
-}
-
-func (server *ssntpTestServer) addCmdChan(cmd ssntp.Command, c chan cmdResult) {
-	server.cmdChansLock.Lock()
-	server.cmdChans[cmd] = c
-	server.cmdChansLock.Unlock()
-}
-
-func (server *ssntpTestServer) ConnectNotify(uuid string, role uint32) {
-	switch role {
-	case ssntp.AGENT:
-		server.clients = append(server.clients, uuid)
-
-	case ssntp.NETAGENT:
-		server.netClientsLock.Lock()
-		server.netClients[uuid] = true
-		server.netClientsLock.Unlock()
-	}
-
-}
-
-func (server *ssntpTestServer) DisconnectNotify(uuid string, role uint32) {
-	for index := range server.clients {
-		if server.clients[index] == uuid {
-			server.clients = append(server.clients[:index], server.clients[index+1:]...)
-			return
-		}
-	}
-
-	server.netClientsLock.Lock()
-	delete(server.netClients, uuid)
-	server.netClientsLock.Unlock()
-}
-
-func (server *ssntpTestServer) StatusNotify(uuid string, status ssntp.Status, frame *ssntp.Frame) {
-}
-
-func (server *ssntpTestServer) CommandNotify(uuid string, command ssntp.Command, frame *ssntp.Frame) {
-	var result cmdResult
-	var nn bool
-
-	payload := frame.Payload
-
-	server.cmdChansLock.Lock()
-	c, ok := server.cmdChans[command]
-	server.cmdChansLock.Unlock()
-
-	switch command {
-	case ssntp.START:
-		var startCmd payloads.Start
-
-		err := yaml.Unmarshal(payload, &startCmd)
-
-		if err == nil {
-			resources := startCmd.Start.RequestedResources
-
-			for i := range resources {
-				if resources[i].Type == payloads.NetworkNode {
-					nn = true
-					break
-				}
-			}
-			result.instanceUUID = startCmd.Start.InstanceUUID
-			result.tenantUUID = startCmd.Start.TenantUUID
-			result.cnci = nn
-		}
-		result.err = err
-
-	case ssntp.DELETE:
-		var delCmd payloads.Delete
-
-		err := yaml.Unmarshal(payload, &delCmd)
-		result.err = err
-		if err == nil {
-			result.instanceUUID = delCmd.Delete.InstanceUUID
-		}
-
-	case ssntp.STOP:
-		var stopCmd payloads.Stop
-
-		err := yaml.Unmarshal(payload, &stopCmd)
-
-		result.err = err
-
-		if err == nil {
-			result.instanceUUID = stopCmd.Stop.InstanceUUID
-			server.ssntp.SendCommand(stopCmd.Stop.WorkloadAgentUUID, command, frame.Payload)
-		}
-
-	case ssntp.RESTART:
-		var restartCmd payloads.Restart
-
-		err := yaml.Unmarshal(payload, &restartCmd)
-
-		result.err = err
-
-		if err == nil {
-			result.instanceUUID = restartCmd.Restart.InstanceUUID
-			server.ssntp.SendCommand(restartCmd.Restart.WorkloadAgentUUID, command, frame.Payload)
-		}
-
-	case ssntp.EVACUATE:
-		var evacCmd payloads.Evacuate
-
-		err := yaml.Unmarshal(payload, &evacCmd)
-
-		result.err = err
-
-		if err == nil {
-			result.nodeUUID = evacCmd.Evacuate.WorkloadAgentUUID
-		}
-	}
-
-	if ok {
-		server.cmdChansLock.Lock()
-		delete(server.cmdChans, command)
-		server.cmdChansLock.Unlock()
-
-		c <- result
-
-		close(c)
-	}
-}
-
-func (server *ssntpTestServer) EventNotify(uuid string, event ssntp.Event, frame *ssntp.Frame) {
-}
-
-func (server *ssntpTestServer) ErrorNotify(uuid string, error ssntp.Error, frame *ssntp.Frame) {
-}
-
-func (server *ssntpTestServer) CommandForward(uuid string, command ssntp.Command, frame *ssntp.Frame) (dest ssntp.ForwardDestination) {
-	var startCmd payloads.Start
-	var nn bool
-
-	payload := frame.Payload
-
-	err := yaml.Unmarshal(payload, &startCmd)
-
-	if err != nil {
-		return
-	}
-
-	resources := startCmd.Start.RequestedResources
-
-	for i := range resources {
-		if resources[i].Type == payloads.NetworkNode {
-			nn = true
-			break
-		}
-	}
-
-	if nn {
-		server.netClientsLock.RLock()
-		for key := range server.netClients {
-			dest.AddRecipient(key)
-			break
-		}
-		server.netClientsLock.RUnlock()
-	} else if len(server.clients) > 0 {
-		index := rand.Intn(len(server.clients))
-		dest.AddRecipient(server.clients[index])
-	}
-
-	return
-}
-
-type ssntpTestClient struct {
-	ssntp             ssntp.Client
-	name              string
-	instances         []payloads.InstanceStat
-	ticker            *time.Ticker
-	uuid              string
-	role              ssntp.Role
-	startFail         bool
-	startFailReason   payloads.StartFailureReason
-	stopFail          bool
-	stopFailReason    payloads.StopFailureReason
-	restartFail       bool
-	restartFailReason payloads.RestartFailureReason
-	traces            []*ssntp.Frame
-
-	cmdChans     map[ssntp.Command]chan cmdResult
-	cmdChansLock *sync.Mutex
-}
-
-func (client *ssntpTestClient) addCmdChan(cmd ssntp.Command, c chan cmdResult) {
-	client.cmdChansLock.Lock()
-	client.cmdChans[cmd] = c
-	client.cmdChansLock.Unlock()
-}
-
-func (client *ssntpTestClient) ConnectNotify() {
-}
-
-func (client *ssntpTestClient) DisconnectNotify() {
-}
-
-func (client *ssntpTestClient) StatusNotify(status ssntp.Status, frame *ssntp.Frame) {
-}
-
-func (client *ssntpTestClient) handleStart(payload []byte) cmdResult {
-	var result cmdResult
-	var start payloads.Start
-
-	err := yaml.Unmarshal(payload, &start)
-	if err != nil {
-		result.err = err
-		return result
-	}
-
-	result.instanceUUID = start.Start.InstanceUUID
-	result.tenantUUID = start.Start.TenantUUID
-
-	if client.role == ssntp.NETAGENT {
-		networking := start.Start.Networking
-
-		client.sendConcentratorAddedEvent(start.Start.InstanceUUID, start.Start.TenantUUID, networking.VnicMAC)
-		result.cnci = true
-		return result
-	}
-
-	if !client.startFail {
-		istat := payloads.InstanceStat{
-			InstanceUUID:  start.Start.InstanceUUID,
-			State:         payloads.Running,
-			MemoryUsageMB: 0,
-			DiskUsageMB:   0,
-			CPUUsage:      0,
-		}
-
-		client.instances = append(client.instances, istat)
-	} else {
-		client.sendStartFailure(start.Start.InstanceUUID, client.startFailReason)
-	}
-
-	return result
-}
-
-func (client *ssntpTestClient) handleStop(payload []byte) cmdResult {
-	var result cmdResult
-	var stopCmd payloads.Stop
-
-	err := yaml.Unmarshal(payload, &stopCmd)
-	if err != nil {
-		result.err = err
-		return result
-	}
-
-	if !client.stopFail {
-		for i := range client.instances {
-			istat := client.instances[i]
-			if istat.InstanceUUID == stopCmd.Stop.InstanceUUID {
-				client.instances[i].State = payloads.Exited
-			}
-		}
-	} else {
-		client.sendStopFailure(stopCmd.Stop.InstanceUUID, client.stopFailReason)
-	}
-
-	return result
-}
-
-func (client *ssntpTestClient) handleRestart(payload []byte) cmdResult {
-	var result cmdResult
-	var restartCmd payloads.Restart
-
-	err := yaml.Unmarshal(payload, &restartCmd)
-	if err != nil {
-		result.err = err
-		return result
-	}
-
-	if !client.restartFail {
-		for i := range client.instances {
-			istat := client.instances[i]
-			if istat.InstanceUUID == restartCmd.Restart.InstanceUUID {
-				client.instances[i].State = payloads.Running
-			}
-		}
-	} else {
-		client.sendRestartFailure(restartCmd.Restart.InstanceUUID, client.restartFailReason)
-	}
-
-	return result
-}
-
-func (client *ssntpTestClient) CommandNotify(command ssntp.Command, frame *ssntp.Frame) {
-	payload := frame.Payload
-
-	var result cmdResult
-
-	if frame.Trace != nil {
-		frame.SetEndStamp()
-		client.traces = append(client.traces, frame)
-	}
-
-	client.cmdChansLock.Lock()
-	c, ok := client.cmdChans[command]
-	client.cmdChansLock.Unlock()
-
-	switch command {
-	case ssntp.START:
-		result = client.handleStart(payload)
-
-	case ssntp.STOP:
-		result = client.handleStop(payload)
-
-	case ssntp.RESTART:
-		result = client.handleRestart(payload)
-	}
-
-	if ok {
-		client.cmdChansLock.Lock()
-		delete(client.cmdChans, command)
-		client.cmdChansLock.Unlock()
-
-		c <- result
-
-		close(c)
-	}
-
-	return
-}
-
-func (client *ssntpTestClient) EventNotify(event ssntp.Event, frame *ssntp.Frame) {
-}
-
-func (client *ssntpTestClient) ErrorNotify(error ssntp.Error, frame *ssntp.Frame) {
-}
 
 func roleToCert(role ssntp.Role) string {
 	switch role {
@@ -398,181 +50,36 @@ func roleToCert(role ssntp.Role) string {
 	return defaultControllerCert
 }
 
-func newTestClient(num int, role ssntp.Role) *ssntpTestClient {
-	client := &ssntpTestClient{
-		name: "Test " + role.String() + strconv.Itoa(num),
-		uuid: uuid.Generate().String(),
-		role: role,
+func newTestClient(num int, role ssntp.Role) *testutil.SsntpTestClient {
+	client := &testutil.SsntpTestClient{
+		Name: "Test " + role.String() + strconv.Itoa(num),
+		UUID: uuid.Generate().String(),
+		Role: role,
 	}
 
-	client.cmdChans = make(map[ssntp.Command]chan cmdResult)
-	client.cmdChansLock = &sync.Mutex{}
+	client.CmdChans = make(map[ssntp.Command]chan testutil.CmdResult)
+	client.CmdChansLock = &sync.Mutex{}
 
 	config := &ssntp.Config{
 		CAcert: *caCert,
 		Cert:   roleToCert(role),
 		Log:    ssntp.Log,
-		UUID:   client.uuid,
+		UUID:   client.UUID,
 	}
 
-	if client.ssntp.Dial(config, client) != nil {
+	if client.Ssntp.Dial(config, client) != nil {
 		return nil
 	}
 
 	return client
 }
 
-func (client *ssntpTestClient) sendStats() {
-	stat := payloads.Stat{
-		NodeUUID:        client.uuid,
-		MemTotalMB:      256,
-		MemAvailableMB:  256,
-		DiskTotalMB:     1024,
-		DiskAvailableMB: 1024,
-		Load:            20,
-		CpusOnline:      4,
-		NodeHostName:    client.name,
-		Instances:       client.instances,
-	}
+func startTestServer(server *testutil.SsntpTestServer) {
+	server.CmdChans = make(map[ssntp.Command]chan testutil.CmdResult)
+	server.CmdChansLock = &sync.Mutex{}
 
-	y, err := yaml.Marshal(stat)
-	if err != nil {
-		return
-	}
-
-	_, err = client.ssntp.SendCommand(ssntp.STATS, y)
-	if err != nil {
-		fmt.Println(err)
-	}
-}
-
-func (client *ssntpTestClient) sendTrace() {
-	var s payloads.Trace
-
-	for _, f := range client.traces {
-		t, err := f.DumpTrace()
-		if err != nil {
-			fmt.Println(err)
-			continue
-		}
-
-		s.Frames = append(s.Frames, *t)
-	}
-
-	payload, err := yaml.Marshal(&s)
-	if err != nil {
-		fmt.Println(err)
-	}
-
-	client.traces = nil
-
-	_, err = client.ssntp.SendEvent(ssntp.TraceReport, payload)
-	if err != nil {
-		fmt.Println(err)
-	}
-}
-
-func (client *ssntpTestClient) sendDeleteEvent(uuid string) {
-	evt := payloads.InstanceDeletedEvent{
-		InstanceUUID: uuid,
-	}
-
-	event := payloads.EventInstanceDeleted{
-		InstanceDeleted: evt,
-	}
-
-	y, err := yaml.Marshal(event)
-	if err != nil {
-		return
-	}
-
-	_, err = client.ssntp.SendEvent(ssntp.InstanceDeleted, y)
-	if err != nil {
-		fmt.Println(err)
-	}
-
-}
-
-func (client *ssntpTestClient) sendConcentratorAddedEvent(instanceUUID string, tenantUUID string, vnicMAC string) {
-	evt := payloads.ConcentratorInstanceAddedEvent{
-		InstanceUUID:    instanceUUID,
-		TenantUUID:      tenantUUID,
-		ConcentratorIP:  "192.168.0.1",
-		ConcentratorMAC: vnicMAC,
-	}
-
-	event := payloads.EventConcentratorInstanceAdded{
-		CNCIAdded: evt,
-	}
-
-	y, err := yaml.Marshal(event)
-	if err != nil {
-		return
-	}
-
-	_, err = client.ssntp.SendEvent(ssntp.ConcentratorInstanceAdded, y)
-	if err != nil {
-		fmt.Println(err)
-	}
-}
-
-func (client *ssntpTestClient) sendStartFailure(instanceUUID string, reason payloads.StartFailureReason) {
-	e := payloads.ErrorStartFailure{
-		InstanceUUID: instanceUUID,
-		Reason:       reason,
-	}
-
-	y, err := yaml.Marshal(e)
-	if err != nil {
-		return
-	}
-
-	_, err = client.ssntp.SendError(ssntp.StartFailure, y)
-	if err != nil {
-		fmt.Println(err)
-	}
-}
-
-func (client *ssntpTestClient) sendStopFailure(instanceUUID string, reason payloads.StopFailureReason) {
-	e := payloads.ErrorStopFailure{
-		InstanceUUID: instanceUUID,
-		Reason:       reason,
-	}
-
-	y, err := yaml.Marshal(e)
-	if err != nil {
-		return
-	}
-
-	_, err = client.ssntp.SendError(ssntp.StopFailure, y)
-	if err != nil {
-		fmt.Println(err)
-	}
-}
-
-func (client *ssntpTestClient) sendRestartFailure(instanceUUID string, reason payloads.RestartFailureReason) {
-	e := payloads.ErrorRestartFailure{
-		InstanceUUID: instanceUUID,
-		Reason:       reason,
-	}
-
-	y, err := yaml.Marshal(e)
-	if err != nil {
-		return
-	}
-
-	_, err = client.ssntp.SendError(ssntp.RestartFailure, y)
-	if err != nil {
-		fmt.Println(err)
-	}
-}
-
-func startTestServer(server *ssntpTestServer) {
-	server.cmdChans = make(map[ssntp.Command]chan cmdResult)
-	server.cmdChansLock = &sync.Mutex{}
-
-	server.netClients = make(map[string]bool)
-	server.netClientsLock = &sync.RWMutex{}
+	server.NetClients = make(map[string]bool)
+	server.NetClientsLock = &sync.RWMutex{}
 
 	serverConfig := ssntp.Config{
 		CAcert: *caCert,
@@ -614,7 +121,7 @@ func startTestServer(server *ssntpTestServer) {
 		},
 	}
 
-	go server.ssntp.Serve(&serverConfig, server)
+	go server.Ssntp.Serve(&serverConfig, server)
 	return
 }
 
@@ -819,12 +326,12 @@ func TestStartWorkload(t *testing.T) {
 	var reason payloads.StartFailureReason
 
 	client, _ := testStartWorkload(t, 1, false, reason)
-	defer client.ssntp.Close()
+	defer client.Ssntp.Close()
 }
 
 func TestStartTracedWorkload(t *testing.T) {
 	client := testStartTracedWorkload(t)
-	defer client.ssntp.Close()
+	defer client.Ssntp.Close()
 }
 
 func TestStartWorkloadLaunchCNCI(t *testing.T) {
@@ -841,7 +348,7 @@ func TestStartWorkloadLaunchCNCI(t *testing.T) {
 		t.Fatal("CNCI Info not updated")
 	}
 
-	netClient.ssntp.Close()
+	netClient.Ssntp.Close()
 }
 
 // TBD: for the launch CNCI tests, I really need to create a fake
@@ -851,14 +358,14 @@ func TestDeleteInstance(t *testing.T) {
 	var reason payloads.StartFailureReason
 
 	client, instances := testStartWorkload(t, 1, false, reason)
-	defer client.ssntp.Close()
+	defer client.Ssntp.Close()
 
 	time.Sleep(1 * time.Second)
 
-	client.sendStats()
+	client.SendStats()
 
-	c := make(chan cmdResult)
-	server.addCmdChan(ssntp.DELETE, c)
+	c := make(chan testutil.CmdResult)
+	server.AddCmdChan(ssntp.DELETE, c)
 
 	time.Sleep(1 * time.Second)
 
@@ -869,11 +376,11 @@ func TestDeleteInstance(t *testing.T) {
 
 	select {
 	case result := <-c:
-		if result.err != nil {
+		if result.Err != nil {
 			t.Fatal("Error parsing command yaml")
 		}
 
-		if result.instanceUUID != instances[0].ID {
+		if result.InstanceUUID != instances[0].ID {
 			t.Fatal("Did not get correct Instance ID")
 		}
 
@@ -881,7 +388,7 @@ func TestDeleteInstance(t *testing.T) {
 		t.Fatal("Timeout waiting for DELETE command")
 	}
 
-	client.ssntp.Close()
+	client.Ssntp.Close()
 }
 
 func TestStopInstance(t *testing.T) {
@@ -891,10 +398,10 @@ func TestStopInstance(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	client.sendStats()
+	client.SendStats()
 
-	c := make(chan cmdResult)
-	server.addCmdChan(ssntp.STOP, c)
+	c := make(chan testutil.CmdResult)
+	server.AddCmdChan(ssntp.STOP, c)
 
 	time.Sleep(1 * time.Second)
 
@@ -905,11 +412,11 @@ func TestStopInstance(t *testing.T) {
 
 	select {
 	case result := <-c:
-		if result.err != nil {
+		if result.Err != nil {
 			t.Fatal("Error parsing command yaml")
 		}
 
-		if result.instanceUUID != instances[0].ID {
+		if result.InstanceUUID != instances[0].ID {
 			t.Fatal("Did not get correct Instance ID")
 		}
 
@@ -917,21 +424,21 @@ func TestStopInstance(t *testing.T) {
 		t.Fatal("Timeout waiting for STOP command")
 	}
 
-	client.ssntp.Close()
+	client.Ssntp.Close()
 }
 
 func TestRestartInstance(t *testing.T) {
 	var reason payloads.StartFailureReason
 
 	client, instances := testStartWorkload(t, 1, false, reason)
-	defer client.ssntp.Close()
+	defer client.Ssntp.Close()
 
 	time.Sleep(1 * time.Second)
 
-	client.sendStats()
+	client.SendStats()
 
-	c := make(chan cmdResult)
-	server.addCmdChan(ssntp.STOP, c)
+	c := make(chan testutil.CmdResult)
+	server.AddCmdChan(ssntp.STOP, c)
 
 	time.Sleep(1 * time.Second)
 
@@ -942,11 +449,11 @@ func TestRestartInstance(t *testing.T) {
 
 	select {
 	case result := <-c:
-		if result.err != nil {
+		if result.Err != nil {
 			t.Fatal("Error parsing command yaml")
 		}
 
-		if result.instanceUUID != instances[0].ID {
+		if result.InstanceUUID != instances[0].ID {
 			t.Fatal("Did not get correct Instance ID")
 		}
 
@@ -957,10 +464,10 @@ func TestRestartInstance(t *testing.T) {
 	// now attempt to restart
 	time.Sleep(1 * time.Second)
 
-	client.sendStats()
+	client.SendStats()
 
-	c = make(chan cmdResult)
-	server.addCmdChan(ssntp.RESTART, c)
+	c = make(chan testutil.CmdResult)
+	server.AddCmdChan(ssntp.RESTART, c)
 
 	time.Sleep(1 * time.Second)
 
@@ -971,40 +478,40 @@ func TestRestartInstance(t *testing.T) {
 
 	select {
 	case result := <-c:
-		if result.err != nil {
+		if result.Err != nil {
 			t.Fatal("Error parsing command yaml")
 		}
 
-		if result.instanceUUID != instances[0].ID {
+		if result.InstanceUUID != instances[0].ID {
 			t.Fatal("Did not get correct Instance ID")
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Timeout waiting for RESTART command")
 	}
 
-	client.ssntp.Close()
+	client.Ssntp.Close()
 }
 
 func TestEvacuateNode(t *testing.T) {
 	client := newTestClient(0, ssntp.AGENT)
 
-	c := make(chan cmdResult)
-	server.addCmdChan(ssntp.EVACUATE, c)
+	c := make(chan testutil.CmdResult)
+	server.AddCmdChan(ssntp.EVACUATE, c)
 
 	// ok to not send workload first?
 
-	err := context.evacuateNode(client.uuid)
+	err := context.evacuateNode(client.UUID)
 	if err != nil {
 		t.Error(err)
 	}
 
 	select {
 	case result := <-c:
-		if result.err != nil {
+		if result.Err != nil {
 			t.Fatal("Error parsing command yaml")
 		}
 
-		if result.nodeUUID != client.uuid {
+		if result.NodeUUID != client.UUID {
 			t.Fatal("Did not get node ID")
 		}
 
@@ -1012,18 +519,18 @@ func TestEvacuateNode(t *testing.T) {
 		t.Fatal("Timeout waiting for EVACUATE command")
 	}
 
-	client.ssntp.Close()
+	client.Ssntp.Close()
 }
 
 func TestInstanceDeletedEvent(t *testing.T) {
 	var reason payloads.StartFailureReason
 
 	client, instances := testStartWorkload(t, 1, false, reason)
-	defer client.ssntp.Close()
+	defer client.Ssntp.Close()
 
 	time.Sleep(1 * time.Second)
 
-	client.sendStats()
+	client.SendStats()
 
 	time.Sleep(1 * time.Second)
 
@@ -1034,7 +541,7 @@ func TestInstanceDeletedEvent(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	client.sendDeleteEvent(instances[0].ID)
+	client.SendDeleteEvent(instances[0].ID)
 
 	time.Sleep(1 * time.Second)
 
@@ -1044,14 +551,14 @@ func TestInstanceDeletedEvent(t *testing.T) {
 		t.Error("Instance not deleted")
 	}
 
-	client.ssntp.Close()
+	client.Ssntp.Close()
 }
 
 func TestLaunchCNCI(t *testing.T) {
 	netClient := newTestClient(0, ssntp.NETAGENT)
 
-	c := make(chan cmdResult)
-	server.addCmdChan(ssntp.START, c)
+	c := make(chan testutil.CmdResult)
+	server.AddCmdChan(ssntp.START, c)
 
 	id := uuid.Generate().String()
 
@@ -1060,15 +567,15 @@ func TestLaunchCNCI(t *testing.T) {
 
 	select {
 	case result := <-c:
-		if result.err != nil {
+		if result.Err != nil {
 			t.Fatal("Error parsing command yaml")
 		}
 
-		if result.tenantUUID != id {
+		if result.TenantUUID != id {
 			t.Fatal("Did not get correct tenant ID")
 		}
 
-		if !result.cnci {
+		if !result.CNCI {
 			t.Fatal("this is not a CNCI launch request")
 		}
 
@@ -1087,14 +594,14 @@ func TestLaunchCNCI(t *testing.T) {
 		t.Fatal("CNCI Info not updated")
 	}
 
-	netClient.ssntp.Close()
+	netClient.Ssntp.Close()
 }
 
 func TestStartFailure(t *testing.T) {
 	reason := payloads.FullCloud
 
 	client, _ := testStartWorkload(t, 1, true, reason)
-	defer client.ssntp.Close()
+	defer client.Ssntp.Close()
 
 	// since we had a start failure, we should confirm that the
 	// instance is no longer pending in the database
@@ -1106,19 +613,19 @@ func TestStopFailure(t *testing.T) {
 	var reason payloads.StartFailureReason
 
 	client, instances := testStartWorkload(t, 1, false, reason)
-	defer client.ssntp.Close()
+	defer client.Ssntp.Close()
 
-	client.stopFail = true
-	client.stopFailReason = payloads.StopNoInstance
-
-	time.Sleep(1 * time.Second)
-
-	client.sendStats()
+	client.StopFail = true
+	client.StopFailReason = payloads.StopNoInstance
 
 	time.Sleep(1 * time.Second)
 
-	c := make(chan cmdResult)
-	server.addCmdChan(ssntp.STOP, c)
+	client.SendStats()
+
+	time.Sleep(1 * time.Second)
+
+	c := make(chan testutil.CmdResult)
+	server.AddCmdChan(ssntp.STOP, c)
 
 	time.Sleep(1 * time.Second)
 
@@ -1129,11 +636,11 @@ func TestStopFailure(t *testing.T) {
 
 	select {
 	case result := <-c:
-		if result.err != nil {
+		if result.Err != nil {
 			t.Fatal("Error parsing command yaml")
 		}
 
-		if result.instanceUUID != instances[0].ID {
+		if result.InstanceUUID != instances[0].ID {
 			t.Fatal("Did not get correct Instance ID")
 		}
 
@@ -1143,7 +650,7 @@ func TestStopFailure(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	client.ssntp.Close()
+	client.Ssntp.Close()
 
 	// the response to a stop failure is to log the failure
 	entries, err := context.ds.GetEventLog()
@@ -1151,7 +658,7 @@ func TestStopFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedMsg := fmt.Sprintf("Stop Failure %s: %s", instances[0].ID, client.stopFailReason.String())
+	expectedMsg := fmt.Sprintf("Stop Failure %s: %s", instances[0].ID, client.StopFailReason.String())
 
 	for i := range entries {
 		if entries[i].Message == expectedMsg {
@@ -1167,19 +674,19 @@ func TestRestartFailure(t *testing.T) {
 	var reason payloads.StartFailureReason
 
 	client, instances := testStartWorkload(t, 1, false, reason)
-	defer client.ssntp.Close()
+	defer client.Ssntp.Close()
 
-	client.restartFail = true
-	client.restartFailReason = payloads.RestartLaunchFailure
-
-	time.Sleep(1 * time.Second)
-
-	client.sendStats()
+	client.RestartFail = true
+	client.RestartFailReason = payloads.RestartLaunchFailure
 
 	time.Sleep(1 * time.Second)
 
-	c := make(chan cmdResult)
-	server.addCmdChan(ssntp.STOP, c)
+	client.SendStats()
+
+	time.Sleep(1 * time.Second)
+
+	c := make(chan testutil.CmdResult)
+	server.AddCmdChan(ssntp.STOP, c)
 
 	err := context.stopInstance(instances[0].ID)
 	if err != nil {
@@ -1188,11 +695,11 @@ func TestRestartFailure(t *testing.T) {
 
 	select {
 	case result := <-c:
-		if result.err != nil {
+		if result.Err != nil {
 			t.Fatal("Error parsing command yaml")
 		}
 
-		if result.instanceUUID != instances[0].ID {
+		if result.InstanceUUID != instances[0].ID {
 			t.Fatal("Did not get correct Instance ID")
 		}
 
@@ -1202,12 +709,12 @@ func TestRestartFailure(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	client.sendStats()
+	client.SendStats()
 
 	time.Sleep(1 * time.Second)
 
-	c = make(chan cmdResult)
-	server.addCmdChan(ssntp.RESTART, c)
+	c = make(chan testutil.CmdResult)
+	server.AddCmdChan(ssntp.RESTART, c)
 
 	err = context.restartInstance(instances[0].ID)
 	if err != nil {
@@ -1216,11 +723,11 @@ func TestRestartFailure(t *testing.T) {
 
 	select {
 	case result := <-c:
-		if result.err != nil {
+		if result.Err != nil {
 			t.Fatal("Error parsing command yaml")
 		}
 
-		if result.instanceUUID != instances[0].ID {
+		if result.InstanceUUID != instances[0].ID {
 			t.Fatal("Did not get correct Instance ID")
 		}
 	case <-time.After(5 * time.Second):
@@ -1229,7 +736,7 @@ func TestRestartFailure(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	client.ssntp.Close()
+	client.Ssntp.Close()
 
 	// the response to a restart failure is to log the failure
 	entries, err := context.ds.GetEventLog()
@@ -1237,7 +744,7 @@ func TestRestartFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedMsg := fmt.Sprintf("Restart Failure %s: %s", instances[0].ID, client.restartFailReason.String())
+	expectedMsg := fmt.Sprintf("Restart Failure %s: %s", instances[0].ID, client.RestartFailReason.String())
 
 	for i := range entries {
 		if entries[i].Message == expectedMsg {
@@ -1255,10 +762,10 @@ func TestNoNetwork(t *testing.T) {
 	var reason payloads.StartFailureReason
 
 	client, _ := testStartWorkload(t, 1, false, reason)
-	defer client.ssntp.Close()
+	defer client.Ssntp.Close()
 }
 
-func testStartTracedWorkload(t *testing.T) *ssntpTestClient {
+func testStartTracedWorkload(t *testing.T) *testutil.SsntpTestClient {
 	tenant, err := addTestTenant()
 	if err != nil {
 		t.Fatal(err)
@@ -1271,8 +778,8 @@ func testStartTracedWorkload(t *testing.T) *ssntpTestClient {
 		t.Fatal(err)
 	}
 
-	c := make(chan cmdResult)
-	client.addCmdChan(ssntp.START, c)
+	c := make(chan testutil.CmdResult)
+	client.AddCmdChan(ssntp.START, c)
 
 	instances, err := context.startWorkload(wls[0].ID, tenant.ID, 1, true, "testtrace1")
 	if err != nil {
@@ -1285,11 +792,11 @@ func testStartTracedWorkload(t *testing.T) *ssntpTestClient {
 
 	select {
 	case result := <-c:
-		if result.err != nil {
+		if result.Err != nil {
 			t.Fatal("Error parsing command yaml")
 		}
 
-		if result.instanceUUID != instances[0].ID {
+		if result.InstanceUUID != instances[0].ID {
 			t.Fatal("Did not get correct Instance ID")
 		}
 
@@ -1300,7 +807,7 @@ func testStartTracedWorkload(t *testing.T) *ssntpTestClient {
 	return client
 }
 
-func testStartWorkload(t *testing.T, num int, fail bool, reason payloads.StartFailureReason) (*ssntpTestClient, []*types.Instance) {
+func testStartWorkload(t *testing.T, num int, fail bool, reason payloads.StartFailureReason) (*testutil.SsntpTestClient, []*types.Instance) {
 	tenant, err := addTestTenant()
 	if err != nil {
 		t.Fatal(err)
@@ -1313,10 +820,10 @@ func testStartWorkload(t *testing.T, num int, fail bool, reason payloads.StartFa
 		t.Fatal(err)
 	}
 
-	c := make(chan cmdResult)
-	client.addCmdChan(ssntp.START, c)
-	client.startFail = fail
-	client.startFailReason = reason
+	c := make(chan testutil.CmdResult)
+	client.AddCmdChan(ssntp.START, c)
+	client.StartFail = fail
+	client.StartFailReason = reason
 
 	instances, err := context.startWorkload(wls[0].ID, tenant.ID, num, false, "")
 	if err != nil {
@@ -1329,11 +836,11 @@ func testStartWorkload(t *testing.T, num int, fail bool, reason payloads.StartFa
 
 	select {
 	case result := <-c:
-		if result.err != nil {
+		if result.Err != nil {
 			t.Fatal("Error parsing command yaml")
 		}
 
-		if result.instanceUUID != instances[0].ID {
+		if result.InstanceUUID != instances[0].ID {
 			t.Fatal("Did not get correct Instance ID")
 		}
 
@@ -1344,7 +851,7 @@ func testStartWorkload(t *testing.T, num int, fail bool, reason payloads.StartFa
 	return client, instances
 }
 
-func testStartWorkloadLaunchCNCI(t *testing.T, num int) (*ssntpTestClient, []*types.Instance) {
+func testStartWorkloadLaunchCNCI(t *testing.T, num int) (*testutil.SsntpTestClient, []*types.Instance) {
 	netClient := newTestClient(0, ssntp.NETAGENT)
 
 	wls, err := context.ds.GetWorkloads()
@@ -1352,8 +859,8 @@ func testStartWorkloadLaunchCNCI(t *testing.T, num int) (*ssntpTestClient, []*ty
 		t.Fatal(err)
 	}
 
-	c := make(chan cmdResult)
-	server.addCmdChan(ssntp.START, c)
+	c := make(chan testutil.CmdResult)
+	server.AddCmdChan(ssntp.START, c)
 
 	id := uuid.Generate().String()
 
@@ -1372,15 +879,15 @@ func testStartWorkloadLaunchCNCI(t *testing.T, num int) (*ssntpTestClient, []*ty
 
 	select {
 	case result := <-c:
-		if result.err != nil {
+		if result.Err != nil {
 			t.Fatal("Error parsing command yaml")
 		}
 
-		if result.tenantUUID != id {
+		if result.TenantUUID != id {
 			t.Fatal("Did not get correct tenant ID")
 		}
 
-		if !result.cnci {
+		if !result.CNCI {
 			t.Fatal("this is not a CNCI launch request")
 		}
 
@@ -1388,16 +895,16 @@ func testStartWorkloadLaunchCNCI(t *testing.T, num int) (*ssntpTestClient, []*ty
 		t.Fatal("Timeout waiting for START command for CNCI")
 	}
 
-	c = make(chan cmdResult)
-	server.addCmdChan(ssntp.START, c)
+	c = make(chan testutil.CmdResult)
+	server.AddCmdChan(ssntp.START, c)
 
 	select {
 	case result := <-c:
-		if result.err != nil {
+		if result.Err != nil {
 			t.Fatal("Error parsing command yaml")
 		}
 
-		if result.instanceUUID != instances[0].ID {
+		if result.InstanceUUID != instances[0].ID {
 			t.Fatal("Did not get correct Instance ID")
 		}
 
@@ -1408,9 +915,9 @@ func testStartWorkloadLaunchCNCI(t *testing.T, num int) (*ssntpTestClient, []*ty
 	return netClient, instances
 }
 
-var testClients []*ssntpTestClient
+var testClients []*testutil.SsntpTestClient
 var context *controller
-var server ssntpTestServer
+var server testutil.SsntpTestServer
 var computeURL string
 var testIdentityURL string
 
@@ -1423,7 +930,7 @@ func TestMain(m *testing.M) {
 
 	// create fake ssntp server
 	startTestServer(&server)
-	defer server.ssntp.Stop()
+	defer server.Ssntp.Stop()
 
 	context = new(controller)
 	context.ds = new(datastore.Datastore)

--- a/ciao-scheduler/export_test.go
+++ b/ciao-scheduler/export_test.go
@@ -30,3 +30,4 @@ var ConnectNetworkNode = connectNetworkNode
 var DisconnectNetworkNode = disconnectNetworkNode
 
 var StartWorkload = startWorkload
+var GetWorkloadAgentUUID = getWorkloadAgentUUID

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -548,17 +548,6 @@ func pickComputeNode(sched *ssntpSchedulerServer, controllerUUID string, workloa
 		return nil
 	}
 
-	/* Shortcut for 1 nodes cluster */
-	if len(sched.cnList) == 1 {
-		node := sched.cnList[0]
-		node.mutex.Lock()
-		if sched.workloadFits(sched.cnList[0], workload) == true {
-			return node // locked nodeStat
-		}
-		node.mutex.Unlock()
-		return nil
-	}
-
 	/* First try nodes after the MRU */
 	if sched.cnMRUIndex != -1 && sched.cnMRUIndex < len(sched.cnList)-1 {
 		for i, node := range sched.cnList[sched.cnMRUIndex+1:] {

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -494,7 +494,7 @@ func (sched *ssntpSchedulerServer) fwdEventToCNCI(event ssntp.Event, payload []b
 	return dest
 }
 
-func (sched *ssntpSchedulerServer) getWorkloadAgentUUID(command ssntp.Command, payload []byte) (string, string, error) {
+func getWorkloadAgentUUID(sched *ssntpSchedulerServer, command ssntp.Command, payload []byte) (string, string, error) {
 	switch command {
 	default:
 		return "", "", fmt.Errorf("unsupported ssntp.Command type \"%s\"", command)
@@ -520,7 +520,7 @@ func (sched *ssntpSchedulerServer) getWorkloadAgentUUID(command ssntp.Command, p
 func (sched *ssntpSchedulerServer) fwdCmdToComputeNode(command ssntp.Command, payload []byte) (dest ssntp.ForwardDestination, instanceUUID string) {
 	// some commands require no scheduling choice, rather the specified
 	// agent/launcher needs the command instead of the scheduler
-	instanceUUID, cnDestUUID, err := sched.getWorkloadAgentUUID(command, payload)
+	instanceUUID, cnDestUUID, err := getWorkloadAgentUUID(sched, command, payload)
 	if err != nil || cnDestUUID == "" {
 		glog.Errorf("Bad %s command yaml from Controller, WorkloadAgentUUID == %s\n", command.String(), cnDestUUID)
 		dest.SetDecision(ssntp.Discard)

--- a/ciao-scheduler/scheduler_internal_test.go
+++ b/ciao-scheduler/scheduler_internal_test.go
@@ -610,3 +610,31 @@ func TestStartWorkload(t *testing.T) {
 		}
 	}
 }
+
+func TestGetWorkloadAgentUUID(t *testing.T) {
+	sched = configSchedulerServer()
+	if sched == nil {
+		t.Fatal("unable to configure test scheduler")
+	}
+
+	var stringTests = []struct {
+		cmd                  ssntp.Command
+		yaml                 []byte
+		expectedInstanceUUID string
+		expectedAgentUUID    string
+	}{
+		{ssntp.RESTART, []byte(testutil.RestartYaml), "0e8516d7-af2f-454a-87ed-072aeb9faf53", "d37e8dd5-3625-42bb-97b5-05291013abad"},
+		{ssntp.STOP, []byte(testutil.StopYaml), "3390740c-dce9-48d6-b83a-a717417072ce", "59460b8a-5f53-4e3e-b5ce-b71fed8c7e64"},
+		{ssntp.DELETE, []byte(testutil.DeleteYaml), "3390740c-dce9-48d6-b83a-a717417072ce", "59460b8a-5f53-4e3e-b5ce-b71fed8c7e64"},
+		{ssntp.EVACUATE, []byte(testutil.EvacuateYaml), "", "64803ffa-fb47-49fa-8191-15d2c34e4dd3"},
+	}
+	for _, test := range stringTests {
+		instanceUUID, agentUUID, _ := GetWorkloadAgentUUID(sched, test.cmd, test.yaml)
+		if instanceUUID != test.expectedInstanceUUID {
+			t.Errorf("failed to get correct instanceUUID, expected %s, got %s", test.expectedInstanceUUID, instanceUUID)
+		}
+		if agentUUID != test.expectedAgentUUID {
+			t.Errorf("failed to get correct workloadAgentUUID, expected %s, got %s", test.expectedAgentUUID, agentUUID)
+		}
+	}
+}

--- a/payloads/assignpublicIP_test.go
+++ b/payloads/assignpublicIP_test.go
@@ -14,11 +14,12 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
 	"testing"
 
+	. "github.com/01org/ciao/payloads"
 	"github.com/docker/distribution/uuid"
 	"gopkg.in/yaml.v2"
 )

--- a/payloads/cnciinstance_test.go
+++ b/payloads/cnciinstance_test.go
@@ -14,11 +14,12 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
 	"testing"
 
+	. "github.com/01org/ciao/payloads"
 	"gopkg.in/yaml.v2"
 )
 

--- a/payloads/concentratorinstanceadded_test.go
+++ b/payloads/concentratorinstanceadded_test.go
@@ -14,11 +14,12 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
 	"testing"
 
+	. "github.com/01org/ciao/payloads"
 	"gopkg.in/yaml.v2"
 )
 

--- a/payloads/configure_test.go
+++ b/payloads/configure_test.go
@@ -14,12 +14,13 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
-	"fmt"
 	"testing"
 
+	"fmt"
+	. "github.com/01org/ciao/payloads"
 	"gopkg.in/yaml.v2"
 )
 

--- a/payloads/deletefailure_test.go
+++ b/payloads/deletefailure_test.go
@@ -14,12 +14,13 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
-	"fmt"
 	"testing"
 
+	"fmt"
+	. "github.com/01org/ciao/payloads"
 	"github.com/docker/distribution/uuid"
 	"gopkg.in/yaml.v2"
 )

--- a/payloads/evacuate_test.go
+++ b/payloads/evacuate_test.go
@@ -14,12 +14,14 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
+	"testing"
+
+	. "github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/testutil"
 	"gopkg.in/yaml.v2"
-	"testing"
 )
 
 const evacAgentUUID = "64803ffa-fb47-49fa-8191-15d2c34e4dd3"

--- a/payloads/evacuate_test.go
+++ b/payloads/evacuate_test.go
@@ -17,14 +17,12 @@
 package payloads
 
 import (
+	"github.com/01org/ciao/testutil"
 	"gopkg.in/yaml.v2"
 	"testing"
 )
 
 const evacAgentUUID = "64803ffa-fb47-49fa-8191-15d2c34e4dd3"
-const evacYaml = "" +
-	"evacuate:\n" +
-	"  workload_agent_uuid: " + evacAgentUUID + "\n"
 
 func TestEvacMarshal(t *testing.T) {
 	var cmd Evacuate
@@ -35,14 +33,14 @@ func TestEvacMarshal(t *testing.T) {
 		t.Error(err)
 	}
 
-	if string(y) != evacYaml {
-		t.Errorf("EVACUATE marshalling failed\n[%s]\n vs\n[%s]", string(y), evacYaml)
+	if string(y) != testutil.EvacuateYaml {
+		t.Errorf("EVACUATE marshalling failed\n[%s]\n vs\n[%s]", string(y), testutil.EvacuateYaml)
 	}
 }
 
 func TestEvacUnmarshal(t *testing.T) {
 	var cmd Evacuate
-	err := yaml.Unmarshal([]byte(evacYaml), &cmd)
+	err := yaml.Unmarshal([]byte(testutil.EvacuateYaml), &cmd)
 	if err != nil {
 		t.Error(err)
 	}

--- a/payloads/instancedeleted_test.go
+++ b/payloads/instancedeleted_test.go
@@ -14,11 +14,13 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
-	"gopkg.in/yaml.v2"
 	"testing"
+
+	. "github.com/01org/ciao/payloads"
+	"gopkg.in/yaml.v2"
 )
 
 const insDelUUID = "3390740c-dce9-48d6-b83a-a717417072ce"

--- a/payloads/nodeconnected_test.go
+++ b/payloads/nodeconnected_test.go
@@ -14,11 +14,13 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
-	"gopkg.in/yaml.v2"
 	"testing"
+
+	. "github.com/01org/ciao/payloads"
+	"gopkg.in/yaml.v2"
 )
 
 const nodeConnectedYaml = "" +

--- a/payloads/publicIPassigned_test.go
+++ b/payloads/publicIPassigned_test.go
@@ -14,11 +14,13 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
-	"gopkg.in/yaml.v2"
 	"testing"
+
+	. "github.com/01org/ciao/payloads"
+	"gopkg.in/yaml.v2"
 )
 
 const assignedIPYaml = "" +

--- a/payloads/ready_test.go
+++ b/payloads/ready_test.go
@@ -14,13 +14,15 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
+	"testing"
+
 	"fmt"
+	. "github.com/01org/ciao/payloads"
 	"github.com/docker/distribution/uuid"
 	"gopkg.in/yaml.v2"
-	"testing"
 )
 
 func TestReadyUnmarshal(t *testing.T) {

--- a/payloads/restart_test.go
+++ b/payloads/restart_test.go
@@ -18,37 +18,14 @@ package payloads
 
 import (
 	"fmt"
+	"github.com/01org/ciao/testutil"
 	"gopkg.in/yaml.v2"
 	"testing"
 )
 
 func TestRestartUnmarshal(t *testing.T) {
-	restartYaml := `restart:
-  instance_uuid: 0e8516d7-af2f-454a-87ed-072aeb9faf53
-  image_uuid: 5beea770-1ef5-4c26-8a6c-2026fbc98e37
-  workload_agent_uuid: d37e8dd5-3625-42bb-97b5-05291013abad
-  fw_type: efi
-  persistence: host
-  requested_resources:
-    - type: vcpus
-      value: 2
-      mandatory: true
-    - type: mem_mb
-      value: 1014
-      mandatory: true
-    - type: disk_mb
-      value: 10000
-      mandatory: true
-  estimated_resources:
-    - type: vcpus
-      value: 1
-    - type: mem_mb
-      value: 128
-    - type: disk_mb
-      value: 4096
-`
 	var cmd Restart
-	err := yaml.Unmarshal([]byte(restartYaml), &cmd)
+	err := yaml.Unmarshal([]byte(testutil.RestartYaml), &cmd)
 	if err != nil {
 		t.Error(err)
 	}
@@ -105,18 +82,8 @@ func TestRestartMarshal(t *testing.T) {
 // make sure the yaml can be unmarshaled into the Restart struct with
 // optional data not present
 func TestRestartUnmarshalPartial(t *testing.T) {
-	restartYaml := `restart:
-  instance_uuid: a2675987-fa30-45ce-84a2-93ce67106f47
-  workload_agent_uuid: 1ab3a664-d344-4a41-acf9-c94d8606e069
-  fw_type: efi
-  persistence: host
-  requested_resources:
-    - type: vcpus
-      value: 2
-      mandatory: true
-`
 	var cmd Restart
-	err := yaml.Unmarshal([]byte(restartYaml), &cmd)
+	err := yaml.Unmarshal([]byte(testutil.PartialRestartYaml), &cmd)
 	if err != nil {
 		t.Error(err)
 	}

--- a/payloads/restart_test.go
+++ b/payloads/restart_test.go
@@ -14,13 +14,15 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
+	"testing"
+
 	"fmt"
+	. "github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/testutil"
 	"gopkg.in/yaml.v2"
-	"testing"
 )
 
 func TestRestartUnmarshal(t *testing.T) {

--- a/payloads/restartfailure_test.go
+++ b/payloads/restartfailure_test.go
@@ -14,12 +14,13 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
-	"fmt"
 	"testing"
 
+	"fmt"
+	. "github.com/01org/ciao/payloads"
 	"github.com/docker/distribution/uuid"
 	"gopkg.in/yaml.v2"
 )

--- a/payloads/start_test.go
+++ b/payloads/start_test.go
@@ -14,13 +14,15 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
+	"testing"
+
 	"fmt"
+	. "github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/testutil"
 	"gopkg.in/yaml.v2"
-	"testing"
 )
 
 func TestStartUnmarshal(t *testing.T) {

--- a/payloads/startfailure_test.go
+++ b/payloads/startfailure_test.go
@@ -14,13 +14,15 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
+	"testing"
+
 	"fmt"
+	. "github.com/01org/ciao/payloads"
 	"github.com/docker/distribution/uuid"
 	"gopkg.in/yaml.v2"
-	"testing"
 )
 
 func TestStartFailureUnmarshal(t *testing.T) {

--- a/payloads/stats_test.go
+++ b/payloads/stats_test.go
@@ -14,12 +14,13 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
-	"fmt"
 	"testing"
 
+	"fmt"
+	. "github.com/01org/ciao/payloads"
 	"github.com/docker/distribution/uuid"
 	"gopkg.in/yaml.v2"
 )

--- a/payloads/stop_test.go
+++ b/payloads/stop_test.go
@@ -17,6 +17,7 @@
 package payloads
 
 import (
+	"github.com/01org/ciao/testutil"
 	"gopkg.in/yaml.v2"
 	"testing"
 )
@@ -24,18 +25,9 @@ import (
 const instanceUUID = "3390740c-dce9-48d6-b83a-a717417072ce"
 const agentUUID = "59460b8a-5f53-4e3e-b5ce-b71fed8c7e64"
 
-const stopYaml = "" +
-	"stop:\n" +
-	"  instance_uuid: " + instanceUUID + "\n" +
-	"  workload_agent_uuid: " + agentUUID + "\n"
-const deleteYaml = "" +
-	"delete:\n" +
-	"  instance_uuid: " + instanceUUID + "\n" +
-	"  workload_agent_uuid: " + agentUUID + "\n"
-
 func TestStopUnmarshal(t *testing.T) {
 	var stop Stop
-	err := yaml.Unmarshal([]byte(stopYaml), &stop)
+	err := yaml.Unmarshal([]byte(testutil.StopYaml), &stop)
 	if err != nil {
 		t.Error(err)
 	}
@@ -51,7 +43,7 @@ func TestStopUnmarshal(t *testing.T) {
 
 func TestDeleteUnmarshal(t *testing.T) {
 	var delete Delete
-	err := yaml.Unmarshal([]byte(deleteYaml), &delete)
+	err := yaml.Unmarshal([]byte(testutil.DeleteYaml), &delete)
 	if err != nil {
 		t.Error(err)
 	}
@@ -75,8 +67,8 @@ func TestStopMarshal(t *testing.T) {
 		t.Error(err)
 	}
 
-	if string(y) != stopYaml {
-		t.Errorf("STOP marshalling failed\n[%s]\n vs\n[%s]", string(y), stopYaml)
+	if string(y) != testutil.StopYaml {
+		t.Errorf("STOP marshalling failed\n[%s]\n vs\n[%s]", string(y), testutil.StopYaml)
 	}
 }
 
@@ -90,7 +82,7 @@ func TestDeleteMarshal(t *testing.T) {
 		t.Error(err)
 	}
 
-	if string(y) != deleteYaml {
-		t.Errorf("DELETE marshalling failed\n[%s]\n vs\n[%s]", string(y), deleteYaml)
+	if string(y) != testutil.DeleteYaml {
+		t.Errorf("DELETE marshalling failed\n[%s]\n vs\n[%s]", string(y), testutil.DeleteYaml)
 	}
 }

--- a/payloads/stop_test.go
+++ b/payloads/stop_test.go
@@ -14,12 +14,14 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
+	"testing"
+
+	. "github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/testutil"
 	"gopkg.in/yaml.v2"
-	"testing"
 )
 
 const instanceUUID = "3390740c-dce9-48d6-b83a-a717417072ce"

--- a/payloads/stopfailure_test.go
+++ b/payloads/stopfailure_test.go
@@ -14,12 +14,13 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
-	"fmt"
 	"testing"
 
+	"fmt"
+	. "github.com/01org/ciao/payloads"
 	"github.com/docker/distribution/uuid"
 	"gopkg.in/yaml.v2"
 )

--- a/payloads/tenantadded_test.go
+++ b/payloads/tenantadded_test.go
@@ -14,11 +14,12 @@
 // limitations under the License.
 */
 
-package payloads
+package payloads_test
 
 import (
 	"testing"
 
+	. "github.com/01org/ciao/payloads"
 	"gopkg.in/yaml.v2"
 )
 

--- a/testutil/agent.go
+++ b/testutil/agent.go
@@ -1,0 +1,346 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package testutil
+
+import (
+	"fmt"
+	"github.com/01org/ciao/payloads"
+	"github.com/01org/ciao/ssntp"
+	"gopkg.in/yaml.v2"
+	"sync"
+	"time"
+)
+
+// SsntpTestClient is global state for the testutil SSNTP client worker
+type SsntpTestClient struct {
+	Ssntp             ssntp.Client
+	Name              string
+	instances         []payloads.InstanceStat
+	ticker            *time.Ticker
+	UUID              string
+	Role              ssntp.Role
+	StartFail         bool
+	StartFailReason   payloads.StartFailureReason
+	StopFail          bool
+	StopFailReason    payloads.StopFailureReason
+	RestartFail       bool
+	RestartFailReason payloads.RestartFailureReason
+	traces            []*ssntp.Frame
+
+	CmdChans     map[ssntp.Command]chan CmdResult
+	CmdChansLock *sync.Mutex
+}
+
+// AddCmdChan opens and command channel to the SsntpTestClient
+func (client *SsntpTestClient) AddCmdChan(cmd ssntp.Command, c chan CmdResult) {
+	client.CmdChansLock.Lock()
+	client.CmdChans[cmd] = c
+	client.CmdChansLock.Unlock()
+}
+
+// ConnectNotify is an SSNTP callback stub for SsntpTestClient
+func (client *SsntpTestClient) ConnectNotify() {
+}
+
+// DisconnectNotify is an SSNTP callback stub for SsntpTestClient
+func (client *SsntpTestClient) DisconnectNotify() {
+}
+
+// StatusNotify is an SSNTP callback stub for SsntpTestClient
+func (client *SsntpTestClient) StatusNotify(status ssntp.Status, frame *ssntp.Frame) {
+}
+
+func (client *SsntpTestClient) handleStart(payload []byte) CmdResult {
+	var result CmdResult
+	var start payloads.Start
+
+	err := yaml.Unmarshal(payload, &start)
+	if err != nil {
+		result.Err = err
+		return result
+	}
+
+	result.InstanceUUID = start.Start.InstanceUUID
+	result.TenantUUID = start.Start.TenantUUID
+
+	if client.Role == ssntp.NETAGENT {
+		networking := start.Start.Networking
+
+		client.sendConcentratorAddedEvent(start.Start.InstanceUUID, start.Start.TenantUUID, networking.VnicMAC)
+		result.CNCI = true
+		return result
+	}
+
+	if !client.StartFail {
+		istat := payloads.InstanceStat{
+			InstanceUUID:  start.Start.InstanceUUID,
+			State:         payloads.Running,
+			MemoryUsageMB: 0,
+			DiskUsageMB:   0,
+			CPUUsage:      0,
+		}
+
+		client.instances = append(client.instances, istat)
+	} else {
+		client.sendStartFailure(start.Start.InstanceUUID, client.StartFailReason)
+	}
+
+	return result
+}
+
+func (client *SsntpTestClient) handleStop(payload []byte) CmdResult {
+	var result CmdResult
+	var stopCmd payloads.Stop
+
+	err := yaml.Unmarshal(payload, &stopCmd)
+	if err != nil {
+		result.Err = err
+		return result
+	}
+
+	if !client.StopFail {
+		for i := range client.instances {
+			istat := client.instances[i]
+			if istat.InstanceUUID == stopCmd.Stop.InstanceUUID {
+				client.instances[i].State = payloads.Exited
+			}
+		}
+	} else {
+		client.sendStopFailure(stopCmd.Stop.InstanceUUID, client.StopFailReason)
+	}
+
+	return result
+}
+
+func (client *SsntpTestClient) handleRestart(payload []byte) CmdResult {
+	var result CmdResult
+	var restartCmd payloads.Restart
+
+	err := yaml.Unmarshal(payload, &restartCmd)
+	if err != nil {
+		result.Err = err
+		return result
+	}
+
+	if !client.RestartFail {
+		for i := range client.instances {
+			istat := client.instances[i]
+			if istat.InstanceUUID == restartCmd.Restart.InstanceUUID {
+				client.instances[i].State = payloads.Running
+			}
+		}
+	} else {
+		client.sendRestartFailure(restartCmd.Restart.InstanceUUID, client.RestartFailReason)
+	}
+
+	return result
+}
+
+// CommandNotify implements the SSNTP client CommandNotify callback for SsntpTestClient
+func (client *SsntpTestClient) CommandNotify(command ssntp.Command, frame *ssntp.Frame) {
+	payload := frame.Payload
+
+	var result CmdResult
+
+	if frame.Trace != nil {
+		frame.SetEndStamp()
+		client.traces = append(client.traces, frame)
+	}
+
+	client.CmdChansLock.Lock()
+	c, ok := client.CmdChans[command]
+	client.CmdChansLock.Unlock()
+
+	switch command {
+	case ssntp.START:
+		result = client.handleStart(payload)
+
+	case ssntp.STOP:
+		result = client.handleStop(payload)
+
+	case ssntp.RESTART:
+		result = client.handleRestart(payload)
+	}
+
+	if ok {
+		client.CmdChansLock.Lock()
+		delete(client.CmdChans, command)
+		client.CmdChansLock.Unlock()
+
+		c <- result
+
+		close(c)
+	}
+
+	return
+}
+
+// EventNotify implements the SSNTP client EventNotify callback for SsntpTestClient
+func (client *SsntpTestClient) EventNotify(event ssntp.Event, frame *ssntp.Frame) {
+}
+
+// ErrorNotify implements the SSNTP client ErrorNotify callback for SsntpTestClient
+func (client *SsntpTestClient) ErrorNotify(error ssntp.Error, frame *ssntp.Frame) {
+}
+
+// SendStats allows an SsntpTestClient to push an ssntp.STATS command frame
+func (client *SsntpTestClient) SendStats() {
+	stat := payloads.Stat{
+		NodeUUID:        client.UUID,
+		MemTotalMB:      256,
+		MemAvailableMB:  256,
+		DiskTotalMB:     1024,
+		DiskAvailableMB: 1024,
+		Load:            20,
+		CpusOnline:      4,
+		NodeHostName:    client.Name,
+		Instances:       client.instances,
+	}
+
+	y, err := yaml.Marshal(stat)
+	if err != nil {
+		return
+	}
+
+	_, err = client.Ssntp.SendCommand(ssntp.STATS, y)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+// SendTrace allows an SsntpTestClient to push an ssntp.TraceReport event frame
+func (client *SsntpTestClient) SendTrace() {
+	var s payloads.Trace
+
+	for _, f := range client.traces {
+		t, err := f.DumpTrace()
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+
+		s.Frames = append(s.Frames, *t)
+	}
+
+	payload, err := yaml.Marshal(&s)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	client.traces = nil
+
+	_, err = client.Ssntp.SendEvent(ssntp.TraceReport, payload)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+// SendDeleteEvent allows an SsntpTestClient to push an ssntp.InstanceDeleted event frame
+func (client *SsntpTestClient) SendDeleteEvent(uuid string) {
+	evt := payloads.InstanceDeletedEvent{
+		InstanceUUID: uuid,
+	}
+
+	event := payloads.EventInstanceDeleted{
+		InstanceDeleted: evt,
+	}
+
+	y, err := yaml.Marshal(event)
+	if err != nil {
+		return
+	}
+
+	_, err = client.Ssntp.SendEvent(ssntp.InstanceDeleted, y)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+}
+
+func (client *SsntpTestClient) sendConcentratorAddedEvent(instanceUUID string, tenantUUID string, vnicMAC string) {
+	evt := payloads.ConcentratorInstanceAddedEvent{
+		InstanceUUID:    instanceUUID,
+		TenantUUID:      tenantUUID,
+		ConcentratorIP:  "192.168.0.1",
+		ConcentratorMAC: vnicMAC,
+	}
+
+	event := payloads.EventConcentratorInstanceAdded{
+		CNCIAdded: evt,
+	}
+
+	y, err := yaml.Marshal(event)
+	if err != nil {
+		return
+	}
+
+	_, err = client.Ssntp.SendEvent(ssntp.ConcentratorInstanceAdded, y)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func (client *SsntpTestClient) sendStartFailure(instanceUUID string, reason payloads.StartFailureReason) {
+	e := payloads.ErrorStartFailure{
+		InstanceUUID: instanceUUID,
+		Reason:       reason,
+	}
+
+	y, err := yaml.Marshal(e)
+	if err != nil {
+		return
+	}
+
+	_, err = client.Ssntp.SendError(ssntp.StartFailure, y)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func (client *SsntpTestClient) sendStopFailure(instanceUUID string, reason payloads.StopFailureReason) {
+	e := payloads.ErrorStopFailure{
+		InstanceUUID: instanceUUID,
+		Reason:       reason,
+	}
+
+	y, err := yaml.Marshal(e)
+	if err != nil {
+		return
+	}
+
+	_, err = client.Ssntp.SendError(ssntp.StopFailure, y)
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func (client *SsntpTestClient) sendRestartFailure(instanceUUID string, reason payloads.RestartFailureReason) {
+	e := payloads.ErrorRestartFailure{
+		InstanceUUID: instanceUUID,
+		Reason:       reason,
+	}
+
+	y, err := yaml.Marshal(e)
+	if err != nil {
+		return
+	}
+
+	_, err = client.Ssntp.SendError(ssntp.RestartFailure, y)
+	if err != nil {
+		fmt.Println(err)
+	}
+}

--- a/testutil/identity.go
+++ b/testutil/identity.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"fmt"
+	"github.com/gorilla/mux"
+	"github.com/rackspace/gophercloud"
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+// TestIdentityConfig contains the URL of the ciao compute service, and the TenantID of
+// the tenant you want tokens to be sent for.  The test Identity service only supports
+// authentication of a single tenant, and gives the token an admin role.
+type TestIdentityConfig struct {
+	ComputeURL string
+	ProjectID  string
+}
+
+var computeURL string
+var testIdentityURL string
+var computeTestUser string
+
+func authHandler(w http.ResponseWriter, r *http.Request) {
+	token := `
+		{
+			"token": {
+				"methods": [
+					"password"
+				],
+				"roles": [
+					{
+						"id" : "12345",
+						"name" : "admin"
+					}
+				],
+				"expires_at": "%s",
+				"project": {
+					"domain": {
+						"id": "default",
+						"name": "Default"
+					},
+					"id": "%s",
+					"name": "admin"
+				},
+				"catalog": [
+					{
+						"endpoints": [
+							{
+								"region_id": "RegionOne",
+								"url": "%s/v3",
+								"region": "RegionOne",
+								"interface": "public",
+								"id": "068d1b359ee84b438266cb736d81de97"
+							},
+							{
+								"region_id": "RegionOne",
+								"url": "%s/v3",
+								"region": "RegionOne",
+								"interface": "admin",
+								"id": "8bfc846841ab441ca38471be6d164ced"
+							},
+							{
+								"region_id": "RegionOne",
+								"url": "%s/v3",
+								"region": "RegionOne",
+								"interface": "internal",
+								"id": "beb6d358c3654b4bada04d4663b640b9"
+							}
+						],
+						"type": "identity",
+						"id": "050726f278654128aba89757ae25950c",
+						"name": "keystone"
+					}
+				],
+			       "extras": {},
+			       "user": {
+				       "domain": {
+				               "id": "default",
+				               "name": "Default"
+				        },
+				       "id": "ee4dfb6e5540447cb3741905149d9b6e",
+			               "name": "admin"
+			        },
+			        "audit_ids": [
+				        "3T2dc1CGQxyJsHdDu1xkcw"
+			        ],
+			        "issued_at": "%s"
+			}
+		}`
+
+	t := []byte(fmt.Sprintf(token,
+		time.Now().Add(1*time.Hour).Format(gophercloud.RFC3339Milli),
+		computeTestUser, testIdentityURL, testIdentityURL,
+		testIdentityURL, time.Now().Format(gophercloud.RFC3339Milli)))
+	w.Header().Set("X-Subject-Token", "imavalidtoken")
+	w.WriteHeader(http.StatusCreated)
+	w.Write(t)
+}
+
+func validateHandler(w http.ResponseWriter, r *http.Request) {
+	tenantURL := computeURL + "/v2.1/" + computeTestUser
+	token := `
+	{
+		"token": {
+		        "methods": [
+		                "token"
+		        ],
+		        "expires_at": "%s",
+		        "extras": {},
+		        "user": {
+				"domain": {
+					"id": "default",
+					"name": "Default"
+				},
+				"id": "10a2e6e717a245d9acad3e5f97aeca3d",
+				"name": "admin"
+			},
+			"roles": [
+				{
+					"id" : "12345",
+					"name" : "admin"
+				}
+			],
+			"project": {
+				"domain": {
+					"id": "default",
+					"name": "Default"
+				},
+				"id": "%s",
+				"name": "admin"
+			},
+			"catalog": [
+				{
+					"endpoints": [
+						{
+							"region_id": "RegionOne",
+							"url": "%s/v3",
+							"region": "RegionOne",
+							"interface": "public",
+							"id": "068d1b359ee84b438266cb736d81de97"
+						},
+						{
+							"region_id": "RegionOne",
+							"url": "%s/v3",
+							"region": "RegionOne",
+							"interface": "admin",
+							"id": "8bfc846841ab441ca38471be6d164ced"
+						},
+						{
+							"region_id": "RegionOne",
+							"url": "%s/v3",
+							"region": "RegionOne",
+							"interface": "internal",
+							"id": "beb6d358c3654b4bada04d4663b640b9"
+						}
+					],
+					"type": "identity",
+					"id": "050726f278654128aba89757ae25950c",
+					"name": "keystone"
+				},
+				{
+			                "endpoints": [
+					         {
+							"region_id": "RegionOne",
+							"url": "%s",
+							"region": "RegionOne",
+							"interface": "admin",
+							"id": "2511589f262a407bb0071a814a480af4"
+						},
+						{
+							"region_id": "RegionOne",
+							"url": "%s",
+							"region": "RegionOne",
+							"interface": "internal",
+							"id": "9cf9209ae4fc4673a7295611001cf0ae"
+						},
+						{
+							"region_id": "RegionOne",
+							"url": "%s",
+							"region": "RegionOne",
+							"interface": "public",
+							"id": "d200b2509e1343e3887dcc465b4fa534"
+						}
+					],
+					"type": "compute",
+					"id": "a226b3eeb5594f50bf8b6df94636ed28",
+					"name": "ciao"
+				}
+			],
+			"audit_ids": [
+			        "mAjXQhiYRyKwkB4qygdLVg"
+			],
+			"issued_at": "%s"
+		}
+	}`
+
+	t := []byte(fmt.Sprintf(token,
+		time.Now().Add(1*time.Hour).Format(gophercloud.RFC3339Milli),
+		computeTestUser, testIdentityURL, testIdentityURL,
+		testIdentityURL, tenantURL, tenantURL,
+		tenantURL, time.Now().Format(gophercloud.RFC3339Milli)))
+	w.WriteHeader(http.StatusOK)
+	w.Write(t)
+}
+
+func identityHandlers() *mux.Router {
+	r := mux.NewRouter()
+
+	r.HandleFunc("/v3/auth/tokens", authHandler).Methods("POST")
+	r.HandleFunc("/v3/auth/tokens", validateHandler).Methods("GET")
+
+	return r
+}
+
+// StartIdentityTestServer starts a fake keystone service for unit testing ciao.
+func StartIdentityTestServer(config TestIdentityConfig) *httptest.Server {
+	id := httptest.NewServer(identityHandlers())
+
+	computeURL = config.ComputeURL
+	testIdentityURL = id.URL
+	computeTestUser = config.ProjectID
+
+	return id
+}

--- a/testutil/identity_test.go
+++ b/testutil/identity_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"testing"
+)
+
+func TestStartIdentityServer(t *testing.T) {
+	config := TestIdentityConfig{
+		ComputeURL: "https://localhost:8888",
+		ProjectID:  "30dedd5c-48d9-45d3-8b44-f973e4f35e48",
+	}
+
+	id := StartIdentityTestServer(config)
+	defer id.Close()
+}

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -1,0 +1,208 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package testutil
+
+import (
+	"github.com/01org/ciao/payloads"
+	"github.com/01org/ciao/ssntp"
+	"gopkg.in/yaml.v2"
+	"math/rand"
+	"sync"
+)
+
+// SsntpTestServer is global state for the testutil SSNTP server
+type SsntpTestServer struct {
+	Ssntp        ssntp.Server
+	clients      []string
+	CmdChans     map[ssntp.Command]chan CmdResult
+	CmdChansLock *sync.Mutex
+
+	NetClients     map[string]bool
+	NetClientsLock *sync.RWMutex
+}
+
+// AddCmdChan opens and command channel to the SsntpTestServer
+func (server *SsntpTestServer) AddCmdChan(cmd ssntp.Command, c chan CmdResult) {
+	server.CmdChansLock.Lock()
+	server.CmdChans[cmd] = c
+	server.CmdChansLock.Unlock()
+}
+
+// ConnectNotify implements an SSNTP ConnectNotify callback for SsntpTestServer
+func (server *SsntpTestServer) ConnectNotify(uuid string, role uint32) {
+	switch role {
+	case ssntp.AGENT:
+		server.clients = append(server.clients, uuid)
+
+	case ssntp.NETAGENT:
+		server.NetClientsLock.Lock()
+		server.NetClients[uuid] = true
+		server.NetClientsLock.Unlock()
+	}
+
+}
+
+// DisconnectNotify implements an SSNTP DisconnectNotify callback for SsntpTestServer
+func (server *SsntpTestServer) DisconnectNotify(uuid string, role uint32) {
+	for index := range server.clients {
+		if server.clients[index] == uuid {
+			server.clients = append(server.clients[:index], server.clients[index+1:]...)
+			return
+		}
+	}
+
+	server.NetClientsLock.Lock()
+	delete(server.NetClients, uuid)
+	server.NetClientsLock.Unlock()
+}
+
+// StatusNotify is an SSNTP callback stub for SsntpTestServer
+func (server *SsntpTestServer) StatusNotify(uuid string, status ssntp.Status, frame *ssntp.Frame) {
+}
+
+// CommandNotify implements an SSNTP CommandNotify callback for SsntpTestServer
+func (server *SsntpTestServer) CommandNotify(uuid string, command ssntp.Command, frame *ssntp.Frame) {
+	var result CmdResult
+	var nn bool
+
+	payload := frame.Payload
+
+	server.CmdChansLock.Lock()
+	c, ok := server.CmdChans[command]
+	server.CmdChansLock.Unlock()
+
+	switch command {
+	case ssntp.START:
+		var startCmd payloads.Start
+
+		err := yaml.Unmarshal(payload, &startCmd)
+
+		if err == nil {
+			resources := startCmd.Start.RequestedResources
+
+			for i := range resources {
+				if resources[i].Type == payloads.NetworkNode {
+					nn = true
+					break
+				}
+			}
+			result.InstanceUUID = startCmd.Start.InstanceUUID
+			result.TenantUUID = startCmd.Start.TenantUUID
+			result.CNCI = nn
+		}
+		result.Err = err
+
+	case ssntp.DELETE:
+		var delCmd payloads.Delete
+
+		err := yaml.Unmarshal(payload, &delCmd)
+		result.Err = err
+		if err == nil {
+			result.InstanceUUID = delCmd.Delete.InstanceUUID
+		}
+
+	case ssntp.STOP:
+		var stopCmd payloads.Stop
+
+		err := yaml.Unmarshal(payload, &stopCmd)
+
+		result.Err = err
+
+		if err == nil {
+			result.InstanceUUID = stopCmd.Stop.InstanceUUID
+			server.Ssntp.SendCommand(stopCmd.Stop.WorkloadAgentUUID, command, frame.Payload)
+		}
+
+	case ssntp.RESTART:
+		var restartCmd payloads.Restart
+
+		err := yaml.Unmarshal(payload, &restartCmd)
+
+		result.Err = err
+
+		if err == nil {
+			result.InstanceUUID = restartCmd.Restart.InstanceUUID
+			server.Ssntp.SendCommand(restartCmd.Restart.WorkloadAgentUUID, command, frame.Payload)
+		}
+
+	case ssntp.EVACUATE:
+		var evacCmd payloads.Evacuate
+
+		err := yaml.Unmarshal(payload, &evacCmd)
+
+		result.Err = err
+
+		if err == nil {
+			result.NodeUUID = evacCmd.Evacuate.WorkloadAgentUUID
+		}
+	}
+
+	if ok {
+		server.CmdChansLock.Lock()
+		delete(server.CmdChans, command)
+		server.CmdChansLock.Unlock()
+
+		c <- result
+
+		close(c)
+	}
+}
+
+// EventNotify is an SSNTP callback stub for SsntpTestServer
+func (server *SsntpTestServer) EventNotify(uuid string, event ssntp.Event, frame *ssntp.Frame) {
+}
+
+// ErrorNotify is an SSNTP callback stub for SsntpTestServer
+func (server *SsntpTestServer) ErrorNotify(uuid string, error ssntp.Error, frame *ssntp.Frame) {
+}
+
+// CommandForward implements an SSNTP CommandForward callback for SsntpTestServer
+func (server *SsntpTestServer) CommandForward(uuid string, command ssntp.Command, frame *ssntp.Frame) (dest ssntp.ForwardDestination) {
+	var startCmd payloads.Start
+	var nn bool
+
+	payload := frame.Payload
+
+	err := yaml.Unmarshal(payload, &startCmd)
+
+	if err != nil {
+		return
+	}
+
+	resources := startCmd.Start.RequestedResources
+
+	for i := range resources {
+		if resources[i].Type == payloads.NetworkNode {
+			nn = true
+			break
+		}
+	}
+
+	if nn {
+		server.NetClientsLock.RLock()
+		for key := range server.NetClients {
+			dest.AddRecipient(key)
+			break
+		}
+		server.NetClientsLock.RUnlock()
+	} else if len(server.clients) > 0 {
+		index := rand.Intn(len(server.clients))
+		dest.AddRecipient(server.clients[index])
+	}
+
+	return
+}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -15,3 +15,14 @@
 //
 
 package testutil
+
+// CmdResult is a common result structure for tests spanning between
+// controller client, scheduler server, and the various (eg: Agent,
+// NetAgent, CNCIAgent) agent roles.
+type CmdResult struct {
+	InstanceUUID string
+	Err          error
+	NodeUUID     string
+	TenantUUID   string
+	CNCI         bool
+}

--- a/testutil/yaml.go
+++ b/testutil/yaml.go
@@ -74,3 +74,58 @@ var PartialStartYaml = `start:
       value: 2
       mandatory: true
 `
+
+// RestartYaml is a sample workload Restart command payload for test cases
+var RestartYaml = `restart:
+  instance_uuid: 0e8516d7-af2f-454a-87ed-072aeb9faf53
+  image_uuid: 5beea770-1ef5-4c26-8a6c-2026fbc98e37
+  workload_agent_uuid: d37e8dd5-3625-42bb-97b5-05291013abad
+  fw_type: efi
+  persistence: host
+  requested_resources:
+    - type: vcpus
+      value: 2
+      mandatory: true
+    - type: mem_mb
+      value: 1014
+      mandatory: true
+    - type: disk_mb
+      value: 10000
+      mandatory: true
+  estimated_resources:
+    - type: vcpus
+      value: 1
+    - type: mem_mb
+      value: 128
+    - type: disk_mb
+      value: 4096
+`
+
+// PartialRestartYaml is a sample minimal workload Restart command payload for test cases
+var PartialRestartYaml = `restart:
+  instance_uuid: a2675987-fa30-45ce-84a2-93ce67106f47
+  workload_agent_uuid: 1ab3a664-d344-4a41-acf9-c94d8606e069
+  fw_type: efi
+  persistence: host
+  requested_resources:
+    - type: vcpus
+      value: 2
+      mandatory: true
+`
+
+// StopYaml is a sample workload Stop command payload for test cases
+var StopYaml = `stop:
+  instance_uuid: 3390740c-dce9-48d6-b83a-a717417072ce
+  workload_agent_uuid: 59460b8a-5f53-4e3e-b5ce-b71fed8c7e64
+`
+
+// DeleteYaml is a sample workload Delete command payload for test cases
+var DeleteYaml = `delete:
+  instance_uuid: 3390740c-dce9-48d6-b83a-a717417072ce
+  workload_agent_uuid: 59460b8a-5f53-4e3e-b5ce-b71fed8c7e64
+`
+
+// EvacuateYaml is a sample node Evacuate command payload for test cases
+var EvacuateYaml = `evacuate:
+  workload_agent_uuid: 64803ffa-fb47-49fa-8191-15d2c34e4dd3
+`


### PR DESCRIPTION
I'm continuing to add test coverage, reduce redundant test code and create a set of "fake" ssntp clients and ssntp server under testutil/.  This set of patches tests good in travis and is misspell/golint/gocycle/go-vet clean.