### PR TITLE
documentation: note waffle.io connection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,9 @@ the problem and work toward resolution.
 For feature requests we're also using github issues, with the label
 "enhancement".
 
+Our github bug/enhancement backlog and work queue are tracked in a
+[Ciao waffle.io kanban](https://waffle.io/01org/ciao).
+
 ## Closing issues
 
 You can either close issues manually by adding the fixing commit SHA1 to the issue


### PR DESCRIPTION
Our backlog and workqueue are now officially in waffle.io.  We have the
front page badge to prove it.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>