### PR TITLE
networking: exclude kvm bridges as network interfaces

### DIFF
--- a/networking/libsnnet/utils.go
+++ b/networking/libsnnet/utils.go
@@ -128,7 +128,8 @@ func validPhysicalLink(link netlink.Link) bool {
 	case "vlan":
 	case "macvlan":
 	case "bridge":
-		if strings.HasPrefix(link.Attrs().Name, "docker") {
+		if strings.HasPrefix(link.Attrs().Name, "docker") ||
+			strings.HasPrefix(link.Attrs().Name, "virbr") {
 			phyDevice = false
 		}
 	default:


### PR DESCRIPTION
Exclude KVM bridges as valid management and compute interfaces.
This allows for seamless auto configuration on hosts where
kvm installation results in the creation of virtual networks
and their corresponding bridges.

This issue crops up because we recently allowed bridges to be used 
as valid network interfaces for compute and management traffic.

Longer term we should consider allowing any interface as a valid 
interface as long as it falls in the configured subnet.

This change allows ciao to be used with no configuration if all the
nodes are single homed.

Fixes issue https://github.com/01org/ciao/issues/272

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>