### PR TITLE
ciao-launcher:  Add unit tests for the instanceLoop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ script:
    - go list ./... | grep -v vendor | xargs -t go vet
 #  - go list ./... | grep -v vendor | xargs -tL 1 golint -set_exit_status
    - if [[ "$TRAVIS_GO_VERSION" != "tip" ]] ; then go list ./... | grep -v vendor | xargs -tL 1 golint -set_exit_status ; fi
+   - sudo mkdir -p /var/lib/ciao/instances
+   - sudo chmod 0777 /var/lib/ciao/instances
    - test-cases -text -coverprofile /tmp/cover.out -short github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/ciao-controller/... github.com/01org/ciao/payloads
    - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -text -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/ssntp
    - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -text -short -tags travis -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/networking/libsnnet

--- a/ciao-launcher/delete.go
+++ b/ciao-launcher/delete.go
@@ -29,7 +29,7 @@ type deleteError struct {
 	code payloads.DeleteFailureReason
 }
 
-func (de *deleteError) send(client *ssntpConn, instance string) {
+func (de *deleteError) send(client serverConn, instance string) {
 	if !client.isConnected() {
 		return
 	}
@@ -46,7 +46,7 @@ func (de *deleteError) send(client *ssntpConn, instance string) {
 	}
 }
 
-func deleteVnic(instanceDir string, client *ssntpConn) {
+func deleteVnic(instanceDir string, client serverConn) {
 	cfg, err := loadVMConfig(instanceDir)
 	if err != nil {
 		glog.Warningf("Unable to load instance state %s: %s", instanceDir, err)
@@ -65,7 +65,7 @@ func deleteVnic(instanceDir string, client *ssntpConn) {
 	}
 }
 
-func processDelete(vm virtualizer, instanceDir string, client *ssntpConn, running ovsRunningState) error {
+func processDelete(vm virtualizer, instanceDir string, client serverConn, running ovsRunningState) error {
 
 	// We have to ignore these errors for the time being.  There's no way to distinguish
 	// between the various sort of errors that docker can return.  We could be getting

--- a/ciao-launcher/delete.go
+++ b/ciao-launcher/delete.go
@@ -29,8 +29,8 @@ type deleteError struct {
 	code payloads.DeleteFailureReason
 }
 
-func (de *deleteError) send(client serverConn, instance string) {
-	if !client.isConnected() {
+func (de *deleteError) send(conn serverConn, instance string) {
+	if !conn.isConnected() {
 		return
 	}
 
@@ -40,13 +40,13 @@ func (de *deleteError) send(client serverConn, instance string) {
 		return
 	}
 
-	_, err = client.SendError(ssntp.DeleteFailure, payload)
+	_, err = conn.SendError(ssntp.DeleteFailure, payload)
 	if err != nil {
 		glog.Errorf("Unable to send delete_failure: %v", err)
 	}
 }
 
-func deleteVnic(instanceDir string, client serverConn) {
+func deleteVnic(instanceDir string, conn serverConn) {
 	cfg, err := loadVMConfig(instanceDir)
 	if err != nil {
 		glog.Warningf("Unable to load instance state %s: %s", instanceDir, err)
@@ -59,13 +59,13 @@ func deleteVnic(instanceDir string, client serverConn) {
 		return
 	}
 
-	err = destroyVnic(client, vnicCfg)
+	err = destroyVnic(conn, vnicCfg)
 	if err != nil {
 		glog.Warningf("Unable to destroy vnic: %s", err)
 	}
 }
 
-func processDelete(vm virtualizer, instanceDir string, client serverConn, running ovsRunningState) error {
+func processDelete(vm virtualizer, instanceDir string, conn serverConn, running ovsRunningState) error {
 
 	// We have to ignore these errors for the time being.  There's no way to distinguish
 	// between the various sort of errors that docker can return.  We could be getting
@@ -76,7 +76,7 @@ func processDelete(vm virtualizer, instanceDir string, client serverConn, runnin
 
 	if networking.Enabled() && running != ovsPending {
 		glog.Info("Deleting Vnic")
-		deleteVnic(instanceDir, client)
+		deleteVnic(instanceDir, conn)
 	}
 
 	err := os.RemoveAll(instanceDir)

--- a/ciao-launcher/instance.go
+++ b/ciao-launcher/instance.go
@@ -101,13 +101,13 @@ func (id *instanceData) startCommand(cmd *insStartCmd) {
 	if id.monitorCh != nil {
 		startErr := &startError{nil, payloads.AlreadyRunning}
 		glog.Errorf("Unable to start instance[%s]", string(startErr.code))
-		startErr.send(&id.ac.ssntpConn, id.instance)
+		startErr.send(id.ac.conn, id.instance)
 		return
 	}
-	st, startErr := processStart(cmd, id.instanceDir, id.vm, &id.ac.ssntpConn)
+	st, startErr := processStart(cmd, id.instanceDir, id.vm, id.ac.conn)
 	if startErr != nil {
 		glog.Errorf("Unable to start instance[%s]: %v", string(startErr.code), startErr.err)
-		startErr.send(&id.ac.ssntpConn, id.instance)
+		startErr.send(id.ac.conn, id.instance)
 
 		if startErr.code == payloads.LaunchFailure {
 			id.ovsCh <- &ovsStateChange{id.instance, ovsStopped}
@@ -135,23 +135,23 @@ func (id *instanceData) restartCommand(cmd *insRestartCmd) {
 	if id.shuttingDown {
 		restartErr := &restartError{nil, payloads.RestartNoInstance}
 		glog.Errorf("Unable to restart instance[%s]", string(restartErr.code))
-		restartErr.send(&id.ac.ssntpConn, id.instance)
+		restartErr.send(id.ac.conn, id.instance)
 		return
 	}
 
 	if id.monitorCh != nil {
 		restartErr := &restartError{nil, payloads.RestartAlreadyRunning}
 		glog.Errorf("Unable to restart instance[%s]", string(restartErr.code))
-		restartErr.send(&id.ac.ssntpConn, id.instance)
+		restartErr.send(id.ac.conn, id.instance)
 		return
 	}
 
-	restartErr := processRestart(id.instanceDir, id.vm, &id.ac.ssntpConn, id.cfg)
+	restartErr := processRestart(id.instanceDir, id.vm, id.ac.conn, id.cfg)
 
 	if restartErr != nil {
 		glog.Errorf("Unable to restart instance[%s]: %v", string(restartErr.code),
 			restartErr.err)
-		restartErr.send(&id.ac.ssntpConn, id.instance)
+		restartErr.send(id.ac.conn, id.instance)
 		return
 	}
 
@@ -170,14 +170,14 @@ func (id *instanceData) stopCommand(cmd *insStopCmd) {
 	if id.shuttingDown {
 		stopErr := &stopError{nil, payloads.StopNoInstance}
 		glog.Errorf("Unable to stop instance[%s]", string(stopErr.code))
-		stopErr.send(&id.ac.ssntpConn, id.instance)
+		stopErr.send(id.ac.conn, id.instance)
 		return
 	}
 
 	if id.monitorCh == nil {
 		stopErr := &stopError{nil, payloads.StopAlreadyStopped}
 		glog.Errorf("Unable to stop instance[%s]", string(stopErr.code))
-		stopErr.send(&id.ac.ssntpConn, id.instance)
+		stopErr.send(id.ac.conn, id.instance)
 		return
 	}
 	glog.Infof("Powerdown %s", id.instance)
@@ -188,7 +188,7 @@ func (id *instanceData) deleteCommand(cmd *insDeleteCmd) bool {
 	if id.shuttingDown && !cmd.suicide {
 		deleteErr := &deleteError{nil, payloads.DeleteNoInstance}
 		glog.Errorf("Unable to delete instance[%s]", string(deleteErr.code))
-		deleteErr.send(&id.ac.ssntpConn, id.instance)
+		deleteErr.send(id.ac.conn, id.instance)
 		return false
 	}
 
@@ -198,7 +198,7 @@ func (id *instanceData) deleteCommand(cmd *insDeleteCmd) bool {
 		id.vm.lostVM()
 	}
 
-	_ = processDelete(id.vm, id.instanceDir, &id.ac.ssntpConn, cmd.running)
+	_ = processDelete(id.vm, id.instanceDir, id.ac.conn, cmd.running)
 
 	if !cmd.suicide {
 		id.ovsCh <- &ovsStatusCmd{}

--- a/ciao-launcher/instance.go
+++ b/ciao-launcher/instance.go
@@ -311,18 +311,8 @@ DONE:
 	id.wg.Done()
 }
 
-func startInstance(instance string, cfg *vmConfig, wg *sync.WaitGroup, doneCh chan struct{},
-	ac *agentClient, ovsCh chan<- interface{}) chan<- interface{} {
-
-	var vm virtualizer
-	if simulate == true {
-		vm = &simulation{}
-	} else if cfg.Container {
-		vm = &docker{}
-	} else {
-		vm = &qemu{}
-	}
-
+func startInstanceWithVM(instance string, cfg *vmConfig, wg *sync.WaitGroup, doneCh chan struct{},
+	ac *agentClient, ovsCh chan<- interface{}, vm virtualizer) chan<- interface{} {
 	id := &instanceData{
 		cmdCh:       make(chan interface{}),
 		instance:    instance,
@@ -338,4 +328,18 @@ func startInstance(instance string, cfg *vmConfig, wg *sync.WaitGroup, doneCh ch
 	wg.Add(1)
 	go id.instanceLoop()
 	return id.cmdCh
+}
+
+func startInstance(instance string, cfg *vmConfig, wg *sync.WaitGroup, doneCh chan struct{},
+	ac *agentClient, ovsCh chan<- interface{}) chan<- interface{} {
+
+	var vm virtualizer
+	if simulate == true {
+		vm = &simulation{}
+	} else if cfg.Container {
+		vm = &docker{}
+	} else {
+		vm = &qemu{}
+	}
+	return startInstanceWithVM(instance, cfg, wg, doneCh, ac, ovsCh, vm)
 }

--- a/ciao-launcher/instance_test.go
+++ b/ciao-launcher/instance_test.go
@@ -1,0 +1,882 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"sync"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/01org/ciao/payloads"
+	"github.com/01org/ciao/ssntp"
+)
+
+var standardCfg = vmConfig{
+	Cpus:        2,
+	Mem:         370,
+	Disk:        8000,
+	Instance:    "testInstance",
+	Image:       "testImage",
+	Legacy:      true,
+	VnicMAC:     "02:00:e6:f5:af:f9",
+	VnicIP:      "192.168.8.2",
+	ConcIP:      "192.168.42.21",
+	SubnetIP:    "192.168.8.0/21",
+	TennantUUID: "67d86208-000-4465-9018-fe14087d415f",
+	ConcUUID:    "67d86208-b46c-4465-0000-fe14087d415f",
+	VnicUUID:    "67d86208-b46c-0000-9018-fe14087d415f",
+}
+
+// instanceTestState implements virtualizer and serverConn
+type instanceTestState struct {
+	t               *testing.T
+	instance        string
+	statsArray      [3]int
+	sf              payloads.ErrorStopFailure
+	stf             payloads.ErrorStartFailure
+	df              payloads.ErrorDeleteFailure
+	rf              payloads.ErrorRestartFailure
+	connect         bool
+	monitorCh       chan string
+	errorCh         chan struct{}
+	monitorClosedCh chan struct{}
+	failStartVM     bool
+	ac              *agentClient
+}
+
+func (v *instanceTestState) init(cfg *vmConfig, instanceDir string) {
+
+}
+
+func (v *instanceTestState) checkBackingImage() error {
+	return nil
+}
+
+func (v *instanceTestState) downloadBackingImage() error {
+	return nil
+}
+
+func (v *instanceTestState) createImage(bridge string, userData, metaData []byte) error {
+	return nil
+}
+
+func (v *instanceTestState) deleteImage() error {
+	return nil
+}
+
+func (v *instanceTestState) startVM(vnicName, ipAddress string) error {
+	if v.failStartVM {
+		return fmt.Errorf("Failed to start VM")
+	}
+	return nil
+}
+
+func (v *instanceTestState) monitorVM(closedCh chan struct{}, connectedCh chan struct{},
+	wg *sync.WaitGroup, boot bool) chan string {
+
+	// Need to be careful here not to modify any state inside v before
+	// we've closed the channel.
+
+	v.monitorClosedCh = closedCh
+
+	monitorCh := make(chan string)
+	v.monitorCh = monitorCh
+	if v.connect {
+		close(connectedCh)
+	}
+	return monitorCh
+}
+
+func (v *instanceTestState) stats() (disk, memory, cpu int) {
+	return v.statsArray[0], v.statsArray[1], v.statsArray[2]
+}
+
+func (v *instanceTestState) connected() {
+
+}
+
+func (v *instanceTestState) lostVM() {
+}
+
+func (v *instanceTestState) SendError(error ssntp.Error, payload []byte) (int, error) {
+	switch error {
+	case ssntp.StopFailure:
+		err := yaml.Unmarshal(payload, &v.sf)
+		if err != nil {
+			v.t.Fatalf("Failed to unmarshall stop error %v", err)
+		}
+	case ssntp.StartFailure:
+		err := yaml.Unmarshal(payload, &v.stf)
+		if err != nil {
+			v.t.Fatalf("Failed to unmarshall start error %v", err)
+		}
+	case ssntp.DeleteFailure:
+		err := yaml.Unmarshal(payload, &v.df)
+		if err != nil {
+			v.t.Fatalf("Failed to unmarshall delete error %v", err)
+		}
+	case ssntp.RestartFailure:
+		err := yaml.Unmarshal(payload, &v.rf)
+		if err != nil {
+			v.t.Fatalf("Failed to unmarshall restart error %v", err)
+		}
+	}
+
+	if v.errorCh != nil {
+		close(v.errorCh)
+	}
+
+	return 0, nil
+}
+
+func (v *instanceTestState) SendEvent(event ssntp.Event, payload []byte) (int, error) {
+	return 0, nil
+}
+
+func (v *instanceTestState) Dial(config *ssntp.Config, ntf ssntp.ClientNotifier) error {
+	return nil
+}
+
+func (v *instanceTestState) SendStatus(status ssntp.Status, payload []byte) (int, error) {
+	return 0, nil
+}
+
+func (v *instanceTestState) SendCommand(cmd ssntp.Command, payload []byte) (int, error) {
+	return 0, nil
+}
+
+func (v *instanceTestState) UUID() string {
+	return ""
+}
+
+func (v *instanceTestState) Close() {
+
+}
+
+func (v *instanceTestState) isConnected() bool {
+	return true
+}
+
+func (v *instanceTestState) setStatus(status bool) {
+
+}
+
+func (v *instanceTestState) cleanUpInstance() {
+	_ = os.RemoveAll(path.Join(instancesDir, v.instance))
+}
+
+func (v *instanceTestState) verifyStatsUpdate(t *testing.T, cmd interface{}) {
+	stats := cmd.(*ovsStatsUpdateCmd)
+	if stats.diskUsageMB != v.statsArray[0] || stats.memoryUsageMB != v.statsArray[1] ||
+		stats.CPUUsage != v.statsArray[2] || stats.instance != v.instance {
+		t.Fatal("Incorrect statistics received")
+	}
+}
+
+func (v *instanceTestState) expectStatsUpdate(t *testing.T, ovsCh <-chan interface{}) bool {
+	var cmd interface{}
+	select {
+	case cmd = <-ovsCh:
+	case <-time.After(time.Second):
+		t.Error("Timed out waiting for ovsStatsUpdateCmd")
+		return false
+	}
+	stats, ok := cmd.(*ovsStatsUpdateCmd)
+	if !ok {
+		t.Error("Unexpected Command received on ovsCh")
+	}
+	if stats.diskUsageMB != v.statsArray[0] || stats.memoryUsageMB != v.statsArray[1] ||
+		stats.CPUUsage != v.statsArray[2] || stats.instance != v.instance {
+		t.Error("Incorrect statistics received")
+		return false
+	}
+	return true
+}
+
+func (v *instanceTestState) deleteInstance(t *testing.T, ovsCh chan interface{},
+	cmdCh chan<- interface{}) bool {
+
+	v.errorCh = make(chan struct{})
+	select {
+	case cmdCh <- &insDeleteCmd{}:
+	case <-time.After(time.Second):
+		t.Error("Timed out sending Stop command")
+		return false
+	}
+
+	for {
+		select {
+		case <-v.errorCh:
+			v.errorCh = nil
+			t.Error("Delete command Failed")
+			return false
+		case ovsCmd := <-ovsCh:
+			switch ovsCmd.(type) {
+			case *ovsStatusCmd:
+				return true
+			case *ovsStatsUpdateCmd:
+			default:
+				t.Error("Unexpected commands received on ovsCh")
+				return false
+			}
+		case monCmd := <-v.monitorCh:
+			if monCmd != virtualizerStopCmd {
+				t.Errorf("Invalid monitor command found %s, expected %s", monCmd, virtualizerStopCmd)
+				return false
+			}
+		case <-time.After(time.Second):
+			t.Error("Timed out waiting for ovsStatsUpdateCmd")
+			return false
+		}
+	}
+}
+
+func cleanupShutdownFail(t *testing.T, instance string, doneCh chan struct{}, ovsCh chan interface{}) {
+	_ = os.RemoveAll(path.Join(instancesDir, instance))
+	shutdownInstanceLoop(doneCh, ovsCh)
+	t.FailNow()
+}
+
+func waitForStateChange(t *testing.T, ovsState ovsRunningState, ovsCh chan interface{}) bool {
+	for {
+		select {
+		case ovsCmd := <-ovsCh:
+			switch stChange := ovsCmd.(type) {
+			case *ovsStateChange:
+				if stChange.state != ovsState {
+					t.Errorf("ovs state %d expected.  Found state %d",
+						ovsState, stChange.state)
+					return false
+				}
+				return true
+			case *ovsStatsUpdateCmd:
+			default:
+				t.Error("Unexpected commands received on ovsCh")
+				return false
+			}
+		case <-time.After(time.Second):
+			t.Error("Timed out waiting for overseer channel")
+			return false
+		}
+	}
+}
+
+func (v *instanceTestState) startInstance(t *testing.T, ovsCh chan interface{},
+	cmdCh chan<- interface{}, cfg *vmConfig, errorOk bool) bool {
+
+	v.errorCh = make(chan struct{})
+	select {
+	case cmdCh <- &insStartCmd{cfg: cfg, rcvStamp: time.Now()}:
+	case <-time.After(time.Second):
+		t.Error("Timed out sending Stop command")
+		return false
+	}
+
+DONE:
+	for {
+		select {
+		case <-v.errorCh:
+			v.errorCh = nil
+			if !errorOk {
+				t.Error("Start command Failed")
+				return false
+			}
+			return true
+		case ovsCmd := <-ovsCh:
+			switch ovsCmd.(type) {
+			case *ovsStatusCmd:
+				break DONE
+			case *ovsStatsUpdateCmd:
+			default:
+				t.Error("Unexpected commands received on ovsCh")
+				return false
+			}
+		case <-time.After(time.Second):
+			t.Error("Timed out waiting for ovsStatsUpdateCmd")
+			return false
+		}
+	}
+
+	if !v.connect {
+		return true
+	}
+
+	if !waitForStateChange(t, ovsRunning, ovsCh) {
+		return false
+	}
+
+	return v.expectStatsUpdate(t, ovsCh)
+}
+
+func (v *instanceTestState) restartInstance(t *testing.T, ovsCh chan interface{},
+	cmdCh chan<- interface{}, errorOk bool) bool {
+
+	v.errorCh = make(chan struct{})
+	select {
+	case cmdCh <- &insRestartCmd{}:
+	case <-time.After(time.Second):
+		t.Error("Timed out sending Restart command")
+		return false
+	}
+
+	for {
+		select {
+		case <-v.errorCh:
+			v.errorCh = nil
+			if !errorOk {
+				t.Error("Restart command Failed")
+			}
+			return false
+		case ovsCmd := <-ovsCh:
+			switch stChange := ovsCmd.(type) {
+			case *ovsStateChange:
+				if stChange.state != ovsRunning {
+					t.Errorf("ovsRunning expected.  Found state %d", stChange.state)
+					return false
+				}
+				return true
+			case *ovsStatsUpdateCmd:
+			default:
+				t.Error("Unexpected commands received on ovsCh")
+				return false
+			}
+		case <-time.After(time.Second):
+			t.Error("Timed out waiting for ovsStatsUpdateCmd")
+			return false
+		}
+	}
+}
+
+func shutdownInstanceLoop(doneCh chan struct{}, ovsCh chan interface{}) {
+	close(doneCh)
+DONE:
+	for {
+		select {
+		case _, ok := <-ovsCh:
+			if !ok {
+				break DONE
+			}
+		default:
+			break DONE
+		}
+	}
+}
+
+// Checks that an instance loop can be started and shutdown
+//
+// We just check that the instanceLoop can be started and shutdown.  No commands are
+// actually executed by the instance.
+//
+// It should be possible to start and stop the instanceLoop without any problems.
+func TestStartInstanceLoop(t *testing.T) {
+	var wg sync.WaitGroup
+	doneCh := make(chan struct{})
+	ovsCh := make(chan interface{})
+	state := &instanceTestState{
+		t:          t,
+		instance:   "testInstance",
+		statsArray: [3]int{10, 128, 10},
+	}
+	cfg := &vmConfig{}
+	cmdWrapCh := make(chan *cmdWrapper)
+	ac := &agentClient{conn: state, cmdCh: cmdWrapCh}
+	_ = startInstanceWithVM(state.instance, cfg, &wg, doneCh, ac, ovsCh, state)
+	ok := state.expectStatsUpdate(t, ovsCh)
+	shutdownInstanceLoop(doneCh, ovsCh)
+	if !ok {
+		t.FailNow()
+	}
+	wg.Wait()
+}
+
+// Checks an instance loop can be deleted before an instance is launched.
+//
+// We start the instance loop and then delete the instance straight away.
+//
+// The instanceLoop should start and should then terminate cleanly once the
+// deleteCmd is received.  Note delete works here, even though we haven't
+// actually started an instance.
+func TestDeleteInstanceLoop(t *testing.T) {
+	var wg sync.WaitGroup
+	doneCh := make(chan struct{})
+	ovsCh := make(chan interface{})
+	state := &instanceTestState{
+		t:          t,
+		instance:   "testInstance",
+		statsArray: [3]int{10, 128, 10},
+		errorCh:    make(chan struct{}),
+	}
+	cfg := &vmConfig{}
+	cmdWrapCh := make(chan *cmdWrapper)
+	ac := &agentClient{conn: state, cmdCh: cmdWrapCh}
+	cmdCh := startInstanceWithVM(state.instance, cfg, &wg, doneCh, ac, ovsCh, state)
+
+	ok := state.expectStatsUpdate(t, ovsCh)
+	if !ok {
+		shutdownInstanceLoop(doneCh, ovsCh)
+		t.FailNow()
+	}
+
+	if !state.deleteInstance(t, ovsCh, cmdCh) {
+		shutdownInstanceLoop(doneCh, ovsCh)
+		t.FailNow()
+	}
+	wg.Wait()
+}
+
+// Check we cannot stop an instance that is not running.
+//
+// We start the instance loop and then try to stop the instance straight away.
+// When this fails we delete the instance.
+//
+//  We should receive a SSNTP stopErr and the instance loop should close.
+func TestStopNotRunning(t *testing.T) {
+	var wg sync.WaitGroup
+	doneCh := make(chan struct{})
+	ovsCh := make(chan interface{})
+	state := &instanceTestState{
+		t:          t,
+		instance:   "testInstance",
+		statsArray: [3]int{10, 128, 10},
+		errorCh:    make(chan struct{}),
+	}
+	cfg := &vmConfig{}
+	cmdWrapCh := make(chan *cmdWrapper)
+	ac := &agentClient{conn: state, cmdCh: cmdWrapCh}
+	cmdCh := startInstanceWithVM(state.instance, cfg, &wg, doneCh, ac, ovsCh, state)
+
+	ok := state.expectStatsUpdate(t, ovsCh)
+	if !ok {
+		shutdownInstanceLoop(doneCh, ovsCh)
+		t.FailNow()
+	}
+
+	select {
+	case cmdCh <- &insStopCmd{}:
+	case <-time.After(time.Second):
+		shutdownInstanceLoop(doneCh, ovsCh)
+		t.Fatal("Timed out sending Stop command")
+	}
+
+	select {
+	case <-state.errorCh:
+		state.errorCh = nil
+	case <-time.After(time.Second):
+		shutdownInstanceLoop(doneCh, ovsCh)
+		t.Fatal("Timed out waiting for error channel")
+	}
+
+	if state.sf.InstanceUUID != state.instance ||
+		state.sf.Reason != payloads.StopAlreadyStopped {
+		t.Error("Invalid Stop error returned")
+	}
+
+	if !state.deleteInstance(t, ovsCh, cmdCh) {
+		shutdownInstanceLoop(doneCh, ovsCh)
+		t.FailNow()
+	}
+	wg.Wait()
+}
+
+func startVMWithCFG(t *testing.T, wg *sync.WaitGroup, cfg *vmConfig, connect bool, errorOk bool) (*instanceTestState, chan interface{}, chan<- interface{}, chan struct{}) {
+	doneCh := make(chan struct{})
+	ovsCh := make(chan interface{})
+	state := &instanceTestState{
+		t:          t,
+		instance:   "testInstance",
+		statsArray: [3]int{10, 128, 10},
+		connect:    connect,
+	}
+	state.ac = &agentClient{conn: state, cmdCh: make(chan *cmdWrapper)}
+	cmdCh := startInstanceWithVM(state.instance, cfg, wg, doneCh, state.ac, ovsCh, state)
+	if !state.expectStatsUpdate(t, ovsCh) {
+		shutdownInstanceLoop(doneCh, ovsCh)
+		t.FailNow()
+	}
+
+	if !state.startInstance(t, ovsCh, cmdCh, cfg, errorOk) {
+		cleanupShutdownFail(t, cfg.Instance, doneCh, ovsCh)
+	}
+	return state, ovsCh, cmdCh, doneCh
+}
+
+// Check we can start an instance that is not running.
+//
+// We start the instance loop and then try to start an instance.  Our test virtualizer
+// closes the connected channel to indicate that the instance is running.  We then
+// check to see whether we receive the state change notification at which point we
+// delete the instance.
+//
+// The instance is started and deleted correctly and the instanceLoop should close
+// down cleanly.
+func TestStartNotRunning(t *testing.T) {
+	var wg sync.WaitGroup
+	cfg := standardCfg
+	state, ovsCh, cmdCh, doneCh := startVMWithCFG(t, &wg, &cfg, true, false)
+
+	if !state.deleteInstance(t, ovsCh, cmdCh) {
+		cleanupShutdownFail(t, cfg.Instance, doneCh, ovsCh)
+	}
+
+	wg.Wait()
+}
+
+// Check we can delete an instance which has been started but has not yet connected.
+//
+// We start the instance loop and then try to start an instance.  The key point here
+// is that we do not close the connected channel, simulating a qemu instance for
+// example that has not yet started up.  We then delete the instance.
+//
+// The instance is started and deleted correctly and the instanceLoop should close
+// down cleanly.
+func TestDeleteNoConnect(t *testing.T) {
+	var wg sync.WaitGroup
+	cfg := standardCfg
+	state, ovsCh, cmdCh, doneCh := startVMWithCFG(t, &wg, &cfg, false, false)
+
+	if !state.deleteInstance(t, ovsCh, cmdCh) {
+		_ = os.RemoveAll(path.Join(instancesDir, cfg.Instance))
+		close(doneCh)
+		t.FailNow()
+	}
+
+	wg.Wait()
+}
+
+// Check we can shut down the instance loop cleanly when we have a running instance.
+//
+// We start the instance loop and then try to start an instance.  Our test virtualizer
+// closes the connected channel to indicate that the instance is running.  We then
+// close the doneCh channel simulating a launcher exit.  We need to explicitly delete
+// the instance directory, so the subsequent tests don't fail.
+//
+// The instance is started correctly and the instanceLoop shuts down cleanly.
+func TestLoopShutdownWithRunningInstance(t *testing.T) {
+	var wg sync.WaitGroup
+	cfg := standardCfg
+	_, ovsCh, _, doneCh := startVMWithCFG(t, &wg, &cfg, true, false)
+
+	shutdownInstanceLoop(doneCh, ovsCh)
+
+	// We need to remove the instance manually to have a clean setup for the
+	// subsequent tests.
+
+	_ = os.RemoveAll(path.Join(instancesDir, cfg.Instance))
+
+	wg.Wait()
+}
+
+// Check we can restart an instance
+//
+// We start the instance loop and then try to restart an instance.  Our test virtualizer
+// closes the connected channel to indicate that the instance is running.  We then
+// check to see whether we receive the state change notification at which point we
+// close the doneCh.
+//
+// The instance should start correctly.  We should receive an error when attempting
+// to restart the instance.  The instanceLoop should quit cleanly.
+func TestRestart(t *testing.T) {
+	var wg sync.WaitGroup
+	cfg := standardCfg
+	doneCh := make(chan struct{})
+	ovsCh := make(chan interface{})
+	state := &instanceTestState{
+		t:          t,
+		instance:   "testInstance",
+		statsArray: [3]int{10, 128, 10},
+		connect:    true,
+	}
+	cmdWrapCh := make(chan *cmdWrapper)
+	ac := &agentClient{conn: state, cmdCh: cmdWrapCh}
+	cmdCh := startInstanceWithVM(state.instance, &cfg, &wg, doneCh, ac, ovsCh, state)
+	ok := state.expectStatsUpdate(t, ovsCh)
+	if !ok {
+		shutdownInstanceLoop(doneCh, ovsCh)
+		t.FailNow()
+	}
+
+	if !state.restartInstance(t, ovsCh, cmdCh, false) {
+		shutdownInstanceLoop(doneCh, ovsCh)
+		t.FailNow()
+	}
+
+	shutdownInstanceLoop(doneCh, ovsCh)
+	wg.Wait()
+}
+
+// Check we can handle a restart error
+//
+// We start the instanceLoop and then try to restart an instance.  This attempt
+// will fail as we've configured startVm to return an error.  We then shutdown
+// the instance loop.
+//
+// The instanceLoop should start correctly, the restartCommand should fail with
+// the correct error and the instanceLoop should close down cleanly.
+func TestRestartFail(t *testing.T) {
+	var wg sync.WaitGroup
+	cfg := standardCfg
+	doneCh := make(chan struct{})
+	ovsCh := make(chan interface{})
+	state := &instanceTestState{
+		t:           t,
+		instance:    "testInstance",
+		statsArray:  [3]int{10, 128, 10},
+		connect:     true,
+		failStartVM: true,
+	}
+	cmdWrapCh := make(chan *cmdWrapper)
+	ac := &agentClient{conn: state, cmdCh: cmdWrapCh}
+	cmdCh := startInstanceWithVM(state.instance, &cfg, &wg, doneCh, ac, ovsCh, state)
+	ok := state.expectStatsUpdate(t, ovsCh)
+	if !ok {
+		shutdownInstanceLoop(doneCh, ovsCh)
+		t.FailNow()
+	}
+
+	if state.restartInstance(t, ovsCh, cmdCh, true) {
+		t.Error("Restart was expected to Fail")
+	}
+
+	if state.rf.Reason != payloads.RestartLaunchFailure {
+		t.Errorf("Invalid restart error found %s, expected %s",
+			state.rf.Reason, payloads.RestartLaunchFailure)
+	}
+
+	shutdownInstanceLoop(doneCh, ovsCh)
+	wg.Wait()
+}
+
+// Check we get an error when starting an instance with an invalid image
+//
+// We start the instance loop and then try to start an instance with an invalid
+// config. This should cause a sudicide command to get sent to the acCmd channel.
+// We'll extract this command and send it back down our instance channel,
+// which should kill the instanceLoop.
+//
+// The instanceLoop should start correctly but the start command should fail.
+// The suicide command recevied from the acCmd channel should terminate the
+// instanceLoop cleanly.
+func TestStartBadImage(t *testing.T) {
+	var wg sync.WaitGroup
+	cfg := standardCfg
+	cfg.Image = ""
+
+	state, ovsCh, cmdCh, doneCh := startVMWithCFG(t, &wg, &cfg, true, true)
+	if state.stf.Reason != payloads.InvalidData {
+		t.Errorf("Incorrect error returned. Reported %s, expected %s",
+			string(state.stf.Reason), string(payloads.ImageFailure))
+	}
+
+	select {
+	case acCmd := <-state.ac.cmdCh:
+		state.errorCh = make(chan struct{})
+		select {
+		case cmdCh <- acCmd.cmd:
+		case <-time.After(time.Second):
+			shutdownInstanceLoop(doneCh, ovsCh)
+			t.Fatal("Timed out sending suicide command")
+		}
+	case <-time.After(time.Second):
+		shutdownInstanceLoop(doneCh, ovsCh)
+		t.Fatal("Timedout waiting from suicide command")
+	}
+	wg.Wait()
+
+	select {
+	case <-state.errorCh:
+		state.errorCh = nil
+		t.Error("Suicide Delete failed unexpectedly")
+	default:
+	}
+}
+
+func sendCommandDuringSuicide(t *testing.T, testCmd interface{}) *instanceTestState {
+	var wg sync.WaitGroup
+	cfg := standardCfg
+	cfg.Image = ""
+
+	state, ovsCh, cmdCh, doneCh := startVMWithCFG(t, &wg, &cfg, true, true)
+	if state.stf.Reason != payloads.InvalidData {
+		t.Errorf("Incorrect error returned. Reported %s, expected %s",
+			string(state.stf.Reason), string(payloads.ImageFailure))
+	}
+
+	var acCmd *cmdWrapper
+	select {
+	case acCmd = <-state.ac.cmdCh:
+	case <-time.After(time.Second):
+		shutdownInstanceLoop(doneCh, ovsCh)
+		t.Fatal("Timedout waiting from suicide command")
+	}
+
+	state.errorCh = make(chan struct{})
+	select {
+	case cmdCh <- testCmd:
+	case <-time.After(time.Second):
+		shutdownInstanceLoop(doneCh, ovsCh)
+		t.Fatal("Timed out sending command during suicide")
+	}
+
+	select {
+	case <-state.errorCh:
+		state.errorCh = nil
+	case <-time.After(time.Second):
+		shutdownInstanceLoop(doneCh, ovsCh)
+		t.Fatal("Timed out waiting on error channel")
+	}
+
+	select {
+	case cmdCh <- acCmd.cmd:
+	case <-time.After(time.Second):
+		shutdownInstanceLoop(doneCh, ovsCh)
+		t.Fatal("Timed out sending suicide command")
+	}
+
+	wg.Wait()
+
+	select {
+	case <-state.errorCh:
+		state.errorCh = nil
+		t.Fatal("Suicide Delete failed unexpectedly")
+	default:
+	}
+
+	return state
+}
+
+// Test deleting an instance that failed to start and is suiciding.
+//
+// We start the instance loop and then try to start an instance. This should cause
+// a suicide command to get sent to the acCmd channel.  We then send a delete
+// command to the instance (without the suicide flag set).  This command should
+// fail.  We then send the real suicide command received from the acCmd channel,
+// which should succeed.
+//
+// The instanceLoop should start, the start command and the first delete command
+// should fail.  The second delete (suicide) should succeed and the loop should
+// exit.
+func TestDeleteNoInstance(t *testing.T) {
+	state := sendCommandDuringSuicide(t, &insDeleteCmd{})
+	if state.df.Reason != payloads.DeleteNoInstance {
+		t.Errorf("Incorrect error returned. Reported %s, expected %s",
+			string(state.df.Reason), string(payloads.DeleteNoInstance))
+	}
+}
+
+// Test restarting an instance that failed to start and is suiciding.
+//
+// We start the instance loop and then try to start an instance. This should cause
+// a suicide command to get sent to the acCmd channel.  We then send a restart
+// command to the instance.  This command should fail.  We then send the suicide
+// command received from the acCmd channel, which should succeed.
+//
+// The instanceLoop should start, the start command and the restart command
+// should fail.  The delete (suicide) should succeed and the loop should
+// exit.
+func TestRestartNoInstance(t *testing.T) {
+	state := sendCommandDuringSuicide(t, &insRestartCmd{})
+	if state.rf.Reason != payloads.RestartNoInstance {
+		t.Errorf("Incorrect error returned. Reported %s, expected %s",
+			string(state.rf.Reason), string(payloads.RestartNoInstance))
+	}
+}
+
+// Test stopping an instance that failed to start and is suiciding.
+//
+// We start the instance loop and then try to start an instance. This should cause
+// a suicide command to get sent to the acCmd channel.  We then send a stop
+// command to the instance.  This command should fail.  We then send the suicide
+// command received from the acCmd channel, which should succeed.
+//
+// The instanceLoop should start, the start command and the stop command
+// should fail.  The delete (suicide) should succeed and the loop should
+// exit.
+func TestStopNoInstance(t *testing.T) {
+	state := sendCommandDuringSuicide(t, &insStopCmd{})
+	if state.sf.Reason != payloads.StopNoInstance {
+		t.Errorf("Incorrect error returned. Reported %s, expected %s",
+			string(state.sf.Reason), string(payloads.StopNoInstance))
+	}
+}
+
+// Check the instanceLoop copes when an instance is dropped.
+//
+// We start the instance loop and then try to start an instance.  Our test virtualizer
+// closes the connected channel to indicate that the instance is running.  We then close
+// the monitorCloseCh channel informing the instanceLoop that the instance has dropped.
+// We then delete the instance.
+//
+// The instanceLoop and then instance should start correctly.  We should receive
+// a state change notification when we simulate the instances untimely demise.
+// The instance should then be deleted correctly and the instanceLoop should exit
+// cleanly.
+func TestLostInstance(t *testing.T) {
+	var wg sync.WaitGroup
+	cfg := standardCfg
+	state, ovsCh, cmdCh, doneCh := startVMWithCFG(t, &wg, &cfg, true, false)
+
+	close(state.monitorClosedCh)
+
+	if !waitForStateChange(t, ovsStopped, ovsCh) {
+		cleanupShutdownFail(t, cfg.Instance, doneCh, ovsCh)
+	}
+
+	// This gets closed by the instanceLoop and so will become available
+	// in the deleteInstance select loop if we don't set it to nil.
+	state.monitorCh = nil
+
+	if !state.deleteInstance(t, ovsCh, cmdCh) {
+		cleanupShutdownFail(t, cfg.Instance, doneCh, ovsCh)
+	}
+
+	wg.Wait()
+}
+
+// Check we get an error when starting a running instance.
+//
+// We start the instance loop and then try to start an instance.  Our test virtualizer
+// closes the connected channel to indicate that the instance is running.  We then
+// send another start command and delete the instance.
+//
+// The instanceLoop and then instance should start correctly.  The second start
+// command should fail.  The instance should then be deleted correctly and
+// the instanceLoop should exit cleanly.
+func TestStartRunningInstance(t *testing.T) {
+	var wg sync.WaitGroup
+	cfg := standardCfg
+	state, ovsCh, cmdCh, doneCh := startVMWithCFG(t, &wg, &cfg, true, false)
+
+	if !state.startInstance(t, ovsCh, cmdCh, &cfg, true) {
+		cleanupShutdownFail(t, cfg.Instance, doneCh, ovsCh)
+	}
+
+	if state.stf.Reason != payloads.AlreadyRunning {
+		t.Errorf("Invalid Error received.  Expected %s found %s",
+			string(state.stf.Reason), string(payloads.AlreadyRunning))
+	}
+
+	if !state.deleteInstance(t, ovsCh, cmdCh) {
+		cleanupShutdownFail(t, cfg.Instance, doneCh, ovsCh)
+	}
+
+	wg.Wait()
+}

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -248,7 +248,7 @@ func insState(instance string, ovsCh chan<- interface{}) ovsGetResult {
 	return <-targetCh
 }
 
-func processCommand(client serverConn, cmd *cmdWrapper, ovsCh chan<- interface{}) {
+func processCommand(conn serverConn, cmd *cmdWrapper, ovsCh chan<- interface{}) {
 	var target chan<- interface{}
 	var delCmd *insDeleteCmd
 
@@ -264,7 +264,7 @@ func processCommand(client serverConn, cmd *cmdWrapper, ovsCh chan<- interface{}
 			glog.Errorf("Instance will make node full: Disk %d Mem %d CPUs %d",
 				insCmd.cfg.Disk, insCmd.cfg.Mem, insCmd.cfg.Cpus)
 			se := startError{nil, payloads.FullComputeNode}
-			se.send(client, cmd.instance)
+			se.send(conn, cmd.instance)
 			return
 		}
 		target = addResult.cmdCh
@@ -274,7 +274,7 @@ func processCommand(client serverConn, cmd *cmdWrapper, ovsCh chan<- interface{}
 		if target == nil {
 			glog.Errorf("Instance %s does not exist", cmd.instance)
 			de := deleteError{nil, payloads.DeleteNoInstance}
-			de.send(client, cmd.instance)
+			de.send(conn, cmd.instance)
 			return
 		}
 		delCmd = insCmd
@@ -284,7 +284,7 @@ func processCommand(client serverConn, cmd *cmdWrapper, ovsCh chan<- interface{}
 		if target == nil {
 			glog.Errorf("Instance %s does not exist", cmd.instance)
 			se := stopError{nil, payloads.StopNoInstance}
-			se.send(client, cmd.instance)
+			se.send(conn, cmd.instance)
 			return
 		}
 	case *insRestartCmd:
@@ -292,7 +292,7 @@ func processCommand(client serverConn, cmd *cmdWrapper, ovsCh chan<- interface{}
 		if target == nil {
 			glog.Errorf("Instance %s does not exist", cmd.instance)
 			re := restartError{nil, payloads.RestartNoInstance}
-			re.send(client, cmd.instance)
+			re.send(conn, cmd.instance)
 			return
 		}
 	default:

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -121,6 +121,18 @@ type cmdWrapper struct {
 }
 type statusCmd struct{}
 
+type serverConn interface {
+	SendError(error ssntp.Error, payload []byte) (int, error)
+	SendEvent(event ssntp.Event, payload []byte) (int, error)
+	Dial(config *ssntp.Config, ntf ssntp.ClientNotifier) error
+	SendStatus(status ssntp.Status, payload []byte) (int, error)
+	SendCommand(cmd ssntp.Command, payload []byte) (int, error)
+	UUID() string
+	Close()
+	isConnected() bool
+	setStatus(status bool)
+}
+
 type ssntpConn struct {
 	sync.RWMutex
 	ssntp.Client
@@ -140,17 +152,17 @@ func (s *ssntpConn) setStatus(status bool) {
 }
 
 type agentClient struct {
-	ssntpConn
+	conn  serverConn
 	cmdCh chan *cmdWrapper
 }
 
 func (client *agentClient) DisconnectNotify() {
-	client.setStatus(false)
+	client.conn.setStatus(false)
 	glog.Warning("disconnected")
 }
 
 func (client *agentClient) ConnectNotify() {
-	client.setStatus(true)
+	client.conn.setStatus(true)
 	client.cmdCh <- &cmdWrapper{"", &statusCmd{}}
 	glog.Info("connected")
 }
@@ -171,7 +183,7 @@ func (client *agentClient) CommandNotify(cmd ssntp.Command, frame *ssntp.Frame) 
 				payloadErr.err,
 				payloads.StartFailureReason(payloadErr.code),
 			}
-			startError.send(&client.ssntpConn, "")
+			startError.send(client.conn, "")
 			glog.Errorf("Unable to parse YAML: %v", payloadErr.err)
 			return
 		}
@@ -183,7 +195,7 @@ func (client *agentClient) CommandNotify(cmd ssntp.Command, frame *ssntp.Frame) 
 				payloadErr.err,
 				payloads.RestartFailureReason(payloadErr.code),
 			}
-			restartError.send(&client.ssntpConn, "")
+			restartError.send(client.conn, "")
 			glog.Errorf("Unable to parse YAML: %v", payloadErr.err)
 			return
 		}
@@ -195,7 +207,7 @@ func (client *agentClient) CommandNotify(cmd ssntp.Command, frame *ssntp.Frame) 
 				payloadErr.err,
 				payloads.StopFailureReason(payloadErr.code),
 			}
-			stopError.send(&client.ssntpConn, "")
+			stopError.send(client.conn, "")
 			glog.Errorf("Unable to parse YAML: %s", payloadErr)
 			return
 		}
@@ -207,7 +219,7 @@ func (client *agentClient) CommandNotify(cmd ssntp.Command, frame *ssntp.Frame) 
 				payloadErr.err,
 				payloads.DeleteFailureReason(payloadErr.code),
 			}
-			deleteError.send(&client.ssntpConn, "")
+			deleteError.send(client.conn, "")
 			glog.Errorf("Unable to parse YAML: %s", payloadErr.err)
 			return
 		}
@@ -236,7 +248,7 @@ func insState(instance string, ovsCh chan<- interface{}) ovsGetResult {
 	return <-targetCh
 }
 
-func processCommand(client *ssntpConn, cmd *cmdWrapper, ovsCh chan<- interface{}) {
+func processCommand(client serverConn, cmd *cmdWrapper, ovsCh chan<- interface{}) {
 	var target chan<- interface{}
 	var delCmd *insDeleteCmd
 
@@ -315,6 +327,7 @@ func connectToServer(doneCh chan struct{}, statusCh chan struct{}) {
 	cfg := &ssntp.Config{URI: serverURL, CAcert: serverCertPath, Cert: clientCertPath,
 		Log: ssntp.Log}
 	client := &agentClient{
+		conn:  &ssntpConn{},
 		cmdCh: make(chan *cmdWrapper),
 	}
 
@@ -323,7 +336,7 @@ func connectToServer(doneCh chan struct{}, statusCh chan struct{}) {
 	dialCh := make(chan error)
 
 	go func() {
-		err := client.Dial(cfg, client)
+		err := client.conn.Dial(cfg, client)
 		if err != nil {
 			glog.Errorf("Unable to connect to server %v", err)
 			dialCh <- err
@@ -344,7 +357,7 @@ DONE:
 				break DONE
 			}
 		case <-doneCh:
-			client.Close()
+			client.conn.Close()
 			if !dialing {
 				break DONE
 			}
@@ -356,12 +369,12 @@ DONE:
 			*/
 			select {
 			case <-doneCh:
-				client.Close()
+				client.conn.Close()
 				break DONE
 			default:
 			}
 
-			processCommand(&client.ssntpConn, cmd, ovsCh)
+			processCommand(client.conn, cmd, ovsCh)
 		}
 	}
 

--- a/ciao-launcher/network.go
+++ b/ciao-launcher/network.go
@@ -234,26 +234,26 @@ func createVnicCfg(cfg *vmConfig) (*libsnnet.VnicConfig, error) {
 	return createCNVnicCfg(cfg)
 }
 
-func sendNetworkEvent(client serverConn, eventType ssntp.Event,
+func sendNetworkEvent(conn serverConn, eventType ssntp.Event,
 	event *libsnnet.SsntpEventInfo) {
 
-	if event == nil || !client.isConnected() {
+	if event == nil || !conn.isConnected() {
 		return
 	}
 
-	payload, err := generateNetEventPayload(event, client.UUID())
+	payload, err := generateNetEventPayload(event, conn.UUID())
 	if err != nil {
 		glog.Warningf("Unable parse ssntpEvent %s", err)
 		return
 	}
 
-	_, err = client.SendEvent(eventType, payload)
+	_, err = conn.SendEvent(eventType, payload)
 	if err != nil {
 		glog.Warningf("Unable to send %s", event)
 	}
 }
 
-func createVnic(client serverConn, vnicCfg *libsnnet.VnicConfig) (string, string, error) {
+func createVnic(conn serverConn, vnicCfg *libsnnet.VnicConfig) (string, string, error) {
 	var name string
 	var bridge string
 
@@ -278,7 +278,7 @@ func createVnic(client serverConn, vnicCfg *libsnnet.VnicConfig) (string, string
 				return "", "", err
 			}
 		}
-		sendNetworkEvent(client, ssntp.TenantAdded, event)
+		sendNetworkEvent(conn, ssntp.TenantAdded, event)
 		name = vnic.LinkName
 		glog.Infoln("CN VNIC created =", name, info, event)
 	} else {
@@ -294,7 +294,7 @@ func createVnic(client serverConn, vnicCfg *libsnnet.VnicConfig) (string, string
 	return name, bridge, nil
 }
 
-func destroyVnic(client serverConn, vnicCfg *libsnnet.VnicConfig) error {
+func destroyVnic(conn serverConn, vnicCfg *libsnnet.VnicConfig) error {
 	if vnicCfg.VnicRole != libsnnet.DataCenter {
 		var event *libsnnet.SsntpEventInfo
 		var err error
@@ -309,7 +309,7 @@ func destroyVnic(client serverConn, vnicCfg *libsnnet.VnicConfig) error {
 			return err
 		}
 
-		sendNetworkEvent(client, ssntp.TenantRemoved, event)
+		sendNetworkEvent(conn, ssntp.TenantRemoved, event)
 
 		glog.Infoln("CN VNIC Destroyed =", vnicCfg.VnicIP, event)
 	} else {

--- a/ciao-launcher/network.go
+++ b/ciao-launcher/network.go
@@ -234,7 +234,7 @@ func createVnicCfg(cfg *vmConfig) (*libsnnet.VnicConfig, error) {
 	return createCNVnicCfg(cfg)
 }
 
-func sendNetworkEvent(client *ssntpConn, eventType ssntp.Event,
+func sendNetworkEvent(client serverConn, eventType ssntp.Event,
 	event *libsnnet.SsntpEventInfo) {
 
 	if event == nil || !client.isConnected() {
@@ -253,7 +253,7 @@ func sendNetworkEvent(client *ssntpConn, eventType ssntp.Event,
 	}
 }
 
-func createVnic(client *ssntpConn, vnicCfg *libsnnet.VnicConfig) (string, string, error) {
+func createVnic(client serverConn, vnicCfg *libsnnet.VnicConfig) (string, string, error) {
 	var name string
 	var bridge string
 
@@ -294,7 +294,7 @@ func createVnic(client *ssntpConn, vnicCfg *libsnnet.VnicConfig) (string, string
 	return name, bridge, nil
 }
 
-func destroyVnic(client *ssntpConn, vnicCfg *libsnnet.VnicConfig) error {
+func destroyVnic(client serverConn, vnicCfg *libsnnet.VnicConfig) error {
 	if vnicCfg.VnicRole != libsnnet.DataCenter {
 		var event *libsnnet.SsntpEventInfo
 		var err error

--- a/ciao-launcher/overseer.go
+++ b/ciao-launcher/overseer.go
@@ -360,7 +360,7 @@ func (ovs *overseer) sendStatusCommand(cns *cnStats, status ssntp.Status) {
 
 	s.Init()
 
-	s.NodeUUID = ovs.ac.ssntpConn.UUID()
+	s.NodeUUID = ovs.ac.conn.UUID()
 	s.MemTotalMB, s.MemAvailableMB = cns.totalMemMB, cns.availableMemMB
 	s.Load = cns.load
 	s.CpusOnline = cns.cpusOnline
@@ -372,7 +372,7 @@ func (ovs *overseer) sendStatusCommand(cns *cnStats, status ssntp.Status) {
 		return
 	}
 
-	_, err = ovs.ac.ssntpConn.SendStatus(status, payload)
+	_, err = ovs.ac.conn.SendStatus(status, payload)
 	if err != nil {
 		glog.Errorf("Failed to send status command %v", err)
 		return
@@ -384,7 +384,7 @@ func (ovs *overseer) sendStats(cns *cnStats, status ssntp.Status) {
 
 	s.Init()
 
-	s.NodeUUID = ovs.ac.ssntpConn.UUID()
+	s.NodeUUID = ovs.ac.conn.UUID()
 	s.Status = status.String()
 	s.MemTotalMB, s.MemAvailableMB = cns.totalMemMB, cns.availableMemMB
 	s.Load = cns.load
@@ -420,7 +420,7 @@ func (ovs *overseer) sendStats(cns *cnStats, status ssntp.Status) {
 		return
 	}
 
-	_, err = ovs.ac.ssntpConn.SendCommand(ssntp.STATS, payload)
+	_, err = ovs.ac.conn.SendCommand(ssntp.STATS, payload)
 	if err != nil {
 		glog.Errorf("Failed to send stats command %v", err)
 		return
@@ -453,7 +453,7 @@ func (ovs *overseer) sendTraceReport() {
 		return
 	}
 
-	_, err = ovs.ac.ssntpConn.SendEvent(ssntp.TraceReport, payload)
+	_, err = ovs.ac.conn.SendEvent(ssntp.TraceReport, payload)
 	if err != nil {
 		glog.Errorf("Failed to send TraceReport event %v", err)
 		return
@@ -482,7 +482,7 @@ func (ovs *overseer) sendInstanceDeletedEvent(instance string) {
 		return
 	}
 
-	_, err = ovs.ac.ssntpConn.SendEvent(ssntp.InstanceDeleted, payload)
+	_, err = ovs.ac.conn.SendEvent(ssntp.InstanceDeleted, payload)
 	if err != nil {
 		glog.Errorf("Failed to send event command %v", err)
 		return
@@ -564,7 +564,7 @@ func (ovs *overseer) processRemoveCommand(cmd *ovsRemoveCmd) {
 
 func (ovs *overseer) processStatusCommand(cmd *ovsStatusCmd) {
 	glog.Info("Overseer: Recieved Status Command")
-	if !ovs.ac.ssntpConn.isConnected() {
+	if !ovs.ac.conn.isConnected() {
 		return
 	}
 	cns := getStats()
@@ -574,7 +574,7 @@ func (ovs *overseer) processStatusCommand(cmd *ovsStatusCmd) {
 
 func (ovs *overseer) processStatsStatusCommand(cmd *ovsStatsStatusCmd) {
 	glog.Info("Overseer: Recieved StatsStatus Command")
-	if !ovs.ac.ssntpConn.isConnected() {
+	if !ovs.ac.conn.isConnected() {
 		return
 	}
 	cns := getStats()
@@ -646,7 +646,7 @@ DONE:
 			}
 			ovs.processCommand(cmd)
 		case <-statsTimer:
-			if !ovs.ac.ssntpConn.isConnected() {
+			if !ovs.ac.conn.isConnected() {
 				statsTimer = time.After(time.Second * statsPeriod)
 				continue
 			}

--- a/ciao-launcher/restart.go
+++ b/ciao-launcher/restart.go
@@ -29,7 +29,7 @@ type restartError struct {
 	code payloads.RestartFailureReason
 }
 
-func (re *restartError) send(client *ssntpConn, instance string) {
+func (re *restartError) send(client serverConn, instance string) {
 	if !client.isConnected() {
 		return
 	}
@@ -46,7 +46,7 @@ func (re *restartError) send(client *ssntpConn, instance string) {
 	}
 }
 
-func processRestart(instanceDir string, vm virtualizer, client *ssntpConn, cfg *vmConfig) *restartError {
+func processRestart(instanceDir string, vm virtualizer, client serverConn, cfg *vmConfig) *restartError {
 	var vnicName string
 	var vnicCfg *libsnnet.VnicConfig
 	var err error

--- a/ciao-launcher/restart.go
+++ b/ciao-launcher/restart.go
@@ -29,8 +29,8 @@ type restartError struct {
 	code payloads.RestartFailureReason
 }
 
-func (re *restartError) send(client serverConn, instance string) {
-	if !client.isConnected() {
+func (re *restartError) send(conn serverConn, instance string) {
+	if !conn.isConnected() {
 		return
 	}
 
@@ -40,13 +40,13 @@ func (re *restartError) send(client serverConn, instance string) {
 		return
 	}
 
-	_, err = client.SendError(ssntp.RestartFailure, payload)
+	_, err = conn.SendError(ssntp.RestartFailure, payload)
 	if err != nil {
 		glog.Errorf("Unable to send restart_failure: %v", err)
 	}
 }
 
-func processRestart(instanceDir string, vm virtualizer, client serverConn, cfg *vmConfig) *restartError {
+func processRestart(instanceDir string, vm virtualizer, conn serverConn, cfg *vmConfig) *restartError {
 	var vnicName string
 	var vnicCfg *libsnnet.VnicConfig
 	var err error
@@ -57,7 +57,7 @@ func processRestart(instanceDir string, vm virtualizer, client serverConn, cfg *
 			glog.Errorf("Could not create VnicCFG: %s", err)
 			return &restartError{err, payloads.RestartInstanceCorrupt}
 		}
-		vnicName, _, err = createVnic(client, vnicCfg)
+		vnicName, _, err = createVnic(conn, vnicCfg)
 		if err != nil {
 			return &restartError{err, payloads.RestartNetworkFailure}
 		}

--- a/ciao-launcher/start.go
+++ b/ciao-launcher/start.go
@@ -43,7 +43,7 @@ type startTimes struct {
 	runStamp          time.Time
 }
 
-func (se *startError) send(client *ssntpConn, instance string) {
+func (se *startError) send(client serverConn, instance string) {
 	if !client.isConnected() {
 		return
 	}
@@ -127,7 +127,7 @@ func createInstance(vm virtualizer, instanceDir string, cfg *vmConfig, bridge st
 	return
 }
 
-func processStart(cmd *insStartCmd, instanceDir string, vm virtualizer, client *ssntpConn) (*startTimes, *startError) {
+func processStart(cmd *insStartCmd, instanceDir string, vm virtualizer, client serverConn) (*startTimes, *startError) {
 	var err error
 	var vnicName string
 	var bridge string

--- a/ciao-launcher/start.go
+++ b/ciao-launcher/start.go
@@ -43,8 +43,8 @@ type startTimes struct {
 	runStamp          time.Time
 }
 
-func (se *startError) send(client serverConn, instance string) {
-	if !client.isConnected() {
+func (se *startError) send(conn serverConn, instance string) {
+	if !conn.isConnected() {
 		return
 	}
 
@@ -54,7 +54,7 @@ func (se *startError) send(client serverConn, instance string) {
 		return
 	}
 
-	_, err = client.SendError(ssntp.StartFailure, payload)
+	_, err = conn.SendError(ssntp.StartFailure, payload)
 	if err != nil {
 		glog.Errorf("Unable to send start_failure: %v", err)
 	}
@@ -127,7 +127,7 @@ func createInstance(vm virtualizer, instanceDir string, cfg *vmConfig, bridge st
 	return
 }
 
-func processStart(cmd *insStartCmd, instanceDir string, vm virtualizer, client serverConn) (*startTimes, *startError) {
+func processStart(cmd *insStartCmd, instanceDir string, vm virtualizer, conn serverConn) (*startTimes, *startError) {
 	var err error
 	var vnicName string
 	var bridge string
@@ -171,7 +171,7 @@ func processStart(cmd *insStartCmd, instanceDir string, vm virtualizer, client s
 	st.backingImageCheck = time.Now()
 
 	if vnicCfg != nil {
-		vnicName, bridge, err = createVnic(client, vnicCfg)
+		vnicName, bridge, err = createVnic(conn, vnicCfg)
 		if err != nil {
 			return nil, &startError{err, payloads.NetworkFailure}
 		}

--- a/ciao-launcher/stop.go
+++ b/ciao-launcher/stop.go
@@ -27,7 +27,7 @@ type stopError struct {
 	code payloads.StopFailureReason
 }
 
-func (se *stopError) send(client *ssntpConn, instance string) {
+func (se *stopError) send(client serverConn, instance string) {
 	if !client.isConnected() {
 		return
 	}

--- a/ciao-launcher/stop.go
+++ b/ciao-launcher/stop.go
@@ -27,8 +27,8 @@ type stopError struct {
 	code payloads.StopFailureReason
 }
 
-func (se *stopError) send(client serverConn, instance string) {
-	if !client.isConnected() {
+func (se *stopError) send(conn serverConn, instance string) {
+	if !conn.isConnected() {
 		return
 	}
 
@@ -38,7 +38,7 @@ func (se *stopError) send(client serverConn, instance string) {
 		return
 	}
 
-	_, err = client.SendError(ssntp.StopFailure, payload)
+	_, err = conn.SendError(ssntp.StopFailure, payload)
 	if err != nil {
 		glog.Errorf("Unable to send stop_failure: %v", err)
 	}


### PR DESCRIPTION
These commits add some unit tests to the instanceLoop go routine.  The tests work by using channels and interfaces to fake the overseer and the connection to the SSNTP server, allowing us to fully test the instanceLoop.  A few small changes were needed to the launcher code to permit this.  The travis build file also needed to be changed to pre-create the /var/lib/ciao/instances directory.  Doing this in the travis files allows the launcher unit tests to run as non-root.

This commit should bring the test coverage of launcher up to 16.2%.