### PR TITLE
release: Adapt for ciao-cli instance list change

### DIFF
--- a/_release/bat/release_test.py
+++ b/_release/bat/release_test.py
@@ -348,7 +348,7 @@ def get_instances():
     Returns:
         A list of dictionary representations of an instance
     """
-    args = ['ciao-cli', 'instance', 'list']
+    args = ['ciao-cli', 'instance', 'list', '-detail']
 
     instances = []
 


### PR DESCRIPTION
ciao-cli instance list no longer show all instances details, we
need to call ciao-cli instance list -detail instead.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>