### PR TITLE
ssntp: Add smart default certificates finding

### DIFF
--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -95,8 +95,8 @@ var simulate bool
 var maxInstances = int(math.MaxInt32)
 
 func init() {
-	flag.StringVar(&serverCertPath, "cacert", "/etc/pki/ciao/CAcert-server-localhost.pem", "Client certificate")
-	flag.StringVar(&clientCertPath, "cert", "/etc/pki/ciao/cert-client-localhost.pem", "CA certificate")
+	flag.StringVar(&serverCertPath, "cacert", "", "Client certificate")
+	flag.StringVar(&clientCertPath, "cert", "", "CA certificate")
 	flag.Var(&networking, "network", "Can be none, cn (compute node) or nn (network node)")
 	flag.BoolVar(&hardReset, "hard-reset", false, "Kill and delete all instances, reset networking and exit")
 	flag.BoolVar(&simulate, "simulation", false, "Launcher simulation")


### PR DESCRIPTION
This change adds value to our Zero Configuration approach in CIAO
project. It sets ``--cacert`` and ``--cert`` as optional parameters.

For example:
```
  $ ciao-launcher --network=<Role>
```
It will search for ``CAcert*`` and ``cert-<Role>*`` certificate files at
``/etc/pki/ciao/`` path, if it finds them, it will try to use them.

Fix to Issue #254 

Signed-off-by: Munoz, Obed N <obed.n.munoz@intel.com>