### PR TITLE
travis:  Enable gofmt, misspell, gocylco and ineffassign

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ before_install:
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/pierrre/gotestcover
+  - go get github.com/fzipp/gocyclo
+  - go get github.com/gordonklaus/ineffassign
 
 # We need to create and install SSNTP certs for the SSNTP and controller tests
 before_script:
@@ -51,6 +53,10 @@ script:
    - go list ./... | grep -v vendor | xargs -t go vet
 #  - go list ./... | grep -v vendor | xargs -tL 1 golint -set_exit_status
    - if [[ "$TRAVIS_GO_VERSION" != "tip" ]] ; then go list ./... | grep -v vendor | xargs -tL 1 golint -set_exit_status ; fi
+   - go list ./... | grep -v vendor | xargs go list -f '{{.Dir}}/*.go' | xargs -I % bash -c "misspell -error %"
+   - go list ./... | grep -v vendor | xargs go list -f '{{.Dir}}' | xargs gocyclo -over 15
+   - go list ./... | grep -v vendor | xargs go list -f '{{.Dir}}' | xargs -L 1 ineffassign
+   - go list ./... | grep -v vendor | xargs go list -f '{{.Dir}}' | xargs gofmt -s -l | wc -l | xargs -I % bash -c "test % -eq 0"
    - sudo mkdir -p /var/lib/ciao/instances
    - sudo chmod 0777 /var/lib/ciao/instances
    - test-cases -text -coverprofile /tmp/cover.out -short github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/ciao-controller/... github.com/01org/ciao/payloads


### PR DESCRIPTION
Run gofmt -s, misspell, gocyclo and ineffassign as part of the travis
builds.  Any build that introduces an error detected by one of these
tools should now fail.  This should ensure that our goreportcard
score never falls below 100%.

Fixes #172

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>