### PR TITLE
configuration: image service URL not mandatory

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -41,7 +41,6 @@ func validMinConf(conf *payloads.Configure) bool {
 		conf.Configure.Controller.HTTPSKey != "" &&
 		conf.Configure.Controller.IdentityUser != "" &&
 		conf.Configure.Controller.IdentityPassword != "" &&
-		conf.Configure.ImageService.URL != "" &&
 		conf.Configure.IdentityService.URL != "")
 }
 

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -51,8 +51,6 @@ const minValidConf = `configure:
   launcher:
     compute_net: 192.168.1.110
     mgmt_net: 192.168.1.111
-  image_service:
-    url: http://glance.example.com
   identity_service:
     url: http://keystone.example.com
 `
@@ -230,7 +228,6 @@ func TestValidMinConf(t *testing.T) {
 	conf.Configure.Controller.IdentityPassword = identityPassword
 	conf.Configure.Launcher.ComputeNetwork = computeNet
 	conf.Configure.Launcher.ManagementNetwork = mgmtNet
-	conf.Configure.ImageService.URL = glanceURL
 
 	valid := validMinConf(&conf)
 	if valid != false {


### PR DESCRIPTION
we don't support image service at this point, so it doesn't
make sense to enforce this value in the configuration setup.
This commit removes checking the ImageService URL from being
present in a minimal configuration yaml.

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>