### PR TITLE
Add compatibility for Compute API /v2.1/{tenant_id}/servers POST

### DIFF
--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -124,7 +124,7 @@ func (c *controller) confirmTenant(tenantID string) error {
 func (c *controller) startWorkload(workloadID string, tenantID string, instances int, trace bool, label string) ([]*types.Instance, error) {
 	var e error
 
-	if instances == 0 {
+	if instances <= 0 {
 		return nil, errors.New("Missing number of instances to start")
 	}
 

--- a/ciao-controller/compute.go
+++ b/ciao-controller/compute.go
@@ -883,9 +883,9 @@ func createServer(w http.ResponseWriter, r *http.Request, context *controller) {
 
 	nInstances := 1
 
-	if server.Server.MaxInstances != 0 {
+	if server.Server.MaxInstances > 0 {
 		nInstances = server.Server.MaxInstances
-	} else if server.Server.MinInstances != 0 {
+	} else if server.Server.MinInstances > 0 {
 		nInstances = server.Server.MinInstances
 	}
 

--- a/ciao-controller/compute.go
+++ b/ciao-controller/compute.go
@@ -482,6 +482,11 @@ func showServerDetails(w http.ResponseWriter, r *http.Request, context *controll
 		return
 	}
 
+	// OpenStack compatibility: expect active status not running for API Call
+	if server.Server.Status == "running" {
+		server.Server.Status = "active"
+	}
+
 	b, err := json.Marshal(server)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -906,7 +911,24 @@ func createServer(w http.ResponseWriter, r *http.Request, context *controller) {
 	}
 	servers.TotalServers = len(instances)
 
-	b, err := json.Marshal(servers)
+	// set machine ID for OpenStack compatibility
+	server.Server.ID = instances[0].ID
+
+	// builtServers is define to meet OpenStack compatibility on result format and keep CIAOs
+	builtServers := struct {
+		payloads.ComputeCreateServer
+		payloads.ComputeServers
+	}{
+		payloads.ComputeCreateServer{
+			Server: server.Server,
+		},
+		payloads.ComputeServers{
+			TotalServers: servers.TotalServers,
+			Servers:      servers.Servers,
+		},
+	}
+
+	b, err := json.Marshal(builtServers)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/payloads/compute.go
+++ b/payloads/compute.go
@@ -197,6 +197,7 @@ func NewComputeFlavorsDetails() (flavors ComputeFlavorsDetails) {
 // one or more instances.
 type ComputeCreateServer struct {
 	Server struct {
+		ID           string `json:"id"`
 		Name         string `json:"name"`
 		Image        string `json:"imageRef"`
 		Workload     string `json:"flavorRef"`


### PR DESCRIPTION
Add compatibility for CIAO Compute API for /v2.1/{tenant_id}/servers
for method POST, the calls and results should be in same format as
Nova to be fully compatible with OpenStack.

Signed-off-by: Leoswaldo Macias <leoswaldo.macias@intel.com>