### PR TITLE
travis: make logdir for scheduler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
 # We need to create and install SSNTP certs for the SSNTP and controller tests
 before_script:
    - sudo mkdir -p /etc/pki/ciao/
+   - sudo mkdir -p /etc/pki/ciao/logs/scheduler
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server -role scheduler
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role agent
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role agent,netagent

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -165,13 +165,16 @@ func testPayload(t *testing.T, blob []byte, expectedConf payloads.Configure, pos
 	conf, err := Payload(blob)
 
 	// expected FAIL
-	if positive == false && err == nil {
-		t.Fatalf("%s", err)
+	if positive == false && err != nil {
+		// do nothing...expected case.
 	}
-	// expected PASS
+
+	// unexpected FAIL
 	if positive == true && err != nil {
 		t.Fatalf("%s", err)
 	}
+
+	// unexpected FAIL
 	if positive == true && emptyPayload(expectedConf) == false {
 		if equalPayload(expectedConf, conf) == false {
 			t.Fatalf("Expected %v got %v", expectedConf, conf)


### PR DESCRIPTION
Scheduler can/should run as non-root, but assumes then that packaging has
created its logdir.  In the case of CI our .travis.yml represents the
packaging and needs to create the directory.  This removes a number of
annoying warnings that pop in logs during test.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>