### PR TITLE
ciao-scheduler: glog distinct messages for no cn/nn connected

### DIFF
--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -554,6 +554,7 @@ func pickComputeNode(sched *ssntpSchedulerServer, controllerUUID string, workloa
 	defer sched.cnMutex.RUnlock()
 
 	if len(sched.cnList) == 0 {
+		glog.Errorf("No compute nodes connected, unable to start workload")
 		sched.sendStartFailureError(controllerUUID, workload.instanceUUID, payloads.NoComputeNodes)
 		return nil
 	}
@@ -597,6 +598,7 @@ func (sched *ssntpSchedulerServer) pickNetworkNode(controllerUUID string, worklo
 	defer sched.nnMutex.RUnlock()
 
 	if len(sched.nnMap) == 0 {
+		glog.Errorf("No network nodes connected, unable to start network workload")
 		sched.sendStartFailureError(controllerUUID, workload.instanceUUID, payloads.NoNetworkNodes)
 		return nil
 	}

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -165,13 +165,16 @@ func testPayload(t *testing.T, blob []byte, expectedConf payloads.Configure, pos
 	conf, err := Payload(blob)
 
 	// expected FAIL
-	if positive == false && err == nil {
-		t.Fatalf("%s", err)
+	if positive == false && err != nil {
+		// do nothing...expected case.
 	}
-	// expected PASS
+
+	// unexpected FAIL
 	if positive == true && err != nil {
 		t.Fatalf("%s", err)
 	}
+
+	// unexpected FAIL
 	if positive == true && emptyPayload(expectedConf) == false {
 		if equalPayload(expectedConf, conf) == false {
 			t.Fatalf("Expected %v got %v", expectedConf, conf)


### PR DESCRIPTION
Workload starts fail if no compute nodes are connected.  Same for network
workloads if no network nodes are connected.  This is different than if
nodes are connected, but don't have sufficient resources.  But it did not
show clearly in logs.  These two glog messages should add debugging of
cluster config/setup/test.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>