### PR TITLE
ciao-controller: Use specific constructors for compute structures

### DIFF
--- a/ciao-controller/compute.go
+++ b/ciao-controller/compute.go
@@ -107,7 +107,7 @@ func pagerQueryParse(r *http.Request) (int, int, string) {
 }
 
 func (pager *serverPager) getInstances(filterType pagerFilterType, filter string, instances []*types.Instance, limit int, offset int) ([]byte, error) {
-	var servers payloads.ComputeServers
+	servers := payloads.NewComputeServers()
 
 	servers.TotalServers = len(instances)
 	pageLength := 0
@@ -192,7 +192,7 @@ type nodePager struct {
 }
 
 func (pager *nodePager) getNodes(filterType pagerFilterType, filter string, nodes []payloads.CiaoComputeNode, limit int, offset int) ([]byte, error) {
-	var computeNodes payloads.CiaoComputeNodes
+	computeNodes := payloads.NewCiaoComputeNodes()
 
 	pageLength := 0
 
@@ -261,7 +261,7 @@ type nodeServerPager struct {
 
 func (pager *nodeServerPager) getNodeServers(filterType pagerFilterType, filter string, instances []payloads.CiaoServerStats,
 	limit int, offset int) ([]byte, error) {
-	var servers payloads.CiaoServersStats
+	servers := payloads.NewCiaoServersStats()
 
 	servers.TotalServers = len(instances)
 	pageLength := 0
@@ -551,7 +551,7 @@ func buildFlavorDetails(workload *types.Workload) (payloads.FlavorDetails, error
 }
 
 func listFlavors(w http.ResponseWriter, r *http.Request, context *controller) {
-	var flavors payloads.ComputeFlavors
+	flavors := payloads.NewComputeFlavors()
 
 	dumpRequest(r)
 
@@ -591,7 +591,7 @@ func listFlavors(w http.ResponseWriter, r *http.Request, context *controller) {
 
 func listFlavorsDetails(w http.ResponseWriter, r *http.Request, context *controller) {
 	var details payloads.FlavorDetails
-	var flavors payloads.ComputeFlavorsDetails
+	flavors := payloads.NewComputeFlavorsDetails()
 
 	dumpRequest(r)
 
@@ -1350,7 +1350,7 @@ func listEvents(w http.ResponseWriter, r *http.Request, context *controller) {
 	vars := mux.Vars(r)
 	tenant := vars["tenant"]
 
-	var events payloads.CiaoEvents
+	events := payloads.NewCiaoEvents()
 
 	if validateToken(context, r) == false {
 		http.Error(w, "Invalid token", http.StatusInternalServerError)

--- a/ciao-controller/compute_test.go
+++ b/ciao-controller/compute_test.go
@@ -93,7 +93,7 @@ func testCreateServer(t *testing.T, n int) payloads.ComputeServers {
 
 	body := testHTTPRequest(t, "POST", url, http.StatusAccepted, b)
 
-	var servers payloads.ComputeServers
+	servers := payloads.NewComputeServers()
 
 	err = json.Unmarshal(body, &servers)
 	if err != nil {
@@ -112,7 +112,7 @@ func testListServerDetailsTenant(t *testing.T, tenantID string) payloads.Compute
 
 	body := testHTTPRequest(t, "GET", url, http.StatusOK, nil)
 
-	var s payloads.ComputeServers
+	s := payloads.NewComputeServers()
 	err := json.Unmarshal(body, &s)
 	if err != nil {
 		t.Fatal(err)
@@ -206,6 +206,7 @@ func TestShowServerDetails(t *testing.T) {
 
 		if reflect.DeepEqual(s1, s2.Server) == false {
 			t.Fatal("Server details not correct")
+			//t.Fatalf("Server details not correct %s %s", s1, s2.Server)
 		}
 	}
 }
@@ -592,7 +593,7 @@ func TestListEventsTenant(t *testing.T) {
 
 	url := computeURL + "/v2.1/" + tenant.ID + "/events"
 
-	var expected payloads.CiaoEvents
+	expected := payloads.NewCiaoEvents()
 
 	logs, err := context.ds.GetEventLog()
 	if err != nil {
@@ -663,7 +664,7 @@ func TestListTenants(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var expected payloads.CiaoComputeTenants
+	expected := payloads.NewCiaoComputeTenants()
 
 	for _, tenant := range tenants {
 		expected.Tenants = append(expected.Tenants,
@@ -913,7 +914,7 @@ func TestListTraces(t *testing.T) {
 func TestListEvents(t *testing.T) {
 	url := computeURL + "/v2.1/events"
 
-	var expected payloads.CiaoEvents
+	expected := payloads.NewCiaoEvents()
 
 	logs, err := context.ds.GetEventLog()
 	if err != nil {

--- a/payloads/compute.go
+++ b/payloads/compute.go
@@ -115,6 +115,15 @@ type ComputeServers struct {
 	Servers      []Server `json:"servers"`
 }
 
+// NewComputeServers allocates a ComputeServers structure.
+// It allocates the Servers slice as well so that the marshalled
+// JSON is an empty array and not a nil pointer for, as
+// specified by the OpenStack APIs.
+func NewComputeServers() (servers ComputeServers) {
+	servers.Servers = []Server{}
+	return
+}
+
 // ComputeServer represents the unmarshalled version of the contents of a
 // /v2.1/{tenant}/servers/{server} response.  It contains information about a
 // specific instance within a ciao cluster.
@@ -131,6 +140,19 @@ type ComputeFlavors struct {
 		Links []Link `json:"links"`
 		Name  string `json:"name"`
 	} `json:"flavors"`
+}
+
+// NewComputeFlavors allocates a ComputeFlavors structure.
+// It allocates the Flavors slice as well so that the marshalled
+// JSON is an empty array and not a nil pointer, as specified
+// by the OpenStack APIs.
+func NewComputeFlavors() (flavors ComputeFlavors) {
+	flavors.Flavors = []struct {
+		ID    string `json:"id"`
+		Links []Link `json:"links"`
+		Name  string `json:"name"`
+	}{}
+	return
 }
 
 // FlavorDetails contains information about a specific flavor.
@@ -161,6 +183,15 @@ type ComputeFlavorsDetails struct {
 	Flavors []FlavorDetails `json:"flavors"`
 }
 
+// NewComputeFlavorsDetails allocates a ComputeFlavorsDetails structure.
+// It allocates the Flavors slice as well so that the marshalled
+// JSON is an empty array and not a nil pointer, as specified by the
+// OpenStack APIs.
+func NewComputeFlavorsDetails() (flavors ComputeFlavorsDetails) {
+	flavors.Flavors = []FlavorDetails{}
+	return
+}
+
 // ComputeCreateServer represents the unmarshalled version of the contents of a
 // /v2.1/{tenant}/servers request.  It contains the information needed to start
 // one or more instances.
@@ -182,6 +213,18 @@ type CiaoComputeTenants struct {
 		ID   string `json:"id"`
 		Name string `json:"name"`
 	} `json:"tenants"`
+}
+
+// NewCiaoComputeTenants allocates a CiaoComputeTenants structure.
+// It allocates the Tenants slice as well so that the marshalled
+// JSON is an empty array and not a nil pointer, as specified by the
+// OpenStack APIs.
+func NewCiaoComputeTenants() (tenants CiaoComputeTenants) {
+	tenants.Tenants = []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}{}
+	return
 }
 
 // CiaoComputeNode contains status and statistic information for an individual
@@ -207,6 +250,15 @@ type CiaoComputeNode struct {
 // for a set of nodes.
 type CiaoComputeNodes struct {
 	Nodes []CiaoComputeNode `json:"nodes"`
+}
+
+// NewCiaoComputeNodes allocates a CiaoComputeNodes structure.
+// It allocates the Nodes slice as well so that the marshalled
+// JSON is an empty array and not a nil pointer, as specified by the
+// OpenStack APIs.
+func NewCiaoComputeNodes() (nodes CiaoComputeNodes) {
+	nodes.Nodes = []CiaoComputeNode{}
+	return
 }
 
 // CiaoTenantResources represents the unmarshalled version of the contents of a
@@ -267,6 +319,15 @@ type CiaoCNCIs struct {
 	CNCIs []CiaoCNCI `json:"cncis"`
 }
 
+// NewCiaoCNCIs allocates a CiaoCNCIs structure.
+// It allocates the CNCIs slice as well so that the marshalled
+// JSON is an empty array and not a nil pointer, as specified by the
+// OpenStack APIs.
+func NewCiaoCNCIs() (cncis CiaoCNCIs) {
+	cncis.CNCIs = []CiaoCNCI{}
+	return
+}
+
 // CiaoServerStats contains status information about a CN or a NN.
 type CiaoServerStats struct {
 	ID        string    `json:"id"`
@@ -286,6 +347,15 @@ type CiaoServerStats struct {
 type CiaoServersStats struct {
 	TotalServers int               `json:"total_servers"`
 	Servers      []CiaoServerStats `json:"servers"`
+}
+
+// NewCiaoServersStats allocates a CiaoServersStats structure.
+// It allocates the Servers slice as well so that the marshalled
+// JSON is an empty array and not a nil pointer, as specified by the
+// OpenStack APIs.
+func NewCiaoServersStats() (servers CiaoServersStats) {
+	servers.Servers = []CiaoServerStats{}
+	return
 }
 
 // CiaoClusterStatus represents the unmarshalled version of the contents of a
@@ -370,4 +440,13 @@ type CiaoEvent struct {
 // v2.1/{tenant}/event or v2.1/event request.
 type CiaoEvents struct {
 	Events []CiaoEvent `json:"events"`
+}
+
+// NewCiaoEvents allocates a CiaoEvents structure.
+// It allocates the Events slice as well so that the marshalled
+// JSON is an empty array and not a nil pointer, as specified by the
+// OpenStack APIs.
+func NewCiaoEvents() (events CiaoEvents) {
+	events.Events = []CiaoEvent{}
+	return
 }


### PR DESCRIPTION
We need to allocate compute structure slices so that JSON
marshalling produces an empty slice and not a nil pointer
when they represent empty lists.

Fixes #166

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>