### PR TITLE
Topic/singlevm: Single VM Development and Test Environment Support

### DIFF
--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -110,7 +110,8 @@ func main() {
 	}
 
 	if *singleMachine {
-		computeURL := "https://localhost:" + strconv.Itoa(*computeAPIPort)
+		hostname, _ := os.Hostname()
+		computeURL := "https://"+hostname+":" + strconv.Itoa(*computeAPIPort)
 		testIdentityConfig := testutil.TestIdentityConfig{
 			ComputeURL: computeURL,
 			ProjectID:  "f452bbc7-5076-44d5-922c-3b9d2ce1503f",
@@ -119,6 +120,11 @@ func main() {
 		id := testutil.StartIdentityTestServer(testIdentityConfig)
 		defer id.Close()
 		*identityURL = id.URL
+		glog.Errorf("========================")
+		glog.Errorf("Identity URL: %s", id.URL)
+		glog.Errorf("Please")
+		glog.Errorf("export CIAO_IDENTITY=%s", id.URL)
+		glog.Errorf("========================")
 	}
 
 	idConfig := identityConfig{

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -18,13 +18,14 @@ package main
 
 import (
 	"flag"
+	"os"
+	"strconv"
+	"sync"
+
 	datastore "github.com/01org/ciao/ciao-controller/internal/datastore"
 	"github.com/01org/ciao/ssntp"
 	"github.com/01org/ciao/testutil"
 	"github.com/golang/glog"
-	"os"
-	"strconv"
-	"sync"
 )
 
 type controller struct {
@@ -111,7 +112,7 @@ func main() {
 
 	if *singleMachine {
 		hostname, _ := os.Hostname()
-		computeURL := "https://"+hostname+":" + strconv.Itoa(*computeAPIPort)
+		computeURL := "https://" + hostname + ":" + strconv.Itoa(*computeAPIPort)
 		testIdentityConfig := testutil.TestIdentityConfig{
 			ComputeURL: computeURL,
 			ProjectID:  "f452bbc7-5076-44d5-922c-3b9d2ce1503f",

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -46,8 +46,8 @@ func (f *networkFlag) String() string {
 }
 
 func (f *networkFlag) Set(val string) error {
-	if val != "none" && val != "cn" && val != "nn" {
-		return fmt.Errorf("none, cn or nn expected")
+	if val != "none" && val != "cn" && val != "nn" && val != "dual" {
+		return fmt.Errorf("none, cn, nn or dual expected")
 	}
 	*f = networkFlag(val)
 
@@ -60,6 +60,10 @@ func (f *networkFlag) Enabled() bool {
 
 func (f *networkFlag) NetworkNode() bool {
 	return string(*f) == "nn"
+}
+
+func (f *networkFlag) DualMode() bool {
+	return string(*f) == "dual"
 }
 
 type uiFlag string
@@ -323,6 +327,17 @@ func connectToServer(doneCh chan struct{}, statusCh chan struct{}) {
 	}()
 
 	var wg sync.WaitGroup
+
+	var role ssntp.Role
+	if networking.NetworkNode() {
+		role = ssntp.NETAGENT
+	} else if networking.DualMode() {
+		role = ssntp.AGENT | ssntp.NETAGENT
+	} else {
+		role = ssntp.AGENT
+	}
+
+	glog.Infof("Agent Role: %s", role.String())
 
 	cfg := &ssntp.Config{URI: serverURL, CAcert: serverCertPath, Cert: clientCertPath,
 		Log: ssntp.Log}

--- a/testutil/identity.go
+++ b/testutil/identity.go
@@ -218,11 +218,40 @@ func validateHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(t)
 }
 
+func projectsHandler(w http.ResponseWriter, r *http.Request) {
+	response := `
+	{
+		"projects": [
+			{
+				"description": "fake project1",
+				"domain_id": "default",
+				"enabled": true,
+				"id": "456788",
+				"parent_id": "212223",
+				"links": {
+					"self": "%s/v3/projects/456788"
+				},
+				"name": "ilovepuppies"
+			}
+		],
+		"links": {
+			"self": "%s/v3/users/10a2e6e717a245d9acad3e5f97aeca3d/projects",
+			"previous": null,
+			"next": null
+		}
+	}`
+
+	p := []byte(fmt.Sprintf(response, testIdentityURL, testIdentityURL))
+	w.WriteHeader(http.StatusOK)
+	w.Write(p)
+}
+
 func identityHandlers() *mux.Router {
 	r := mux.NewRouter()
 
 	r.HandleFunc("/v3/auth/tokens", authHandler).Methods("POST")
 	r.HandleFunc("/v3/auth/tokens", validateHandler).Methods("GET")
+	r.HandleFunc("/v3/users/10a2e6e717a245d9acad3e5f97aeca3d/projects", projectsHandler).Methods("GET")
 
 	return r
 }


### PR DESCRIPTION
This PR includes all the changes required in launcher, controller, fake keystone services required to run ciao in a single vm as described in https://github.com/01org/ciao/issues/125

However this PR does not includes the changes required in the scheduler. This should not cause any issues to existing functionality. How to completely implement the Single VM setup the scheduler code needs to support dual role launchers.