### PR TITLE
ciao-launcher: Fix unit tests

### DIFF
--- a/ciao-launcher/overseer_test.go
+++ b/ciao-launcher/overseer_test.go
@@ -165,6 +165,10 @@ func (v *overseerTestState) setStatus(status bool) {
 
 }
 
+func (v *overseerTestState) ClusterConfiguration() (payloads.Configure, error) {
+	return payloads.Configure{}, nil
+}
+
 type procPaths struct {
 	procDir string
 	memInfo string


### PR DESCRIPTION
Add the ClusterConfiguration method to overseerTestState to fix the
ciao-launcher unit tests.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>