### PR TITLE
test-cases: Deal with the travis time out and hung tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,9 @@ script:
    - go list ./... | grep -v github.com/01org/ciao/vendor | xargs go list -f '{{.Dir}}' | xargs gofmt -s -l | wc -l | xargs -I % bash -c "test % -eq 0"
    - sudo mkdir -p /var/lib/ciao/instances
    - sudo chmod 0777 /var/lib/ciao/instances
-   - test-cases -text -coverprofile /tmp/cover.out -short github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/ciao-controller/... github.com/01org/ciao/payloads github.com/01org/ciao/configuration github.com/01org/ciao/testutil github.com/01org/ciao/ssntp/uuid
-   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -text -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/ssntp
-   - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -text -short -tags travis -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/networking/libsnnet
+   - test-cases -v -timeout 9 -text -coverprofile /tmp/cover.out -short github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/ciao-controller/... github.com/01org/ciao/payloads github.com/01org/ciao/configuration github.com/01org/ciao/testutil github.com/01org/ciao/ssntp/uuid
+   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -text -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/ssntp
+   - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -text -short -tags travis -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/networking/libsnnet
 
 after_success:
    - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=/tmp/cover.out


### PR DESCRIPTION
The following two commits improve test-cases integration with travis in two ways:

1. An optional -v parameter is added.  When specified test-cases prints out the name of the package it is about to test.  Previously, test-cases didn't output anything until unit tests for all packages had finished.  But this mean that all tests needed to finish in under 10 minutes otherwise travis would cancel the build.  If you specify the -v option you give each package 10 minutes to complete it's tests.
2. The timeout option has been added which can be used to cancel the unit tests for a given package after a given amount of time.  The underlying go-test executable is terminated with a SIGABRT, which allows us to capture the stack trace.  This option is useful to cancel the unit tests for packages that have hung.  If the test-cases timeout is not use, Travis CI will cancel the entire build and we will probably not get any meaningful logs.
3. The .travis.yml file has been updated to enable both of these options.  A timeout of 9 minutes is specified.  You can see the results of all this by looking at the following build:

https://travis-ci.org/markdryan/ciao/jobs/141718321

From the logs we can deduce that TestDeleteInstance has hung, probably because the previous test failed and there were some locking issues as a result.