### PR TITLE
Fix instance status strings inconsistency

### DIFF
--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/01org/ciao/ciao-controller/types"
+	"github.com/01org/ciao/payloads"
 	"github.com/golang/glog"
 )
 
@@ -62,7 +63,7 @@ func (c *controller) stopInstance(instanceID string) error {
 		return errors.New("Cannot stop instance not assigned to Node")
 	}
 
-	if i.State == "pending" {
+	if i.State == payloads.ComputeStatusPending {
 		return errors.New("You may not stop a pending instance")
 	}
 

--- a/ciao-controller/compute.go
+++ b/ciao-controller/compute.go
@@ -449,12 +449,6 @@ func instanceToServer(context *controller, instance *types.Instance) (payloads.S
 		SSHPort: instance.SSHPort,
 	}
 
-	// OpenStack compatibility: expected status for a running
-	// instance is 'active and not 'running'.
-	if server.Status == "running" {
-		server.Status = "active"
-	}
-
 	return server, nil
 }
 

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -128,7 +128,7 @@ func addTestInstanceStats(t *testing.T) ([]*types.Instance, payloads.Stat) {
 	for i := range instances {
 		stat := payloads.InstanceStat{
 			InstanceUUID:  instances[i].ID,
-			State:         "running",
+			State:         payloads.ComputeStatusRunning,
 			SSHIP:         "192.168.0.1",
 			SSHPort:       34567,
 			MemoryUsageMB: 0,
@@ -512,7 +512,7 @@ func TestGetInstance(t *testing.T) {
 		t.Error("retrieved incorrect NodeID")
 	}
 
-	if instance.State != "running" {
+	if instance.State != payloads.ComputeStatusRunning {
 		t.Error("retrieved incorrect state")
 	}
 }
@@ -547,7 +547,7 @@ func TestHandleStats(t *testing.T) {
 	for i := range instances {
 		stat := payloads.InstanceStat{
 			InstanceUUID:  instances[i].ID,
-			State:         "running",
+			State:         payloads.ComputeStatusRunning,
 			SSHIP:         "192.168.0.1",
 			SSHPort:       34567,
 			MemoryUsageMB: 0,
@@ -587,7 +587,7 @@ func TestHandleStats(t *testing.T) {
 			t.Error("Incorrect NodeID in stats table")
 		}
 
-		if instance.State != "running" {
+		if instance.State != payloads.ComputeStatusRunning {
 			t.Error("state not updated")
 		}
 	}
@@ -623,7 +623,7 @@ func TestGetInstanceLastStats(t *testing.T) {
 	for i := range instances {
 		stat := payloads.InstanceStat{
 			InstanceUUID:  instances[i].ID,
-			State:         "running",
+			State:         payloads.ComputeStatusRunning,
 			SSHIP:         "192.168.0.1",
 			SSHPort:       34567,
 			MemoryUsageMB: 0,
@@ -688,7 +688,7 @@ func TestGetNodeLastStats(t *testing.T) {
 	for i := range instances {
 		stat := payloads.InstanceStat{
 			InstanceUUID:  instances[i].ID,
-			State:         "running",
+			State:         payloads.ComputeStatusRunning,
 			SSHIP:         "192.168.0.1",
 			SSHPort:       34567,
 			MemoryUsageMB: 0,
@@ -870,7 +870,7 @@ func TestAddInstanceStats(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		stat := payloads.InstanceStat{
 			InstanceUUID:  uuid.Generate().String(),
-			State:         "running",
+			State:         payloads.ComputeStatusRunning,
 			SSHIP:         "192.168.0.1",
 			SSHPort:       34567,
 			MemoryUsageMB: 0,
@@ -894,7 +894,7 @@ func TestAddNodeStats(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		stat := payloads.InstanceStat{
 			InstanceUUID:  uuid.Generate().String(),
-			State:         "running",
+			State:         payloads.ComputeStatusRunning,
 			SSHIP:         "192.168.0.1",
 			SSHPort:       34567,
 			MemoryUsageMB: 0,

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -1196,7 +1196,7 @@ func (ds *sqliteDB) getInstances() ([]*types.Instance, error) {
 	)
 	SELECT	instances.id,
 		instances.tenant_id,
-		IFNULL(latest.state, "pending") AS state,
+		IFNULL(latest.state, "` + payloads.ComputeStatusPending + `") AS state,
 		workload_id,
 		IFNULL(latest.ssh_ip, "Not Assigned") as ssh_ip,
 		latest.ssh_port as ssh_port,
@@ -1289,7 +1289,7 @@ func (ds *sqliteDB) getTenantInstances(tenantID string) (map[string]*types.Insta
 	)
 	SELECT	instances.id,
 		instances.tenant_id,
-		IFNULL(latest.state, "pending") AS state,
+		IFNULL(latest.state, "` + payloads.ComputeStatusPending + `") AS state,
 		IFNULL(latest.ssh_ip, "Not Assigned") AS ssh_ip,
 		latest.ssh_port AS ssh_port,
 		workload_id,
@@ -1628,7 +1628,7 @@ WITH instances AS
 		GROUP BY instance_id
 	)
 	SELECT db.instances.id AS instance_id,
-	       IFNULL(latest.state, "pending") AS state,
+	       IFNULL(latest.state, "` + payloads.ComputeStatusPending + `") AS state,
 	       IFNULL(latest.node_id, "Not Assigned") AS node_id
 	FROM db.instances
 	LEFT JOIN latest
@@ -1646,7 +1646,7 @@ total_running AS
 	SELECT	instances.node_id AS node_id,
 		count(instances.instance_id) AS total
 	FROM instances
-	WHERE state='running'
+	WHERE state='` + payloads.ComputeStatusRunning + `'
 	GROUP BY node_id
 ),
 total_pending AS
@@ -1654,7 +1654,7 @@ total_pending AS
 	SELECT	instances.node_id AS node_id,
 		count(instances.instance_id) AS total
 	FROM instances
-	WHERE state='pending'
+	WHERE state='` + payloads.ComputeStatusPending + `'
 	GROUP BY node_id
 ),
 total_exited AS
@@ -1662,7 +1662,7 @@ total_exited AS
 	SELECT	instances.node_id,
 		count(instances.instance_id) AS total
 	FROM instances
-	WHERE state='exited'
+	WHERE state='` + payloads.ComputeStatusStopped + `'
 	GROUP BY node_id
 )
 SELECT	total_instances.node_id,

--- a/ciao-launcher/tests/ciaolc/ciaolc.go
+++ b/ciao-launcher/tests/ciaolc/ciaolc.go
@@ -62,9 +62,11 @@ func (f *filter) String() string {
 }
 
 func (f *filter) Set(val string) error {
-	if val != "none" && val != "exited" && val != "pending" &&
-		val != "running" {
-		return fmt.Errorf("exited, pending, running expected")
+	if val != "none" &&
+		val != payloads.ComputeStatusStopped &&
+		val != payloads.ComputeStatusPending &&
+		val != payloads.ComputeStatusRunning {
+		return fmt.Errorf("exited, pending, active expected")
 	}
 	*f = filter(val)
 

--- a/payloads/compute.go
+++ b/payloads/compute.go
@@ -64,7 +64,7 @@ const (
 
 	// ComputeStatusRunning is a filter that used to select running
 	// instances in requests to the controller.
-	ComputeStatusRunning = "running"
+	ComputeStatusRunning = "active"
 
 	// ComputeStatusStopped is a filter that used to select exited
 	// instances in requests to the controller.

--- a/payloads/stats.go
+++ b/payloads/stats.go
@@ -107,15 +107,15 @@ const (
 	// instance is in the process of being created, or ciao-launcher itself
 	// has just started and is still gathering information about the
 	// existing instances.
-	Pending = "pending"
+	Pending = ComputeStatusPending
 
 	// Running indicates an instance is running
-	Running = "running"
+	Running = ComputeStatusRunning
 
 	// Exited indicates that an instance has been successfully created but
 	// is not currently running, either because it failed to start or was
 	// explicitly stopped by a STOP command or perhaps by a CN reboot.
-	Exited = "exited"
+	Exited = ComputeStatusStopped
 	// ExitFailed is not currently used
 	ExitFailed = "exit_failed"
 	// ExitPaused is not currently used

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -465,14 +465,14 @@ networks:
   mac: 02:00:8c:ba:f9:45
 instances:
 - instance_uuid: fe2970fa-7b36-460b-8b79-9eb4745e62f2
-  state: running
+  state: active
   ssh_ip: ""
   ssh_port: 0
   memory_usage_mb: 40
   disk_usage_mb: 2
   cpu_usage: 90
 - instance_uuid: cbda5bd8-33bd-4d39-9f52-ace8c9f0b99c
-  state: running
+  state: active
   ssh_ip: 172.168.2.2
   ssh_port: 8768
   memory_usage_mb: 50


### PR DESCRIPTION
- Align the STATS instance status strings with the compute API ones
- Only use the payloads defined constants for manipulating instance statuses
- Redefine ComputeStatusRunning to "active"