### PR TITLE
ciao-controller: workloads: change docker ubuntu latest workload

### DIFF
--- a/ciao-controller/workloads/docker-ubuntu.yaml
+++ b/ciao-controller/workloads/docker-ubuntu.yaml
@@ -1,5 +1,5 @@
 ---
 #cloud-config
 runcmd:
-  - [ /usr/bin/python3, -m, http.server]
+  - [ /bin/bash, -c, "while true; do sleep 60; done" ]
 ...


### PR DESCRIPTION
The latest ubuntu image does not support python3. Change the cloud
init to a simple bash script which does an infinite loop so that
the container can be verified as running for test purposes.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>

Fixes: #246 