### PR TITLE
testutils: Simple automated single VM test scripts

### DIFF
--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sudo killall ciao-scheduler
+sudo killall ciao-controller
+sudo killall ciao-launcher

--- a/testutil/singlevm/run_controller.sh
+++ b/testutil/singlevm/run_controller.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+ciao_host=$(hostname)
+
+sudo rm ciao-controller.db-shm ciao-controller.db-wal ciao-controller.db /tmp/ciao-controller-stats.db
+
+sudo "$GOPATH"/bin/ciao-controller --cacert=./CAcert-"$ciao_host".pem --cert=./cert-Controller-"$ciao_host".pem --single --username=csr --password=hello --httpskey=./controller_key.pem --httpscert=./controller_cert.pem --v 3 &

--- a/testutil/singlevm/run_launcher.sh
+++ b/testutil/singlevm/run_launcher.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+ciao_host=$(hostname)
+
+#Obtain the subnet of the primary interface
+default_if=$(ip route list | awk '/^default/ {print $5}')
+default_subnet=$(ip -o -f inet addr show $default_if | awk '{print $4}')
+
+#Cleanup artifacts
+sudo "$GOPATH"/bin/ciao-launcher --cacert=./CAcert-"$ciao_host".pem --cert=./cert-CNAgent-NetworkingAgent-"$ciao_host".pem --network=dual --compute-net "$default_subnet" --mgmt-net "$default_subnet" --alsologtostderr -v 3 --disk-limit=false --hard-reset
+
+#Cleanup any prior docker instances and networks
+sudo docker rm $(sudo docker ps -qa)
+sudo docker network rm $(sudo docker network ls -q -f "type=custom")
+sudo rm -f /var/lib/ciao/networking/docker_plugin.db
+
+#Run launcher
+sudo "$GOPATH"/bin/ciao-launcher --cacert=./CAcert-"$ciao_host".pem --cert=./cert-CNAgent-NetworkingAgent-"$ciao_host".pem --network=dual --compute-net "$default_subnet" --mgmt-net "$default_subnet" -v 3 --disk-limit=false &

