### PR TITLE
ciao-launcher: Update the -network parameter

### DIFF
--- a/ciao-launcher/README.md
+++ b/ciao-launcher/README.md
@@ -72,7 +72,7 @@ Currently, this is the only data source supported by launcher.
 
 ciao-launcher can be launched from the command line as follows
 ```
-sudo ciao-launcher -network [cn|nn|none]
+sudo ciao-launcher
 ```
 
 Currently, launcher needs to be run as root so that it can create network links and
@@ -105,8 +105,8 @@ Usage of ./launcher:
     	If non-empty, write log files in this directory
   -logtostderr
     	log to standard error instead of files
-  -network value
-    	Can be none, cn (compute node) or nn (network node) (default none)
+  -network
+    	Enable networking (default true)
   -simulation
     	Launcher simulation
   -stderrthreshold value
@@ -273,7 +273,7 @@ ciao-launcher-server.
 
 Open a new terminal and start ciao-launcher, e.g.,
 
-./ciao-launcher --logtostderr --network cn
+./ciao-launcher --logtostderr
 
 Open a new terminal and try some ciaolc commands
 

--- a/ciao-launcher/delete_instance.go
+++ b/ciao-launcher/delete_instance.go
@@ -50,7 +50,7 @@ func processDelete(vm virtualizer, instanceDir string, conn serverConn, running 
 
 	_ = vm.deleteImage()
 
-	if networking.Enabled() && running != ovsPending {
+	if networking && running != ovsPending {
 		glog.Info("Deleting Vnic")
 		deleteVnic(instanceDir, conn)
 	}

--- a/ciao-launcher/instance_test.go
+++ b/ciao-launcher/instance_test.go
@@ -501,6 +501,7 @@ func TestStopNotRunning(t *testing.T) {
 }
 
 func startVMWithCFG(t *testing.T, wg *sync.WaitGroup, cfg *vmConfig, connect bool, errorOk bool) (*instanceTestState, chan interface{}, chan<- interface{}, chan struct{}) {
+	networking = false
 	doneCh := make(chan struct{})
 	ovsCh := make(chan interface{})
 	state := &instanceTestState{

--- a/ciao-launcher/restart_instance.go
+++ b/ciao-launcher/restart_instance.go
@@ -27,7 +27,7 @@ func processRestart(instanceDir string, vm virtualizer, conn serverConn, cfg *vm
 	var vnicCfg *libsnnet.VnicConfig
 	var err error
 
-	if networking.Enabled() {
+	if networking {
 		vnicCfg, err = createVnicCfg(cfg)
 		if err != nil {
 			glog.Errorf("Could not create VnicCFG: %s", err)

--- a/ciao-launcher/start_instance.go
+++ b/ciao-launcher/start_instance.go
@@ -131,7 +131,7 @@ func processStart(cmd *insStartCmd, instanceDir string, vm virtualizer, conn ser
 		return nil, &startError{err, payloads.InvalidData}
 	}
 
-	if networking.Enabled() {
+	if networking {
 		vnicCfg, err = createVnicCfg(cfg)
 		if err != nil {
 			glog.Errorf("Could not create VnicCFG: %s", err)

--- a/testutil/singlevm/run_launcher.sh
+++ b/testutil/singlevm/run_launcher.sh
@@ -7,7 +7,7 @@ default_if=$(ip route list | awk '/^default/ {print $5}')
 default_subnet=$(ip -o -f inet addr show $default_if | awk '{print $4}')
 
 #Cleanup artifacts
-sudo "$GOPATH"/bin/ciao-launcher --cacert=./CAcert-"$ciao_host".pem --cert=./cert-CNAgent-NetworkingAgent-"$ciao_host".pem --alsologtostderr -v 3 --hard-reset --network=dual
+sudo "$GOPATH"/bin/ciao-launcher --cacert=./CAcert-"$ciao_host".pem --cert=./cert-CNAgent-NetworkingAgent-"$ciao_host".pem --alsologtostderr -v 3 --hard-reset
 
 #Cleanup any prior docker instances and networks
 sudo docker rm $(sudo docker ps -qa)
@@ -15,4 +15,4 @@ sudo docker network rm $(sudo docker network ls -q -f "type=custom")
 sudo rm -f /var/lib/ciao/networking/docker_plugin.db
 
 #Run launcher
-sudo "$GOPATH"/bin/ciao-launcher --cacert=./CAcert-"$ciao_host".pem --cert=./cert-CNAgent-NetworkingAgent-"$ciao_host".pem -v 3 --network=dual &
+sudo "$GOPATH"/bin/ciao-launcher --cacert=./CAcert-"$ciao_host".pem --cert=./cert-CNAgent-NetworkingAgent-"$ciao_host".pem -v 3  &


### PR DESCRIPTION
-network is now a bool parameter and it defaults to true.  Previously, it
was an emumerated type that accepted none, cn, nn, or dual.  But these
additional values are no longer needed as SSNTP can deduce the role
from its certificates.  Another important note is that -network defaults
to true.  Previously, if the networking flag was unspecified, networking
was disabled.  This default behaviour was left over from the early days
of ciao when we were integrating networking.  Networking on by default
is now the sensible choice.

Fixes #162

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>