### PR TITLE
travis: get annotated tag from root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,6 @@ after_success:
    - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=/tmp/cover.out
 
 before_deploy:
-   - cd $GOPATH/src/github.com/01org/ciao
    - tag=`git describe --abbrev=0 --tags`
    - git show $tag > /tmp/release.txt
 


### PR DESCRIPTION
We don't need to use GOPATH as travis should checkout our
repo into the root.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>