### PR TITLE
ciao-launcher: Add Config package support for  ciao-launcher

### DIFF
--- a/ciao-launcher/README.md
+++ b/ciao-launcher/README.md
@@ -91,12 +91,8 @@ Usage of ./launcher:
     	Client certificate (default "/etc/pki/ciao/CAcert-server-localhost.pem")
   -cert string
     	CA certificate (default "/etc/pki/ciao/cert-client-localhost.pem")
-  -compute-net string
-    	Compute Subnet
   -cpuprofile string
     	write profile information to file
-  -disk-limit
-    	Use disk usage limits (default true)
   -hard-reset
     	Kill and delete all instances, reset networking and exit
   -log_backtrace_at value
@@ -105,10 +101,6 @@ Usage of ./launcher:
     	If non-empty, write log files in this directory
   -logtostderr
     	log to standard error instead of files
-  -mem-limit
-    	Use memory usage limits (default true)
-  -mgmt-net string
-    	Management Subnet
   -network value
     	Can be none, cn (compute node) or nn (network node) (default none)
   -server string

--- a/ciao-launcher/instance_test.go
+++ b/ciao-launcher/instance_test.go
@@ -249,6 +249,10 @@ func (v *instanceTestState) deleteInstance(t *testing.T, ovsCh chan interface{},
 	}
 }
 
+func (v *instanceTestState) ClusterConfiguration() (payloads.Configure, error) {
+	return payloads.Configure{}, nil
+}
+
 func cleanupShutdownFail(t *testing.T, instance string, doneCh chan struct{}, ovsCh chan interface{}) {
 	_ = os.RemoveAll(path.Join(instancesDir, instance))
 	shutdownInstanceLoop(doneCh, ovsCh)


### PR DESCRIPTION
Add config package support for enabling Scheduler-provided cluster
configuration.

ciao-launcher start commands should look like:
```
$ ./ciao-launcher --cacert=/path/to/cacert --cert=/path/to/cert \
       --server=<server-ip> --network=<cn|nn>
```

The options that were removed are:
```
--compute-net
--mgmt-net
--disk-limit
--mem-limit
```

Implements part of issue #66

Above configurations are provided by Scheduler at launch stage.

Signed-off-by: Munoz, Obed N <obed.n.munoz@intel.com>