### PR TITLE
ciao-controller: Return a meaningful error when workload does not exist

### DIFF
--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -891,7 +891,10 @@ func (ds *sqliteDB) getWorkloadNoCache(id string) (*workload, error) {
 	var VMType string
 
 	err := datastore.QueryRow(query, id).Scan(&work.ID, &work.Description, &work.filename, &work.FWType, &VMType, &work.ImageID, &work.ImageName)
-	if err != nil {
+	switch {
+	case err == sql.ErrNoRows:
+		return nil, fmt.Errorf("Workload %q not found", id)
+	case err != nil:
 		return nil, err
 	}
 


### PR DESCRIPTION
When running ciao-cli instance add -workload not-a-workload the error
returned is not clear on the cause of it.

Fixes #292

Signed-off-by: Alberto Murillo <alberto.murillo.silva@intel.com>