### PR TITLE
ciao-controller: Flush the indentity strings

### DIFF
--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -126,6 +126,7 @@ func main() {
 		glog.Errorf("Please")
 		glog.Errorf("export CIAO_IDENTITY=%s", id.URL)
 		glog.Errorf("========================")
+		glog.Flush()
 	}
 
 	idConfig := identityConfig{


### PR DESCRIPTION
In --single mode the controller records the dynamically generated
identity information in the log files. However this information is
not available to the user till the logs are flushed.

To ensure that test scripts and the user can retrieve this
information immediately after the ciao-controller is started
the log buffer needs to be flushed.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>