### PR TITLE
configuration: fix false failure bug

### DIFF
--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -165,13 +165,16 @@ func testPayload(t *testing.T, blob []byte, expectedConf payloads.Configure, pos
 	conf, err := Payload(blob)
 
 	// expected FAIL
-	if positive == false && err == nil {
-		t.Fatalf("%s", err)
+	if positive == false && err != nil {
+		// do nothing...expected case.
 	}
-	// expected PASS
+
+	// unexpected FAIL
 	if positive == true && err != nil {
 		t.Fatalf("%s", err)
 	}
+
+	// unexpected FAIL
 	if positive == true && emptyPayload(expectedConf) == false {
 		if equalPayload(expectedConf, conf) == false {
 			t.Fatalf("Expected %v got %v", expectedConf, conf)


### PR DESCRIPTION
An inverted condition in an expected-to-fail test case was resulting in
a t.Fatalf(nil) sometimes.  Obviously we shouldn't print a value that
was just verified to be nil.  While I'm at it, I also clarified the
comments around the conditions.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>