--- a/testutil/singlevm/run_scheduler.sh
+++ b/testutil/singlevm/run_scheduler.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+ciao_host=$(hostname)
+
+sudo -E "$GOPATH"/bin/ciao-scheduler --cacert=./CAcert-"$ciao_host".pem --cert=./cert-Scheduler-"$ciao_host".pem -v 3 &

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+ciao_host=$(hostname)
+ciao_bin="$HOME/local"
+ciao_cert="$ciao_bin""/cert-Scheduler-""$ciao_host"".pem"
+
+ciao_email="ciao-devel@lists.clearlinux.org"
+ciao_org="Intel"
+ciao_src="$GOPATH/src/github.com/01org/ciao"
+ciao_scripts="$GOPATH/src/github.com/01org/ciao/testutil/singlevm"
+ciao_env="$ciao_bin/demo.sh"
+ciao_ctl_log="/var/lib/ciao/logs/controller/ciao-controller.ERROR"
+ciao_cnci_image="clear-8260-ciao-networking.img"
+
+
+#Stop any running agents
+sudo killall ciao-scheduler
+sudo killall ciao-controller
+sudo killall ciao-launcher
+sleep 5
+
+
+#Create a directory where all the certificates, binaries and other
+#dependencies are placed
+mkdir "$ciao_bin"
+cd "$ciao_bin"
+
+#Cleanup any old artifcats
+rm -f "$ciao_bin"/*.pem
+sudo rm -f "$ciao_bin"/ciao-controller.db-shm 
+sudo rm -f "$ciao_bin"/ciao-controller.db-wal 
+sudo rm -f "$ciao_bin"/ciao-controller.db
+sudo rm -f /tmp/ciao-controller-stats.db
+rm -rf "$ciao_bin"/tables
+rm -rf "$ciao_bin"/workloads
+
+
+#Generate Certificates
+$GOPATH/bin/ciao-cert -server -role scheduler -email="$ciao_email" -organization="$ciao_org" -host="$ciao_host" -verify 
+
+$GOPATH/bin/ciao-cert -role cnciagent -server-cert "$ciao_cert" -email="$ciao_email" -organization="ciao_org" -host="$ciao_host" -verify 
+
+$GOPATH/bin/ciao-cert -role controller -server-cert "$ciao_cert" -email="$ciao_email" -organization="$ciao_org" -host="$ciao_host" -verify 
+
+$GOPATH/bin/ciao-cert -role agent,netagent -server-cert "$ciao_cert" -email="ciao_email" -organization="ciao_org" -host="$ciao_host" -verify
+
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout controller_key.pem -out controller_cert.pem -subj "/C=US/ST=CA/L=Santa Clara/O=ciao/CN=ciao.example.com"
+
+#Build ciao
+cd "$ciao_src"
+go install -v --tags 'debug' ./...
+cd "$ciao_bin"
+
+#Copy the configuration
+cp -a "$ciao_src"/ciao-controller/tables "$ciao_bin"
+cp -a "$ciao_src"/ciao-controller/workloads "$ciao_bin"
+
+#Copy the launch scripts
+cp "$ciao_scripts"/run_scheduler.sh "$ciao_bin"
+cp "$ciao_scripts"/run_controller.sh "$ciao_bin"
+cp "$ciao_scripts"/run_launcher.sh "$ciao_bin"
+
+
+#Generate the CNCI VM
+cd "$ciao_bin"
+"$GOPATH"/src/github.com/01org/ciao/networking/ciao-cnci-agent/scripts/generate_cnci_cloud_image.sh -c "$ciao_bin" -i "$ciao_cnci_image" -d
+qemu-img convert -f raw -O qcow2 "$ciao_cnci_image" "$ciao_cnci_image".qcow
+sudo cp "$ciao_cnci_image".qcow /var/lib/ciao/images
+cd /var/lib/ciao/images
+sudo ln -sf "$ciao_cnci_image".qcow 4e16e743-265a-4bf2-9fd1-57ada0b28904
+
+#Kick off the agents
+cd "$ciao_bin"
+"$ciao_bin"/run_scheduler.sh  &> /dev/null
+"$ciao_bin"/run_launcher.sh &> /dev/null
+"$ciao_bin"/run_controller.sh &> /dev/null
+
+echo "export CIAO_CONTROLLER=""$ciao_host" > "$ciao_env"
+echo "export CIAO_USERNAME=admin" >> "$ciao_env"
+echo "export CIAO_PASSWORD=giveciaoatry" >> "$ciao_env"
+sleep 5
+cat "$ciao_ctl_log"
+identity=`grep CIAO_IDENTITY $ciao_ctl_log | sed 's/^.*export/export/'`
+echo "$identity" >> "$ciao_env"
+export CIAO_CONTROLLER="$ciao_host"
+export CIAO_USERNAME=admin
+export CIAO_PASSWORD=giveciaoatry
+eval "$identity"
+ciao-cli --list-workloads
+ciao-cli --launch-instances --workload=e35ed972-c46c-4aad-a1e7-ef103ae079a2 --instances=2
+ciao-cli --launch-instances --workload=ab68111c-03a6-11e6-87de-001320fb6e31 --instances=2
+ciao-cli --list-instances
+sleep 30
+ciao-cli --list-instances
+
+#Check docker networking
+docker_id=`sudo docker ps -q | head -1`
+sudo docker logs $docker_id
+
+#Check SSH connectivity
+ssh_ip=`ciao-cli --list-instances |  grep "SSH IP:" | sed 's/^.*SSH IP: //' | head -1`
+head -1 < /dev/tcp/"$ssh_ip"/33002


### PR DESCRIPTION
This commit includes a simple set of scripts that can be used
to perform a quick sanity check to ensure that ciao is
fully functional in a single VM setup.

The scripts handle the following
- Generation of certificates
- Generation of the CNCI Image
- Starting the Controller, Launcher and Scheduler
- Launching of Clear Container and Docker workloads
- Checking for docker and clear container networking

Assumptions:
- Docker and Clear Cloud images are setup properly
- The VM is running with hairpin mode enabled

Future Changes:
- Error checking
- Obtaining user input for relevant parameters
- These scripts check ssh and docker network connectivity
  but the caller needs to visually verify. This will need to
  be automated

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>