### PR TITLE
configuration: Compute and Mgmt subnets are not mandatory

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -41,8 +41,6 @@ func validMinConf(conf *payloads.Configure) bool {
 		conf.Configure.Controller.HTTPSKey != "" &&
 		conf.Configure.Controller.IdentityUser != "" &&
 		conf.Configure.Controller.IdentityPassword != "" &&
-		conf.Configure.Launcher.ComputeNetwork != "" &&
-		conf.Configure.Launcher.ManagementNetwork != "" &&
 		conf.Configure.ImageService.URL != "" &&
 		conf.Configure.IdentityService.URL != "")
 }


### PR DESCRIPTION
On single physical interfaces, the network will autoconfigure
itself.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>