### PR TITLE
travis: add before_deploy and deploy steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,3 +66,16 @@ script:
 
 after_success:
    - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=/tmp/cover.out
+
+before_deploy:
+   - cd $GOPATH/src/github.com/01org/ciao
+   - tag=`git describe --abbrev=0 --tags`
+   - git show $tag > release.txt
+
+deploy:
+        provider: releases
+        api_key: $GH_TOKEN
+        file: release.txt
+        skip_cleanup: true
+        on:
+                tags: true


### PR DESCRIPTION
Travis will release to github if we have a deploy step. This patch
triggers a deployment whenever master is tagged. Prior to doing the
release, the tag message is output to a file so that it can be included
as a release artifact (attachment).

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>