### PR TITLE
ssntp: Add SSNTP Frame Origin field

### DIFF
--- a/ssntp/example_server_test.go
+++ b/ssntp/example_server_test.go
@@ -63,8 +63,6 @@ func (server *ssntpDumpServer) ErrorNotify(uuid string, error Error, frame *Fram
 	fmt.Printf("%s: ERROR (%s) from %s\n", server.name, error, uuid)
 }
 
-const agentUUID = "3390740c-dce9-48d6-b83a-a717417072ce"
-
 func (server *ssntpDumpServer) CommandForward(uuid string, command Command, frame *Frame) (dest ForwardDestination) {
 	dest.AddRecipient(agentUUID)
 

--- a/ssntp/frame.go
+++ b/ssntp/frame.go
@@ -62,10 +62,17 @@ type FrameTrace struct {
 
 // Frame represents an SSNTP frame structure.
 type Frame struct {
-	Major         uint8
-	Minor         uint8
-	Type          Type
-	Operand       uint8
+	Major   uint8
+	Minor   uint8
+	Type    Type
+	Operand uint8
+
+	// Origin is the frame first sender and creator UUID.
+	// When a SSNTP frame is forwarded by a server, the client
+	// then only sees a new frame coming but it can not tell
+	// who the frame creator and first sender is. This method
+	// allows to fetch such information from a frame.
+	Origin        uuid.UUID
 	PayloadLength uint32
 	Trace         *FrameTrace
 	Payload       []byte
@@ -158,12 +165,12 @@ func (f Frame) String() string {
 			path = path + fmt.Sprintf("\n\t\tNode #%d\n\t\tUUID %s\n", i, node) + ts
 		}
 
-		return fmt.Sprintf("\n\tMajor %d\n\tMinor %d\n\tType %s\n\tOp %s\n\tPayload len %d\n\tPath %s\n",
-			f.major(), f.Minor, t, op, f.PayloadLength, path)
+		return fmt.Sprintf("\n\tMajor %d\n\tMinor %d\n\tType %s\n\tOp %s\n\tOrigin %s\n\tPayload len %d\n\tPath %s\n",
+			f.major(), f.Minor, t, op, f.Origin, f.PayloadLength, path)
 	}
 
-	return fmt.Sprintf("\n\tMajor %d\n\tMinor %d\n\tType %s\n\tOp %s\n\tPayload len %d\n",
-		f.major(), f.Minor, t, op, f.PayloadLength)
+	return fmt.Sprintf("\n\tMajor %d\n\tMinor %d\n\tType %s\n\tOp %s\n\tOrigin %s\n\tPayload len %d\n",
+		f.major(), f.Minor, t, op, f.Origin, f.PayloadLength)
 }
 
 func (f ConnectFrame) String() string {

--- a/ssntp/session.go
+++ b/ssntp/session.go
@@ -111,6 +111,7 @@ func (session *session) commandFrame(cmd Command, payload []byte, trace *TraceCo
 		Minor:         minor,
 		Type:          COMMAND,
 		Operand:       byte(cmd),
+		Origin:        session.src,
 		PayloadLength: (uint32)(len(payload)),
 		Payload:       payload,
 	}
@@ -127,6 +128,7 @@ func (session *session) statusFrame(status Status, payload []byte, trace *TraceC
 		Minor:         minor,
 		Type:          STATUS,
 		Operand:       byte(status),
+		Origin:        session.src,
 		PayloadLength: (uint32)(len(payload)),
 		Payload:       payload,
 	}
@@ -143,6 +145,7 @@ func (session *session) eventFrame(event Event, payload []byte, trace *TraceConf
 		Minor:         minor,
 		Type:          EVENT,
 		Operand:       byte(event),
+		Origin:        session.src,
 		PayloadLength: (uint32)(len(payload)),
 		Payload:       payload,
 	}
@@ -159,6 +162,7 @@ func (session *session) errorFrame(error Error, payload []byte, trace *TraceConf
 		Minor:         minor,
 		Type:          ERROR,
 		Operand:       byte(error),
+		Origin:        session.src,
 		PayloadLength: (uint32)(len(payload)),
 		Payload:       payload,
 	}


### PR DESCRIPTION
Origin tracks the first creator and sender of an SSNTP frame.
This allows for any frame receiver to track who the first sender is, even across SSNTP forwarding.

No significant throughput regressions were identified with this new field added to the SSNTP frames.