### PR TITLE
data: Add datastore directory for DB files.

### DIFF
--- a/data/systemd/ciao.conf
+++ b/data/systemd/ciao.conf
@@ -1,3 +1,4 @@
 d /var/lib/ciao - ciao ciao - -
+d /var/lib/ciao/datastore - ciao ciao - -
 d /var/lib/ciao/instances - ciao ciao - -
 d /var/lib/ciao/images - ciao ciao - -


### PR DESCRIPTION
let systemd take care of the VMs data directory
(/var/lib/ciao/datastore) creation at boot time.

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>