### PR TITLE
Fix static analysis issues with ciao-vendor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,14 +49,14 @@ script:
    - sudo ip addr add 198.51.100.1/24 dev testdummy
    - go get github.com/google/gofuzz github.com/stretchr/testify
    - go get github.com/golang/lint/golint github.com/client9/misspell/cmd/misspell
-   - go list ./... | grep -v vendor | xargs -t misspell
-   - go list ./... | grep -v vendor | xargs -t go vet
-#  - go list ./... | grep -v vendor | xargs -tL 1 golint -set_exit_status
-   - if [[ "$TRAVIS_GO_VERSION" != "tip" ]] ; then go list ./... | grep -v vendor | xargs -tL 1 golint -set_exit_status ; fi
-   - go list ./... | grep -v vendor | xargs go list -f '{{.Dir}}/*.go' | xargs -I % bash -c "misspell -error %"
-   - go list ./... | grep -v vendor | xargs go list -f '{{.Dir}}' | xargs gocyclo -over 15
-   - go list ./... | grep -v vendor | xargs go list -f '{{.Dir}}' | xargs -L 1 ineffassign
-   - go list ./... | grep -v vendor | xargs go list -f '{{.Dir}}' | xargs gofmt -s -l | wc -l | xargs -I % bash -c "test % -eq 0"
+   - go list ./... | grep -v github.com/01org/ciao/vendor | xargs -t misspell
+   - go list ./... | grep -v github.com/01org/ciao/vendor | xargs -t go vet
+#  - go list ./... | grep -v github.com/01org/ciao/vendor | xargs -tL 1 golint -set_exit_status
+   - if [[ "$TRAVIS_GO_VERSION" != "tip" ]] ; then go list ./... | grep -v github.com/01org/ciao/vendor | xargs -tL 1 golint -set_exit_status ; fi
+   - go list ./... | grep -v github.com/01org/ciao/vendor | xargs go list -f '{{.Dir}}/*.go' | xargs -I % bash -c "misspell -error %"
+   - go list ./... | grep -v github.com/01org/ciao/vendor | xargs go list -f '{{.Dir}}' | xargs gocyclo -over 15
+   - go list ./... | grep -v github.com/01org/ciao/vendor | xargs go list -f '{{.Dir}}' | xargs -L 1 ineffassign
+   - go list ./... | grep -v github.com/01org/ciao/vendor | xargs go list -f '{{.Dir}}' | xargs gofmt -s -l | wc -l | xargs -I % bash -c "test % -eq 0"
    - sudo mkdir -p /var/lib/ciao/instances
    - sudo chmod 0777 /var/lib/ciao/instances
    - test-cases -text -coverprofile /tmp/cover.out -short github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/ciao-controller/... github.com/01org/ciao/payloads

--- a/ciao-vendor/ciao-vendor.go
+++ b/ciao-vendor/ciao-vendor.go
@@ -859,6 +859,26 @@ func uses(pkg string, projectRoot string) error {
 	return nil
 }
 
+func runCommand(cwd, sourceRoot string, args []string) error {
+	var err error
+
+	projectRoot := cwd[len(sourceRoot)+1:]
+	switch args[1] {
+	case "check":
+		err = check(cwd, projectRoot)
+	case "vendor":
+		err = vendor(cwd, projectRoot, sourceRoot)
+	case "deps":
+		err = deps(projectRoot)
+	case "packages":
+		err = packages(cwd, projectRoot)
+	case "uses":
+		err = uses(args[2], projectRoot)
+	}
+
+	return err
+}
+
 func main() {
 	if !((len(os.Args) == 2 &&
 		(os.Args[1] == "vendor" || os.Args[1] == "check" || os.Args[1] == "deps" ||
@@ -878,20 +898,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "Could not determine project root")
 		os.Exit(1)
 	}
-	projectRoot := cwd[len(sourceRoot)+1:]
-
-	switch os.Args[1] {
-	case "check":
-		err = check(cwd, projectRoot)
-	case "vendor":
-		err = vendor(cwd, projectRoot, sourceRoot)
-	case "deps":
-		err = deps(projectRoot)
-	case "packages":
-		err = packages(cwd, projectRoot)
-	case "uses":
-		err = uses(os.Args[2], projectRoot)
-	}
+	err = runCommand(cwd, sourceRoot, os.Args)
 
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
This PR fixes two issues #197  and #198.  PR #194 managed to introduce a gocyclo error as the .travis.yml file was not running the static analysis tools on ciao-vendor.  This patch fixes the gocyclo error and the .travis.yml file.