### PR TITLE
ciao-controller: set proper http error return codes

### DIFF
--- a/ciao-controller/compute.go
+++ b/ciao-controller/compute.go
@@ -1356,13 +1356,13 @@ func listTraces(w http.ResponseWriter, r *http.Request, context *controller) {
 	var traces payloads.CiaoTracesSummary
 
 	if validateToken(context, r) == false {
-		http.Error(w, "Invalid token", http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusUnauthorized, "Invalid token")
 		return
 	}
 
 	summaries, err := context.ds.GetBatchFrameSummary()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -1376,7 +1376,7 @@ func listTraces(w http.ResponseWriter, r *http.Request, context *controller) {
 
 	b, err := json.Marshal(traces)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -1446,13 +1446,13 @@ func traceData(w http.ResponseWriter, r *http.Request, context *controller) {
 	var traceData payloads.CiaoTraceData
 
 	if validateToken(context, r) == false {
-		http.Error(w, "Invalid token", http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusUnauthorized, "Invalid token")
 		return
 	}
 
 	batchStats, err := context.ds.GetBatchFrameStatistics(label)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusNotFound, "Could not found trace with label")
 		return
 	}
 
@@ -1470,7 +1470,7 @@ func traceData(w http.ResponseWriter, r *http.Request, context *controller) {
 
 	b, err := json.Marshal(traceData)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 

--- a/ciao-controller/compute.go
+++ b/ciao-controller/compute.go
@@ -577,13 +577,13 @@ func listFlavors(w http.ResponseWriter, r *http.Request, context *controller) {
 	dumpRequest(r)
 
 	if validateToken(context, r) == false {
-		http.Error(w, "Invalid token", http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusUnauthorized, "Invalid token")
 		return
 	}
 
 	workloads, err := context.ds.GetWorkloads()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -602,7 +602,7 @@ func listFlavors(w http.ResponseWriter, r *http.Request, context *controller) {
 
 	b, err := json.Marshal(flavors)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -617,13 +617,13 @@ func listFlavorsDetails(w http.ResponseWriter, r *http.Request, context *control
 	dumpRequest(r)
 
 	if validateToken(context, r) == false {
-		http.Error(w, "Invalid token", http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusUnauthorized, "Invalid token")
 		return
 	}
 
 	workloads, err := context.ds.GetWorkloads()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -638,7 +638,7 @@ func listFlavorsDetails(w http.ResponseWriter, r *http.Request, context *control
 
 	b, err := json.Marshal(flavors)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -654,19 +654,19 @@ func showFlavorDetails(w http.ResponseWriter, r *http.Request, context *controll
 	dumpRequest(r)
 
 	if validateToken(context, r) == false {
-		http.Error(w, "Invalid token", http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusUnauthorized, "Invalid token")
 		return
 	}
 
 	workload, err := context.ds.GetWorkload(workloadID)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusNotFound, "Workload not found")
 		return
 	}
 
 	details, err := buildFlavorDetails(workload)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -674,7 +674,7 @@ func showFlavorDetails(w http.ResponseWriter, r *http.Request, context *controll
 
 	b, err := json.Marshal(flavor)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 

--- a/ciao-controller/compute.go
+++ b/ciao-controller/compute.go
@@ -1391,13 +1391,13 @@ func listEvents(w http.ResponseWriter, r *http.Request, context *controller) {
 	events := payloads.NewCiaoEvents()
 
 	if validateToken(context, r) == false {
-		http.Error(w, "Invalid token", http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusUnauthorized, "Invalid token")
 		return
 	}
 
 	logs, err := context.ds.GetEventLog()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -1417,7 +1417,7 @@ func listEvents(w http.ResponseWriter, r *http.Request, context *controller) {
 
 	b, err := json.Marshal(events)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -1427,13 +1427,13 @@ func listEvents(w http.ResponseWriter, r *http.Request, context *controller) {
 
 func clearEvents(w http.ResponseWriter, r *http.Request, context *controller) {
 	if validateToken(context, r) == false {
-		http.Error(w, "Invalid token", http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusUnauthorized, "Invalid token")
 		return
 	}
 
 	err := context.ds.ClearLog()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 

--- a/ciao-controller/compute.go
+++ b/ciao-controller/compute.go
@@ -1129,7 +1129,7 @@ func listNodes(w http.ResponseWriter, r *http.Request, context *controller) {
 	dumpRequest(r)
 
 	if validateToken(context, r) == false {
-		http.Error(w, "Invalid token", http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusUnauthorized, "Invalid token")
 		return
 	}
 
@@ -1137,7 +1137,7 @@ func listNodes(w http.ResponseWriter, r *http.Request, context *controller) {
 
 	nodeSummary, err := context.ds.GetNodeSummary()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -1163,7 +1163,7 @@ func listNodes(w http.ResponseWriter, r *http.Request, context *controller) {
 
 	b, err := pager.nextPage(none, "", r)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -1177,7 +1177,7 @@ func nodesSummary(w http.ResponseWriter, r *http.Request, context *controller) {
 	dumpRequest(r)
 
 	if validateToken(context, r) == false {
-		http.Error(w, "Invalid token", http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusUnauthorized, "Invalid token")
 		return
 	}
 
@@ -1200,7 +1200,7 @@ func nodesSummary(w http.ResponseWriter, r *http.Request, context *controller) {
 
 	b, err := json.Marshal(nodesStatus)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -1215,7 +1215,7 @@ func listNodeServers(w http.ResponseWriter, r *http.Request, context *controller
 	dumpRequest(r)
 
 	if validateToken(context, r) == false {
-		http.Error(w, "Invalid token", http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusUnauthorized, "Invalid token")
 		return
 	}
 
@@ -1223,7 +1223,7 @@ func listNodeServers(w http.ResponseWriter, r *http.Request, context *controller
 
 	instances, err := context.ds.GetAllInstancesByNode(nodeID)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusNotFound, "Instances could not be found in node")
 		return
 	}
 
@@ -1245,7 +1245,7 @@ func listNodeServers(w http.ResponseWriter, r *http.Request, context *controller
 
 	b, err := pager.nextPage(none, "", r)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 

--- a/ciao-controller/compute.go
+++ b/ciao-controller/compute.go
@@ -697,13 +697,13 @@ func listTenantQuotas(w http.ResponseWriter, r *http.Request, context *controlle
 	dumpRequest(r)
 
 	if validateToken(context, r) == false {
-		http.Error(w, "Invalid token", http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusUnauthorized, "Invalid token")
 		return
 	}
 
 	t, err := context.ds.GetTenant(tenant)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusNotFound, "Tenant could not be found")
 		return
 	}
 
@@ -711,20 +711,20 @@ func listTenantQuotas(w http.ResponseWriter, r *http.Request, context *controlle
 		if *noNetwork {
 			_, err := context.ds.AddTenant(tenant)
 			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
+				returnErrorCode(w, http.StatusInternalServerError, err.Error())
 				return
 			}
 		} else {
 			err = context.addTenant(tenant)
 			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
+				returnErrorCode(w, http.StatusInternalServerError, err.Error())
 				return
 			}
 		}
 
 		t, err = context.ds.GetTenant(tenant)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			returnErrorCode(w, http.StatusNotFound, "Tenant could not be found")
 			return
 		}
 	}
@@ -755,7 +755,7 @@ func listTenantQuotas(w http.ResponseWriter, r *http.Request, context *controlle
 
 	b, err := json.Marshal(tenantResource)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -792,13 +792,13 @@ func listTenantResources(w http.ResponseWriter, r *http.Request, context *contro
 	dumpRequest(r)
 
 	if validateToken(context, r) == false {
-		http.Error(w, "Invalid token", http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusUnauthorized, "Invalid token")
 		return
 	}
 
 	start, end, err := tenantQueryParse(r)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -807,13 +807,13 @@ func listTenantResources(w http.ResponseWriter, r *http.Request, context *contro
 
 	usage.Usages, err = context.ds.GetTenantUsage(tenant, start, end)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
 	b, err := json.Marshal(usage)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -1093,13 +1093,13 @@ func listTenants(w http.ResponseWriter, r *http.Request, context *controller) {
 	dumpRequest(r)
 
 	if validateToken(context, r) == false {
-		http.Error(w, "Unauthorized token", http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusUnauthorized, "Invalid token")
 		return
 	}
 
 	tenants, err := context.ds.GetAllTenants()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -1117,7 +1117,7 @@ func listTenants(w http.ResponseWriter, r *http.Request, context *controller) {
 
 	b, err := json.Marshal(computeTenants)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 

--- a/ciao-controller/compute.go
+++ b/ciao-controller/compute.go
@@ -1259,13 +1259,13 @@ func listCNCIs(w http.ResponseWriter, r *http.Request, context *controller) {
 	dumpRequest(r)
 
 	if validateToken(context, r) == false {
-		http.Error(w, "Invalid token", http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusUnauthorized, "Invalid token")
 		return
 	}
 
 	cncis, err := context.ds.GetTenantCNCISummary("")
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -1296,7 +1296,7 @@ func listCNCIs(w http.ResponseWriter, r *http.Request, context *controller) {
 
 	b, err := json.Marshal(ciaoCNCIs)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 
@@ -1312,13 +1312,13 @@ func listCNCIDetails(w http.ResponseWriter, r *http.Request, context *controller
 	dumpRequest(r)
 
 	if validateToken(context, r) == false {
-		http.Error(w, "Invalid token", http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusUnauthorized, "Invalid token")
 		return
 	}
 
 	cncis, err := context.ds.GetTenantCNCISummary(cnciID)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusNotFound, "CNCI could not be found")
 		return
 	}
 
@@ -1344,7 +1344,7 @@ func listCNCIDetails(w http.ResponseWriter, r *http.Request, context *controller
 
 	b, err := json.Marshal(ciaoCNCI)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		returnErrorCode(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 


### PR DESCRIPTION
This pull requests is to set the proper http error return codes when something goes wrong in the controller.
Here we define the type errors 
- StatusNotFound
- StatusInternalServerError
- StatusUnauthorized
- StatusBadRequest
- StatusServiceUnavailable

A complete reference for net/http module can be found in https://golang.org/pkg/net/http/
This series of commits are split by entities handled by CIAO-CONTROLLER, same functionality but I prefer to keep them separated for each one :

- Servers
- Flavors
- Tenants
- Nodes
- Events
- CNCI
- Trace