### PR TITLE
configuration: Consistency fixes

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -73,15 +73,14 @@ func discoverDriver(uriStr string) (storageType payloads.StorageType, err error)
 
 // Payload fills the payloads.Configure struct passed in 'conf'
 // with the values from the bytes given
-func Payload(yamlConf []byte, conf *payloads.Configure) (err error) {
-	if yamlConf == nil {
-		return fmt.Errorf("Unable to retrieve configuration from empty definition")
+func Payload(blob []byte) (conf payloads.Configure, err error) {
+	if blob == nil {
+		return conf, fmt.Errorf("Unable to retrieve configuration from empty definition")
 	}
-	err = yaml.Unmarshal(yamlConf, &conf)
-	if err != nil {
-		return err
-	}
-	return nil
+	fillDefaults(&conf)
+	err = yaml.Unmarshal(blob, &conf)
+
+	return conf, err
 }
 
 // Blob returns an array of bytes containing
@@ -100,7 +99,7 @@ func Blob(conf *payloads.Configure) (blob []byte, err error) {
 
 // ExtractBlob returns a configuration payload.
 // It could be used by the SSNTP server or some other entity.
-func ExtractBlob(uri string) (payload []byte, err error) {
+func ExtractBlob(uri string) (blob []byte, err error) {
 	var d driver
 	driverType, err := discoverDriver(uri)
 	if err != nil {
@@ -116,9 +115,9 @@ func ExtractBlob(uri string) (payload []byte, err error) {
 	if err != nil {
 		return nil, err
 	}
-	payload, err = Blob(&conf)
+	blob, err = Blob(&conf)
 	if err != nil {
 		return nil, err
 	}
-	return payload, nil
+	return blob, nil
 }

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -162,8 +162,7 @@ func fillPayload(conf *payloads.Configure) {
 }
 
 func testPayload(t *testing.T, blob []byte, expectedConf payloads.Configure, positive bool) {
-	var conf payloads.Configure
-	err := Payload(blob, &conf)
+	conf, err := Payload(blob)
 
 	// expected FAIL
 	if positive == false && err == nil {

--- a/configuration/file.go
+++ b/configuration/file.go
@@ -52,8 +52,8 @@ func (f *file) fetchConfiguration(uriStr string) (conf payloads.Configure, err e
 	if err != nil {
 		return conf, err
 	}
-	fillDefaults(&conf)
-	err = Payload(yamlConf, &conf)
+
+	conf, err = Payload(yamlConf)
 	if err != nil {
 		return conf, err
 	}


### PR DESCRIPTION
Minor modification for API consistency sake:

- Payload takes a blob and returns a payload
- ExtractBlob return variable is called a blob

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>