### PR TITLE
Single VM Dev: Fix race condition in image download

### DIFF
--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -192,7 +192,7 @@ if [ $download -eq 1 ] || [ ! -f clear-"${LATEST}"-cloud.img ]
 then
 	rm -f clear-"${LATEST}"-cloud.img.xz
 	rm -f clear-"${LATEST}"-cloud.img
-	curl -O https://download.clearlinux.org/image/clear-"${LATEST}"-cloud.img.xz
+	curl -O https://download.clearlinux.org/releases/"$LATEST"/clear/clear-"$LATEST"-cloud.img.xz
 	xz -T0 --decompress clear-"${LATEST}"-cloud.img.xz
 fi
 


### PR DESCRIPTION
Don't break if/when reading the "latest" file and
https://download.clearlinux.org/image/ races against a publication
of changes to those two directories.

Switch to downloading from the releases location which should
be available

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>