### PR TITLE
README.md: Add Waffle badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![Stories in Ready](https://badge.waffle.io/01org/ciao.png?label=ready&title=Ready)](https://waffle.io/01org/ciao)
 #Ciao Project
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/01org/ciao)](https://goreportcard.com/report/github.com/01org/ciao)
 [![Build Status](https://travis-ci.org/01org/ciao.svg?branch=master)](https://travis-ci.org/01org/ciao)
 [![Coverage Status](https://coveralls.io/repos/github/01org/ciao/badge.svg?branch=master)](https://coveralls.io/github/01org/ciao?branch=master)
 [![GoDoc](https://godoc.org/github.com/01org/ciao?status.svg)](https://godoc.org/github.com/01org/ciao)
+[![Stories in Ready](https://badge.waffle.io/01org/ciao.png?label=ready&title=Ready)](https://waffle.io/01org/ciao)
 
 Ciao is the "Cloud Integrated Advanced Orchestrator".  Its goal is
 to provide an easy to deploy, secure, scalable cloud orchestration

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/01org/ciao.png?label=ready&title=Ready)](https://waffle.io/01org/ciao)
 #Ciao Project
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/01org/ciao)](https://goreportcard.com/report/github.com/01org/ciao)


### PR DESCRIPTION
This commit supersedes #218.  It contains the original automated commit from waffle plus a separate commit from me that moves the badge to the correct location in the README.md file.  I decided to leave the original waffle commit intact even though it doesn't have a signed-off by field.  I thought we might make an exception for bots.  If this isn't acceptable I'll squash the two commits and re-push.