### PR TITLE
ciao-cli: Fix README typos

### DIFF
--- a/ciao-cli/README.md
+++ b/ciao-cli/README.md
@@ -185,7 +185,7 @@ $GOBIN/ciao-cli -username admin -password ciao tenant list -all
 ### List quotas
 
 ```shell
-$GOBIN/ciao-cli -username user -password ciaouser tenant list -quotas
+$GOBIN/ciao-cli tenant list -quotas
 ```
 
 ### List consumed resources
@@ -276,7 +276,7 @@ $GOBIN/ciao-cli -username admin -password ciao trace show -label start_trace_201
 
 ```shell
 $GOBIN/ciao-cli -username admin -password ciao event list -all
-``
+```
 
 ### List all cluster events for a given tenant
 


### PR DESCRIPTION
- No need to pass the user and password for unprivileged operations
- Add a missing '`' for proper formatting

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>