### PR TITLE
configuration: Add Init method for Configure payload default values

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -47,15 +47,6 @@ func validMinConf(conf *payloads.Configure) bool {
 		conf.Configure.IdentityService.URL != "")
 }
 
-func fillDefaults(conf *payloads.Configure) {
-	conf.Configure.Scheduler.ConfigStorageType = payloads.Filesystem
-	conf.Configure.Controller.ComputePort = 8774
-	conf.Configure.ImageService.Type = payloads.Glance
-	conf.Configure.IdentityService.Type = payloads.Keystone
-	conf.Configure.Launcher.DiskLimit = true
-	conf.Configure.Launcher.MemoryLimit = true
-}
-
 // TODO: add etcd support related scheme(s)
 func discoverDriver(uriStr string) (storageType payloads.StorageType, err error) {
 	uri, err := url.Parse(uriStr)
@@ -77,7 +68,7 @@ func Payload(blob []byte) (conf payloads.Configure, err error) {
 	if blob == nil {
 		return conf, fmt.Errorf("Unable to retrieve configuration from empty definition")
 	}
-	fillDefaults(&conf)
+	conf.InitDefaults()
 	err = yaml.Unmarshal(blob, &conf)
 
 	return conf, err

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -149,7 +149,7 @@ func emptyPayload(p payloads.Configure) bool {
 }
 
 func fillPayload(conf *payloads.Configure) {
-	fillDefaults(conf)
+	conf.InitDefaults()
 	conf.Configure.Scheduler.ConfigStorageURI = storageURI
 	conf.Configure.Controller.HTTPSCACert = httpsCACert
 	conf.Configure.Controller.HTTPSKey = httpsKey
@@ -208,9 +208,9 @@ func saneDefaults(conf *payloads.Configure) bool {
 		conf.Configure.Launcher.MemoryLimit == true)
 }
 
-func TestFillDefaults(t *testing.T) {
+func TestInitDefaults(t *testing.T) {
 	var conf payloads.Configure
-	fillDefaults(&conf)
+	conf.InitDefaults()
 	res := saneDefaults(&conf)
 	if res != true {
 		t.Fatalf("Expected true, got %v", res)

--- a/configuration/file_test.go
+++ b/configuration/file_test.go
@@ -123,7 +123,7 @@ func TestFileStoreConfiguration(t *testing.T) {
 	var d driver
 	var conf payloads.Configure
 
-	fillDefaults(&conf)
+	conf.InitDefaults()
 	d = &file{}
 
 	err := d.storeConfiguration(conf)

--- a/payloads/configure.go
+++ b/payloads/configure.go
@@ -102,3 +102,13 @@ type ConfigurePayload struct {
 type Configure struct {
 	Configure ConfigurePayload `yaml:"configure"`
 }
+
+// InitDefaults initializes default vaulues for Configure structure.
+func (conf *Configure) InitDefaults() {
+	conf.Configure.Scheduler.ConfigStorageType = Filesystem
+	conf.Configure.Controller.ComputePort = 8774
+	conf.Configure.ImageService.Type = Glance
+	conf.Configure.IdentityService.Type = Keystone
+	conf.Configure.Launcher.DiskLimit = true
+	conf.Configure.Launcher.MemoryLimit = true
+}


### PR DESCRIPTION
Based on requirements for CIAO Minimal Config Package, we need
to have some default initial values:
https://github.com/01org/ciao/issues/66

Below are the config package related (In-Progress) PRs:
config_package PR:  https://github.com/01org/ciao/pull/149
config_launcher PR: https://github.com/01org/ciao/pull/168

Signed-off-by: Munoz, Obed N <obed.n.munoz@intel.com>