### PR TITLE
ssntp: make Role a more opaque type

### DIFF
--- a/ciao-cert/main.go
+++ b/ciao-cert/main.go
@@ -123,27 +123,27 @@ func pemBlockForKey(priv interface{}) *pem.Block {
 }
 
 func addOIDs(role ssntp.Role, oids []asn1.ObjectIdentifier) []asn1.ObjectIdentifier {
-	if role&ssntp.AGENT == ssntp.AGENT {
+	if role.IsAgent() {
 		oids = append(oids, ssntp.RoleAgentOID)
 	}
 
-	if role&ssntp.SCHEDULER == ssntp.SCHEDULER {
+	if role.IsScheduler() {
 		oids = append(oids, ssntp.RoleSchedulerOID)
 	}
 
-	if role&ssntp.Controller == ssntp.Controller {
+	if role.IsController() {
 		oids = append(oids, ssntp.RoleControllerOID)
 	}
 
-	if role&ssntp.NETAGENT == ssntp.NETAGENT {
+	if role.IsNetAgent() {
 		oids = append(oids, ssntp.RoleNetAgentOID)
 	}
 
-	if role&ssntp.SERVER == ssntp.SERVER {
+	if role.IsServer() {
 		oids = append(oids, ssntp.RoleServerOID)
 	}
 
-	if role&ssntp.CNCIAGENT == ssntp.CNCIAGENT {
+	if role.IsCNCIAgent() {
 		oids = append(oids, ssntp.RoleCNCIAgentOID)
 	}
 

--- a/ciao-launcher/tests/ciao-launcher-server/server.go
+++ b/ciao-launcher/tests/ciao-launcher-server/server.go
@@ -63,12 +63,11 @@ var server = struct {
 
 type testServer struct{}
 
-func (ts *testServer) ConnectNotify(uuid string, role uint32) {
+func (ts *testServer) ConnectNotify(uuid string, role ssntp.Role) {
 	server.Lock()
 	defer server.Unlock()
 
-	if !(role == ssntp.AGENT || role == ssntp.NETAGENT ||
-		role == ssntp.NETAGENT|ssntp.AGENT) {
+	if !(role.IsAgent() || role.IsNetAgent()) {
 		return
 	}
 
@@ -79,7 +78,7 @@ func (ts *testServer) ConnectNotify(uuid string, role uint32) {
 	server.clients[uuid] = new(client)
 }
 
-func (ts *testServer) DisconnectNotify(uuid string, role uint32) {
+func (ts *testServer) DisconnectNotify(uuid string, role ssntp.Role) {
 	server.Lock()
 	defer server.Unlock()
 

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -321,26 +321,28 @@ func disconnectNetworkNode(sched *ssntpSchedulerServer, uuid string) {
 
 	sched.sendNodeDisconnectedEvents(uuid, payloads.NetworkNode)
 }
-func (sched *ssntpSchedulerServer) ConnectNotify(uuid string, role uint32) {
-	switch role {
-	case ssntp.Controller:
+func (sched *ssntpSchedulerServer) ConnectNotify(uuid string, role ssntp.Role) {
+	if role.IsController() {
 		connectController(sched, uuid)
-	case ssntp.AGENT:
+	}
+	if role.IsAgent() {
 		connectComputeNode(sched, uuid)
-	case ssntp.NETAGENT:
+	}
+	if role.IsNetAgent() {
 		connectNetworkNode(sched, uuid)
 	}
 
 	glog.V(2).Infof("Connect (role 0x%x, uuid=%s)\n", role, uuid)
 }
 
-func (sched *ssntpSchedulerServer) DisconnectNotify(uuid string, role uint32) {
-	switch role {
-	case ssntp.Controller:
+func (sched *ssntpSchedulerServer) DisconnectNotify(uuid string, role ssntp.Role) {
+	if role.IsController() {
 		disconnectController(sched, uuid)
-	case ssntp.AGENT:
+	}
+	if role.IsAgent() {
 		disconnectComputeNode(sched, uuid)
-	case ssntp.NETAGENT:
+	}
+	if role.IsNetAgent() {
 		disconnectNetworkNode(sched, uuid)
 	}
 

--- a/networking/ciao-cnci-agent/test_cnci_server/server.go
+++ b/networking/ciao-cnci-agent/test_cnci_server/server.go
@@ -130,7 +130,7 @@ func (l logger) Warningf(format string, args ...interface{}) {
 	fmt.Printf("WARNING: Test Server: "+format, args...)
 }
 
-func (server *ssntpTestServer) ConnectNotify(uuid string, role uint32) {
+func (server *ssntpTestServer) ConnectNotify(uuid string, role ssntp.Role) {
 	server.nConnections++
 	fmt.Printf("%s: %s connected (role 0x%x, current connections %d)\n", server.name, uuid, role, server.nConnections)
 
@@ -160,7 +160,7 @@ func (server *ssntpTestServer) ConnectNotify(uuid string, role uint32) {
 
 }
 
-func (server *ssntpTestServer) DisconnectNotify(uuid string, role uint32) {
+func (server *ssntpTestServer) DisconnectNotify(uuid string, role ssntp.Role) {
 	server.nConnections--
 	fmt.Printf("%s: %s disconnected (current connections %d)\n", server.name, uuid, server.nConnections)
 }

--- a/ssntp/client.go
+++ b/ssntp/client.go
@@ -67,7 +67,7 @@ type Client struct {
 	uuid      uuid.UUID
 	lUUID     lockedUUID
 	uris      []string
-	role      uint32
+	role      Role
 	tls       *tls.Config
 	ntf       ClientNotifier
 	transport string

--- a/ssntp/example_server_test.go
+++ b/ssntp/example_server_test.go
@@ -39,11 +39,11 @@ type ssntpDumpServer struct {
 	name  string
 }
 
-func (server *ssntpDumpServer) ConnectNotify(uuid string, role uint32) {
+func (server *ssntpDumpServer) ConnectNotify(uuid string, role Role) {
 	fmt.Printf("%s: %s connected (role 0x%x)\n", server.name, uuid, role)
 }
 
-func (server *ssntpDumpServer) DisconnectNotify(uuid string, role uint32) {
+func (server *ssntpDumpServer) DisconnectNotify(uuid string, role Role) {
 	fmt.Printf("%s: %s disconnected (role 0x%x)\n", server.name, uuid, role)
 }
 

--- a/ssntp/examples/server.go
+++ b/ssntp/examples/server.go
@@ -49,12 +49,12 @@ func (l logger) Warningf(format string, args ...interface{}) {
 	fmt.Printf("WARNING: Server example: "+format, args...)
 }
 
-func (server *ssntpEchoServer) ConnectNotify(uuid string, role uint32) {
+func (server *ssntpEchoServer) ConnectNotify(uuid string, role Role) {
 	server.nConnections++
 	fmt.Printf("%s: %s connected (role 0x%x, current connections %d)\n", server.name, uuid, role, server.nConnections)
 }
 
-func (server *ssntpEchoServer) DisconnectNotify(uuid string, role uint32) {
+func (server *ssntpEchoServer) DisconnectNotify(uuid string, role Role) {
 	server.nConnections--
 	fmt.Printf("%s: %s disconnected (role 0x%x, current connections %d)\n", server.name, uuid, role, server.nConnections)
 }

--- a/ssntp/forward.go
+++ b/ssntp/forward.go
@@ -186,19 +186,19 @@ func (f *frameForward) addForwardDestination(session *session) {
 
 		switch op := r.Operand.(type) {
 		case Command:
-			if session.destRole&(uint32)(r.Dest) == (uint32)(r.Dest) {
+			if session.destRole.HasRole(r.Dest) {
 				f.forwardCommandDest[op] = append(f.forwardCommandDest[op], session)
 			}
 		case Status:
-			if session.destRole&(uint32)(r.Dest) == (uint32)(r.Dest) {
+			if session.destRole.HasRole(r.Dest) {
 				f.forwardStatusDest[op] = append(f.forwardStatusDest[op], session)
 			}
 		case Error:
-			if session.destRole&(uint32)(r.Dest) == (uint32)(r.Dest) {
+			if session.destRole.HasRole(r.Dest) {
 				f.forwardErrorDest[op] = append(f.forwardErrorDest[op], session)
 			}
 		case Event:
-			if session.destRole&(uint32)(r.Dest) == (uint32)(r.Dest) {
+			if session.destRole.HasRole(r.Dest) {
 				f.forwardEventDest[op] = append(f.forwardEventDest[op], session)
 			}
 		}

--- a/ssntp/frame.go
+++ b/ssntp/frame.go
@@ -44,7 +44,7 @@ type TraceConfig struct {
 // Node represent an SSNTP networking node.
 type Node struct {
 	UUID        []byte
-	Role        uint32
+	Role        Role
 	TxTimestamp time.Time
 	RxTimestamp time.Time
 }
@@ -77,7 +77,7 @@ type ConnectFrame struct {
 	Minor       uint8
 	Type        Type
 	Operand     uint8
-	Role        uint32
+	Role        Role
 	Source      []byte
 	Destination []byte
 }
@@ -88,7 +88,7 @@ type ConnectedFrame struct {
 	Minor         uint8
 	Type          Type
 	Operand       uint8
-	Role          uint32
+	Role          Role
 	Source        []byte
 	Destination   []byte
 	PayloadLength uint32
@@ -184,7 +184,7 @@ func (f ConnectFrame) String() string {
 	copy(dest[:], f.Destination[:16])
 
 	return fmt.Sprintf("\tMajor %d\n\tMinor %d\n\tType %s\n\tOp %s\n\tRole %s\n\tSource %s\n\tDestination %s\n",
-		f.Major, f.Minor, (Type)(f.Type), op, (*Role)(&f.Role), src, dest)
+		f.Major, f.Minor, (Type)(f.Type), op, &f.Role, src, dest)
 }
 
 func (f ConnectedFrame) String() string {
@@ -205,7 +205,7 @@ func (f ConnectedFrame) String() string {
 	copy(dest[:], f.Destination[:16])
 
 	return fmt.Sprintf("\tMajor %d\n\tMinor %d\n\tType %s\n\tOp %s\n\tRole %s\n\tSource %s\n\tDestination %s\n",
-		f.Major, f.Minor, (Type)(f.Type), op, (*Role)(&f.Role), src, dest)
+		f.Major, f.Minor, (Type)(f.Type), op, &f.Role, src, dest)
 }
 
 func (f *Frame) addPathNode(session *session) {
@@ -275,7 +275,7 @@ func (f Frame) DumpTrace() (*payloads.FrameTrace, error) {
 		copy(node[:], n.UUID[:16])
 		sNode := payloads.SSNTPNode{
 			SSNTPUUID: node.String(),
-			SSNTPRole: (*Role)(&n.Role).String(),
+			SSNTPRole: n.Role.String(),
 		}
 
 		if n.TxTimestamp.IsZero() == false {

--- a/ssntp/server.go
+++ b/ssntp/server.go
@@ -31,11 +31,11 @@ import (
 // Any SSNTP server must implement this interface.
 type ServerNotifier interface {
 	// ConnectNotify notifies of a new SSNTP client connection.
-	ConnectNotify(uuid string, role uint32)
+	ConnectNotify(uuid string, role Role)
 
 	// DisconnectNotify notifies of a SSNTP client having
 	// disconnected from us.
-	DisconnectNotify(uuid string, role uint32)
+	DisconnectNotify(uuid string, role Role)
 
 	// StatusNotify notifies of a pending status frame.
 	// The frame comes from a SSNTP client identified by uuid.
@@ -70,7 +70,7 @@ type Server struct {
 	listener      net.Listener
 	stopped       boolFlag
 	stoppedChan   chan struct{}
-	role          uint32
+	role          Role
 	roleVerify    bool
 	clientWg      sync.WaitGroup
 
@@ -179,7 +179,7 @@ func handleSSNTPClient(server *Server, conn net.Conn) {
 
 		switch frame.Type {
 		case COMMAND:
-			if (Command)(frame.Operand) == CONFIGURE && session.destRole == Controller {
+			if (Command)(frame.Operand) == CONFIGURE && session.destRole.IsController() {
 				/* TODO Send the CONFIGURE payload to the config package */
 				server.configuration.setConfiguration(frame.Payload)
 			}

--- a/ssntp/session.go
+++ b/ssntp/session.go
@@ -43,8 +43,8 @@ func clearWriteTimeout(conn net.Conn) {
 type session struct {
 	src      uuid.UUID
 	dest     uuid.UUID
-	srcRole  uint32
-	destRole uint32
+	srcRole  Role
+	destRole Role
 	conn     net.Conn
 
 	encoder *gob.Encoder
@@ -54,7 +54,7 @@ type session struct {
 /*
  * session methods
  */
-func newSession(src *uuid.UUID, srcRole uint32, destRole uint32, netConn net.Conn) *session {
+func newSession(src *uuid.UUID, srcRole Role, destRole Role, netConn net.Conn) *session {
 	var session session
 
 	if src != nil {
@@ -75,7 +75,7 @@ func (session *session) setDest(uuid []byte) {
 	copy(session.dest[:], uuid[:16])
 }
 
-func (session *session) connectedFrame(serverRole uint32, payload []byte) (f *ConnectedFrame) {
+func (session *session) connectedFrame(serverRole Role, payload []byte) (f *ConnectedFrame) {
 	f = &ConnectedFrame{
 		Major:         major,
 		Minor:         minor,

--- a/ssntp/ssntp.go
+++ b/ssntp/ssntp.go
@@ -612,30 +612,86 @@ func (error Error) String() string {
 	return ""
 }
 
+// HasRole checks if a role instance has the specified role
+func (role *Role) HasRole(cmp Role) bool {
+	if *role&cmp == cmp {
+		return true
+	}
+	return false
+}
+
+// IsServer checks if a role instance has the ssntp.SERVER role
+func (role *Role) IsServer() bool {
+	if role.HasRole(SERVER) {
+		return true
+	}
+	return false
+}
+
+// IsController checks if a role instance has the ssntp.Controller role
+func (role *Role) IsController() bool {
+	if role.HasRole(Controller) {
+		return true
+	}
+	return false
+}
+
+// IsAgent checks if a role instance has the ssntp.AGENT role
+func (role *Role) IsAgent() bool {
+	if role.HasRole(AGENT) {
+		return true
+	}
+	return false
+}
+
+// IsScheduler checks if a role instance has the ssntp.SCHEDULER role
+func (role *Role) IsScheduler() bool {
+	if role.HasRole(SCHEDULER) {
+		return true
+	}
+	return false
+}
+
+// IsNetAgent checks if a role instance has the ssntp.NETAGENT role
+func (role *Role) IsNetAgent() bool {
+	if role.HasRole(NETAGENT) {
+		return true
+	}
+	return false
+}
+
+// IsCNCIAgent checks if a role instance has the ssntp.CNCIAGENT role
+func (role *Role) IsCNCIAgent() bool {
+	if role.HasRole(CNCIAGENT) {
+		return true
+	}
+	return false
+}
+
 func (role *Role) String() string {
 	roleString := ""
 
-	if *role&SERVER == SERVER {
+	if role.IsServer() {
 		roleString += "Server-"
 	}
 
-	if *role&Controller == Controller {
+	if role.IsController() {
 		roleString += "Controller-"
 	}
 
-	if *role&AGENT == AGENT {
+	if role.IsAgent() {
 		roleString += "CNAgent-"
 	}
 
-	if *role&SCHEDULER == SCHEDULER {
+	if role.IsScheduler() {
 		roleString += "Scheduler-"
 	}
 
-	if *role&NETAGENT == NETAGENT {
+	if role.IsNetAgent() {
 		roleString += "NetworkingAgent-"
 	}
 
-	if *role&CNCIAGENT == CNCIAGENT {
+	if role.IsCNCIAgent() {
 		roleString += "CNCIAgent-"
 	}
 
@@ -846,7 +902,7 @@ func prepareTLS(caPEM, certPEM []byte, server bool) *tls.Config {
 }
 
 var roleOID = []struct {
-	role uint32
+	role Role
 	oid  asn1.ObjectIdentifier
 }{
 	{
@@ -875,8 +931,8 @@ var roleOID = []struct {
 	},
 }
 
-func getRoleFromOIDs(oids []asn1.ObjectIdentifier) uint32 {
-	role := (uint32)(UNKNOWN)
+func getRoleFromOIDs(oids []asn1.ObjectIdentifier) Role {
+	role := UNKNOWN
 
 	for _, oid := range oids {
 		for _, r := range roleOID {
@@ -889,10 +945,10 @@ func getRoleFromOIDs(oids []asn1.ObjectIdentifier) uint32 {
 	return role
 }
 
-func getOIDsFromRole(role uint32) ([]asn1.ObjectIdentifier, error) {
+func getOIDsFromRole(role Role) ([]asn1.ObjectIdentifier, error) {
 	var oids []asn1.ObjectIdentifier
 	for _, r := range roleOID {
-		if role&r.role == r.role {
+		if role.HasRole(r.role) {
 			oids = append(oids, r.oid)
 		}
 	}
@@ -904,7 +960,7 @@ func getOIDsFromRole(role uint32) ([]asn1.ObjectIdentifier, error) {
 	return oids, nil
 }
 
-func verifyRole(conn interface{}, role uint32) (bool, error) {
+func verifyRole(conn interface{}, role Role) (bool, error) {
 	var oidError = fmt.Errorf("**** TEMPORARY WARNING ****\n*** Wrong certificate or missing/mismatched role OID ***\nIn order to fix this, use the -role option when generating your certificates with the ciao-cert tool.\n")
 	switch tlsConn := conn.(type) {
 	case *tls.Conn:
@@ -956,7 +1012,7 @@ func (config *Config) parseCertificateAuthority() ([]string, []string, error) {
 	return ips, fqdns, nil
 }
 
-func (config *Config) parseCertificate() (uint32, error) {
+func (config *Config) parseCertificate() (Role, error) {
 	certPEM, err := ioutil.ReadFile(config.Cert)
 	if err != nil {
 		log.Fatalf("SSNTP: Load certificate [%s]: %s", config.Cert, err)
@@ -975,14 +1031,14 @@ func (config *Config) parseCertificate() (uint32, error) {
 
 	role := getRoleFromOIDs(cert[0].UnknownExtKeyUsage)
 	/* We could not find a valid OID in the certificate */
-	if role == (uint32)(UNKNOWN) {
+	if role == UNKNOWN {
 		return role, errors.New("Could not find a SSNTP role")
 	}
 
 	return role, nil
 }
 
-func (config *Config) configUUID(role uint32) (lockedUUID, uuid.UUID) {
+func (config *Config) configUUID(role Role) (lockedUUID, uuid.UUID) {
 	if config.UUID == "" {
 		var err error
 		lUUID, err := newUUID("client", role)
@@ -1035,7 +1091,7 @@ func (config *Config) configURIs(uris []string, port uint32) []string {
 	return uris
 }
 
-func (config *Config) role() (uint32, error) {
+func (config *Config) role() (Role, error) {
 	role, err := config.parseCertificate()
 	if err != nil {
 		return 0, err
@@ -1077,9 +1133,9 @@ type lockedUUID struct {
 	uuid   uuid.UUID
 }
 
-func newUUID(prefix string, role uint32) (lockedUUID, error) {
-	uuidFile := fmt.Sprintf("%s/%s/0x%x", uuidPrefix, prefix, role)
-	uuidLockFile := fmt.Sprintf("%s/%s-role-0x%x", uuidLockPrefix, prefix, role)
+func newUUID(prefix string, role Role) (lockedUUID, error) {
+	uuidFile := fmt.Sprintf("%s/%s/0x%x", uuidPrefix, prefix, (uint32)(role))
+	uuidLockFile := fmt.Sprintf("%s/%s-role-0x%x", uuidLockPrefix, prefix, (uint32)(role))
 	_nUUID, _ := uuid.Parse(nullUUID)
 	nUUID := lockedUUID{
 		uuid:   _nUUID,

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -44,7 +44,7 @@ func (server *SsntpTestServer) AddCmdChan(cmd ssntp.Command, c chan CmdResult) {
 }
 
 // ConnectNotify implements an SSNTP ConnectNotify callback for SsntpTestServer
-func (server *SsntpTestServer) ConnectNotify(uuid string, role uint32) {
+func (server *SsntpTestServer) ConnectNotify(uuid string, role ssntp.Role) {
 	switch role {
 	case ssntp.AGENT:
 		server.clients = append(server.clients, uuid)
@@ -58,7 +58,7 @@ func (server *SsntpTestServer) ConnectNotify(uuid string, role uint32) {
 }
 
 // DisconnectNotify implements an SSNTP DisconnectNotify callback for SsntpTestServer
-func (server *SsntpTestServer) DisconnectNotify(uuid string, role uint32) {
+func (server *SsntpTestServer) DisconnectNotify(uuid string, role ssntp.Role) {
 	for index := range server.clients {
 		if server.clients[index] == uuid {
 			server.clients = append(server.clients[:index], server.clients[index+1:]...)


### PR DESCRIPTION
The Role is a typedef'd bitmask of an enumeration of constant values.
But much of the code directly accessed the underlying integer, with a
variety of casting involved.  By removing all the integer typing and
adding some accessor/test functions, the casts go away and and some code
reads more succintly.  We get a more strongly typed object for "Role" that
can transparently change its underlying implementation in the future if
needed.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>