### PR TITLE
ciao-scheduler: refactor StatusNotify() for combo role AGENT|NETAGENT

### DIFF
--- a/ssntp/server.go
+++ b/ssntp/server.go
@@ -444,3 +444,14 @@ func (server *Server) SendTracedError(uuid string, error Error, payload []byte, 
 func (server *Server) UUID() string {
 	return server.uuid.String()
 }
+
+// ClientRole returns the role of the ssntp session peer with the specified uuid.
+func (server *Server) ClientRole(uuid string) (Role, error) {
+	server.sessionMutex.RLock()
+	session := server.sessions[uuid]
+	defer server.sessionMutex.RUnlock()
+	if session == nil {
+		return UNKNOWN, fmt.Errorf("SSNTP session missing for uuid %s", uuid)
+	}
+	return session.destRole, nil
+}


### PR DESCRIPTION
Split out a helper to update a nodeStat.

With StatusNotify() including a role parameter, the helper function can be
simply called for each relevant role, instead of having to check all maps
for the uuid passed in the already existing StatusNotify() parameter list.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>