### PR TITLE
ciao-vendor: Add uses command and update gophercloud

### DIFF
--- a/ciao-vendor/ciao-vendor.go
+++ b/ciao-vendor/ciao-vendor.go
@@ -93,7 +93,7 @@ var repos = map[string]repoInfo{
 	"github.com/mattn/go-sqlite3":       {"https://github.com/mattn/go-sqlite3.git", "467f50b", "MIT + Public domain"},
 	"github.com/mitchellh/mapstructure": {"https://github.com/mitchellh/mapstructure.git", "d2dd026", "MIT"},
 	"github.com/opencontainers/runc":    {"https://github.com/opencontainers/runc.git", "v0.1.0", "Apache v2.0"},
-	"github.com/rackspace/gophercloud":  {"https://github.com/rackspace/gophercloud.git", "c54bbac", "Apache v2.0"},
+	"github.com/rackspace/gophercloud":  {"https://github.com/rackspace/gophercloud.git", "67139b9", "Apache v2.0"},
 	"github.com/tylerb/graceful":        {"https://github.com/tylerb/graceful.git", "9a3d423", "MIT"},
 	"github.com/vishvananda/netlink":    {"https://github.com/vishvananda/netlink.git", "a632d6d", "Apache v2.0"},
 	"golang.org/x/net":                  {"https://go.googlesource.com/net", "origin/release-branch.go1.6", "BSD (3 clause)"},

--- a/test-cases/test-cases.go
+++ b/test-cases/test-cases.go
@@ -220,7 +220,8 @@ func parseTestFile(filePath string) ([]*TestInfo, error) {
 func extractTests(packages []PackageInfo) []*PackageTests {
 	pts := make([]*PackageTests, 0, len(packages))
 	for _, p := range packages {
-		if len(p.Files) == 0 || strings.Contains(p.Name, "/vendor/") {
+		if ((len(p.Files) == 0) && (len(p.XFiles) == 0)) ||
+			strings.Contains(p.Name, "/vendor/") {
 			continue
 		}
 		packageTest := &PackageTests{

--- a/vendor/github.com/rackspace/gophercloud/openstack/client.go
+++ b/vendor/github.com/rackspace/gophercloud/openstack/client.go
@@ -281,6 +281,29 @@ func NewBlockStorageV1(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 	return &gophercloud.ServiceClient{ProviderClient: client, Endpoint: url}, nil
 }
 
+// NewBlockStorageV2 creates a ServiceClient that may be used to access the v2 block storage service.
+func NewBlockStorageV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	eo.ApplyDefaults("volume")
+	url, err := client.EndpointLocator(eo)
+	if err != nil {
+		return nil, err
+	}
+
+	// Force using v2 API
+	if strings.Contains(url, "/v1") {
+		url = strings.Replace(url, "/v1", "/v2", -1)
+	}
+	if !strings.Contains(url, "/v2") {
+		return nil, fmt.Errorf("Block Storage v2 endpoint not found")
+	}
+
+	return &gophercloud.ServiceClient{
+		ProviderClient: client,
+		Endpoint:       url,
+		ResourceBase:   url,
+	}, nil
+}
+
 // NewCDNV1 creates a ServiceClient that may be used to access the OpenStack v1
 // CDN service.
 func NewCDNV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {

--- a/vendor/github.com/rackspace/gophercloud/pagination/pager.go
+++ b/vendor/github.com/rackspace/gophercloud/pagination/pager.go
@@ -138,6 +138,11 @@ func (p Pager) AllPages() (Page, error) {
 	// that type.
 	pageType := reflect.TypeOf(testPage)
 
+	// if it's a single page, just return the testPage (first page)
+	if _, found := pageType.FieldByName("SinglePageBase"); found {
+		return testPage, nil
+	}
+
 	// Switch on the page body type. Recognized types are `map[string]interface{}`,
 	// `[]byte`, and `[]interface{}`.
 	switch testPage.GetBody().(type) {
@@ -153,7 +158,14 @@ func (p Pager) AllPages() (Page, error) {
 					key = k
 				}
 			}
-			pagesSlice = append(pagesSlice, b[key].([]interface{})...)
+			switch keyType := b[key].(type) {
+			case map[string]interface{}:
+				pagesSlice = append(pagesSlice, keyType)
+			case []interface{}:
+				pagesSlice = append(pagesSlice, b[key].([]interface{})...)
+			default:
+				return false, fmt.Errorf("Unsupported page body type: %+v", keyType)
+			}
 			return true, nil
 		})
 		if err != nil {


### PR DESCRIPTION
This commit updates gophercloud to 67139b9.  The ciao-vendor tool has also been enhanced.  A new command called 'uses' has been added.  This allows the user to determine which of ciao's dependencies, including ciao itself, uses a given package.  It's important to know this when updating a vendored package as there may be complications if that package is used by more than one of ciao's dependencies. 