### PR TITLE
Add proper return codes to /v2.1/{tenant}/servers/{server} GET Method…

### DIFF
--- a/payloads/compute.go
+++ b/payloads/compute.go
@@ -451,3 +451,19 @@ func NewCiaoEvents() (events CiaoEvents) {
 	events.Events = []CiaoEvent{}
 	return
 }
+
+// HTTPErrorData represents the HTTP response body for
+// a compute API request error.
+type HTTPErrorData struct {
+	Code    int    `json:"code"`
+	Name    string `json:"name"`
+	Message string `json:"message"`
+}
+
+// HTTPReturnErrorCode represents the unmarshalled version for Return codes
+// when a API call is made and you need to return explicit data of
+// the call as OpenStack format
+// http://developer.openstack.org/api-guide/compute/faults.html
+type HTTPReturnErrorCode struct {
+	Error HTTPErrorData `json:"error"`
+}


### PR DESCRIPTION
… API Call

The function showServerDetails attending calls from /v2.1/{tenant}/servers/{server}
GET Method was returning 500 InternalServerError for all error cases, this
fix covers Unauthorized, NotFound and InternalServer return errors for each
corresponding case. Also returning a more meaningful error message.

Fixes #158

Signed-off-by: Leoswaldo Macias <leoswaldo.macias@intel.com>