### PR TITLE
Unittests: more ssntp event flows

### DIFF
--- a/ciao-controller/compute_test.go
+++ b/ciao-controller/compute_test.go
@@ -233,12 +233,7 @@ func TestDeleteServer(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	c := client.AddCmdChan(ssntp.STATS)
-	go client.SendStatsCmd()
-	_, err = client.GetCmdChanResult(c, ssntp.STATS)
-	if err != nil {
-		t.Fatal(err)
-	}
+	sendStatsCmd(client, t)
 
 	time.Sleep(2 * time.Second)
 
@@ -280,12 +275,7 @@ func TestServersActionStart(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	c := client.AddCmdChan(ssntp.STATS)
-	go client.SendStatsCmd()
-	_, err = client.GetCmdChanResult(c, ssntp.STATS)
-	if err != nil {
-		t.Fatal(err)
-	}
+	sendStatsCmd(client, t)
 
 	time.Sleep(1 * time.Second)
 
@@ -296,12 +286,7 @@ func TestServersActionStart(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	c = client.AddCmdChan(ssntp.STATS)
-	go client.SendStatsCmd()
-	_, err = client.GetCmdChanResult(c, ssntp.STATS)
-	if err != nil {
-		t.Fatal(err)
-	}
+	sendStatsCmd(client, t)
 
 	time.Sleep(1 * time.Second)
 
@@ -342,12 +327,7 @@ func TestServersActionStop(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	c := client.AddCmdChan(ssntp.STATS)
-	go client.SendStatsCmd()
-	_, err = client.GetCmdChanResult(c, ssntp.STATS)
-	if err != nil {
-		t.Fatal(err)
-	}
+	sendStatsCmd(client, t)
 
 	time.Sleep(1 * time.Second)
 
@@ -388,12 +368,7 @@ func TestServerActionStop(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	c := client.AddCmdChan(ssntp.STATS)
-	go client.SendStatsCmd()
-	_, err = client.GetCmdChanResult(c, ssntp.STATS)
-	if err != nil {
-		t.Fatal(err)
-	}
+	sendStatsCmd(client, t)
 
 	time.Sleep(1 * time.Second)
 
@@ -422,35 +397,25 @@ func TestServerActionStart(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	c := client.AddCmdChan(ssntp.STATS)
-	go client.SendStatsCmd()
-	_, err = client.GetCmdChanResult(c, ssntp.STATS)
-	if err != nil {
-		t.Fatal(err)
-	}
+	sendStatsCmd(client, t)
 
 	time.Sleep(1 * time.Second)
 
-	c = server.AddCmdChan(ssntp.STOP)
+	serverCh := server.AddCmdChan(ssntp.STOP)
 
 	err = context.stopInstance(servers.Servers[0].ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = server.GetCmdChanResult(c, ssntp.STOP)
+	_, err = server.GetCmdChanResult(serverCh, ssntp.STOP)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	time.Sleep(1 * time.Second)
 
-	c = client.AddCmdChan(ssntp.STATS)
-	go client.SendStatsCmd()
-	_, err = client.GetCmdChanResult(c, ssntp.STATS)
-	if err != nil {
-		t.Fatal(err)
-	}
+	sendStatsCmd(client, t)
 
 	time.Sleep(1 * time.Second)
 
@@ -924,7 +889,7 @@ func TestListTraces(t *testing.T) {
 	client := testStartTracedWorkload(t)
 	defer client.Ssntp.Close()
 
-	client.SendTrace()
+	sendTraceReportEvent(client, t)
 
 	time.Sleep(2 * time.Second)
 
@@ -1010,7 +975,7 @@ func TestTraceData(t *testing.T) {
 	client := testStartTracedWorkload(t)
 	defer client.Ssntp.Close()
 
-	client.SendTrace()
+	sendTraceReportEvent(client, t)
 
 	time.Sleep(2 * time.Second)
 

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -258,6 +259,34 @@ func TestStartWorkloadLaunchCNCI(t *testing.T) {
 
 }
 
+func sendTraceReportEvent(client *testutil.SsntpTestClient, t *testing.T) {
+	clientCh := client.AddEventChan(ssntp.TraceReport)
+	serverCh := server.AddEventChan(ssntp.TraceReport)
+	go client.SendTrace()
+	_, err := client.GetEventChanResult(clientCh, ssntp.TraceReport)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = server.GetEventChanResult(serverCh, ssntp.TraceReport)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func sendStatsCmd(client *testutil.SsntpTestClient, t *testing.T) {
+	clientCh := client.AddCmdChan(ssntp.STATS)
+	serverCh := server.AddCmdChan(ssntp.STATS)
+	go client.SendStatsCmd()
+	_, err := client.GetCmdChanResult(clientCh, ssntp.STATS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = server.GetCmdChanResult(serverCh, ssntp.STATS)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TBD: for the launch CNCI tests, I really need to create a fake
 // network node and test that way.
 
@@ -267,11 +296,9 @@ func TestDeleteInstance(t *testing.T) {
 	client, instances := testStartWorkload(t, 1, false, reason)
 	defer client.Ssntp.Close()
 
-	time.Sleep(1 * time.Second)
+	sendStatsCmd(client, t)
 
-	client.SendStatsCmd()
-
-	c := server.AddCmdChan(ssntp.DELETE)
+	serverCh := server.AddCmdChan(ssntp.DELETE)
 
 	time.Sleep(1 * time.Second)
 
@@ -280,7 +307,7 @@ func TestDeleteInstance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := server.GetCmdChanResult(c, ssntp.DELETE)
+	result, err := server.GetCmdChanResult(serverCh, ssntp.DELETE)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -295,11 +322,9 @@ func TestStopInstance(t *testing.T) {
 	client, instances := testStartWorkload(t, 1, false, reason)
 	defer client.Ssntp.Close()
 
-	time.Sleep(1 * time.Second)
+	sendStatsCmd(client, t)
 
-	client.SendStatsCmd()
-
-	c := server.AddCmdChan(ssntp.STOP)
+	serverCh := server.AddCmdChan(ssntp.STOP)
 
 	time.Sleep(1 * time.Second)
 
@@ -308,7 +333,7 @@ func TestStopInstance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := server.GetCmdChanResult(c, ssntp.STOP)
+	result, err := server.GetCmdChanResult(serverCh, ssntp.STOP)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -325,9 +350,10 @@ func TestRestartInstance(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	client.SendStatsCmd()
+	sendStatsCmd(client, t)
 
-	c := server.AddCmdChan(ssntp.STOP)
+	serverCh := server.AddCmdChan(ssntp.STOP)
+	clientCh := client.AddCmdChan(ssntp.STOP)
 
 	time.Sleep(1 * time.Second)
 
@@ -336,7 +362,11 @@ func TestRestartInstance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := server.GetCmdChanResult(c, ssntp.STOP)
+	result, err := server.GetCmdChanResult(serverCh, ssntp.STOP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.GetCmdChanResult(clientCh, ssntp.STOP)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -345,11 +375,10 @@ func TestRestartInstance(t *testing.T) {
 	}
 
 	// now attempt to restart
-	time.Sleep(1 * time.Second)
 
-	client.SendStatsCmd()
+	sendStatsCmd(client, t)
 
-	c = server.AddCmdChan(ssntp.RESTART)
+	serverCh = server.AddCmdChan(ssntp.RESTART)
 
 	time.Sleep(1 * time.Second)
 
@@ -358,7 +387,7 @@ func TestRestartInstance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err = server.GetCmdChanResult(c, ssntp.RESTART)
+	result, err = server.GetCmdChanResult(serverCh, ssntp.RESTART)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -374,7 +403,7 @@ func TestEvacuateNode(t *testing.T) {
 	}
 	defer client.Ssntp.Close()
 
-	c := server.AddCmdChan(ssntp.EVACUATE)
+	serverCh := server.AddCmdChan(ssntp.EVACUATE)
 
 	// ok to not send workload first?
 
@@ -383,7 +412,7 @@ func TestEvacuateNode(t *testing.T) {
 		t.Error(err)
 	}
 
-	result, err := server.GetCmdChanResult(c, ssntp.EVACUATE)
+	result, err := server.GetCmdChanResult(serverCh, ssntp.EVACUATE)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -398,9 +427,9 @@ func TestInstanceDeletedEvent(t *testing.T) {
 	client, instances := testStartWorkload(t, 1, false, reason)
 	defer client.Ssntp.Close()
 
-	time.Sleep(1 * time.Second)
+	sendStatsCmd(client, t)
 
-	client.SendStatsCmd()
+	serverCh := server.AddCmdChan(ssntp.DELETE)
 
 	time.Sleep(1 * time.Second)
 
@@ -409,9 +438,22 @@ func TestInstanceDeletedEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(1 * time.Second)
+	_, err = server.GetCmdChanResult(serverCh, ssntp.DELETE)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	client.SendDeleteEvent(instances[0].ID)
+	clientEvtCh := client.AddEventChan(ssntp.InstanceDeleted)
+	serverEvtCh := server.AddEventChan(ssntp.InstanceDeleted)
+	go client.SendDeleteEvent(instances[0].ID)
+	_, err = client.GetEventChanResult(clientEvtCh, ssntp.InstanceDeleted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = server.GetEventChanResult(serverEvtCh, ssntp.InstanceDeleted)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	time.Sleep(1 * time.Second)
 
@@ -419,43 +461,6 @@ func TestInstanceDeletedEvent(t *testing.T) {
 	_, err = context.ds.GetInstance(instances[0].ID)
 	if err == nil {
 		t.Error("Instance not deleted")
-	}
-}
-
-func TestLaunchCNCI(t *testing.T) {
-	netClient, err := testutil.NewSsntpTestClientConnection("LaunchCNCI", ssntp.NETAGENT, testutil.NetAgentUUID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer netClient.Ssntp.Close()
-
-	c := server.AddCmdChan(ssntp.START)
-
-	id := uuid.Generate().String()
-
-	// this blocks till it get success or failure
-	go context.addTenant(id)
-
-	result, err := server.GetCmdChanResult(c, ssntp.START)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.TenantUUID != id {
-		t.Fatal("Did not get correct tenant ID")
-	}
-	if !result.CNCI {
-		t.Fatal("this is not a CNCI launch request")
-	}
-
-	time.Sleep(2 * time.Second)
-
-	tenant, err := context.ds.GetTenant(id)
-	if err != nil || tenant == nil {
-		t.Fatal(err)
-	}
-
-	if tenant.CNCIIP == "" {
-		t.Fatal("CNCI Info not updated")
 	}
 }
 
@@ -480,13 +485,9 @@ func TestStopFailure(t *testing.T) {
 	client.StopFail = true
 	client.StopFailReason = payloads.StopNoInstance
 
-	time.Sleep(1 * time.Second)
+	sendStatsCmd(client, t)
 
-	client.SendStatsCmd()
-
-	time.Sleep(1 * time.Second)
-
-	c := server.AddCmdChan(ssntp.STOP)
+	serverCh := server.AddCmdChan(ssntp.STOP)
 
 	time.Sleep(1 * time.Second)
 
@@ -495,7 +496,7 @@ func TestStopFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := server.GetCmdChanResult(c, ssntp.STOP)
+	result, err := server.GetCmdChanResult(serverCh, ssntp.STOP)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -532,20 +533,23 @@ func TestRestartFailure(t *testing.T) {
 	client.RestartFail = true
 	client.RestartFailReason = payloads.RestartLaunchFailure
 
-	time.Sleep(1 * time.Second)
-
-	client.SendStatsCmd()
+	sendStatsCmd(client, t)
 
 	time.Sleep(1 * time.Second)
 
-	c := server.AddCmdChan(ssntp.STOP)
+	serverCh := server.AddCmdChan(ssntp.STOP)
+	clientCh := client.AddCmdChan(ssntp.STOP)
 
 	err := context.stopInstance(instances[0].ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	result, err := server.GetCmdChanResult(c, ssntp.STOP)
+	_, err = client.GetCmdChanResult(clientCh, ssntp.STOP)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := server.GetCmdChanResult(serverCh, ssntp.STOP)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -553,20 +557,18 @@ func TestRestartFailure(t *testing.T) {
 		t.Fatal("Did not get correct Instance ID")
 	}
 
-	time.Sleep(1 * time.Second)
-
-	client.SendStatsCmd()
+	sendStatsCmd(client, t)
 
 	time.Sleep(1 * time.Second)
 
-	c = server.AddCmdChan(ssntp.RESTART)
+	serverCh = server.AddCmdChan(ssntp.RESTART)
 
 	err = context.restartInstance(instances[0].ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	result, err = server.GetCmdChanResult(c, ssntp.RESTART)
+	result, err = server.GetCmdChanResult(serverCh, ssntp.RESTART)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -625,7 +627,8 @@ func testStartTracedWorkload(t *testing.T) *testutil.SsntpTestClient {
 		t.Fatal("No workloads, expected len(wls) > 0, got len(wls) == 0")
 	}
 
-	c := client.AddCmdChan(ssntp.START)
+	clientCh := client.AddCmdChan(ssntp.START)
+	serverCh := server.AddCmdChan(ssntp.START)
 
 	instances, err := context.startWorkload(wls[0].ID, tenant.ID, 1, true, "testtrace1")
 	if err != nil {
@@ -635,7 +638,11 @@ func testStartTracedWorkload(t *testing.T) *testutil.SsntpTestClient {
 		t.Fatalf("Wrong number of instances, expected 1, got %d", len(instances))
 	}
 
-	result, err := client.GetCmdChanResult(c, ssntp.START)
+	_, err = client.GetCmdChanResult(clientCh, ssntp.START)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := server.GetCmdChanResult(serverCh, ssntp.START)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -668,7 +675,8 @@ func testStartWorkload(t *testing.T, num int, fail bool, reason payloads.StartFa
 		t.Fatal("No workloads, expected len(wls) > 0, got len(wls) == 0")
 	}
 
-	c := client.AddCmdChan(ssntp.START)
+	clientCmdCh := client.AddCmdChan(ssntp.START)
+	clientErrCh := client.AddErrorChan(ssntp.StartFailure)
 	client.StartFail = fail
 	client.StartFailReason = reason
 
@@ -680,7 +688,14 @@ func testStartWorkload(t *testing.T, num int, fail bool, reason payloads.StartFa
 		t.Fatalf("Wrong number of instances, expected %d, got %d", len(instances), num)
 	}
 
-	result, err := client.GetCmdChanResult(c, ssntp.START)
+	if fail == true {
+		_, err := client.GetErrorChanResult(clientErrCh, ssntp.StartFailure)
+		if err == nil { // unexpected success
+			t.Fatal(err)
+		}
+	}
+
+	result, err := client.GetCmdChanResult(clientCmdCh, ssntp.START)
 	if fail == true && err == nil { // unexpected success
 		t.Fatal(err)
 	}
@@ -694,14 +709,13 @@ func testStartWorkload(t *testing.T, num int, fail bool, reason payloads.StartFa
 	return client, instances
 }
 
-// TestStartWorkloadLaunchCNCI starts a test CNCI
 // NOTE: the caller is responsible for calling Ssntp.Close() on the *SsntpTestClient
 func testStartWorkloadLaunchCNCI(t *testing.T, num int) (*testutil.SsntpTestClient, []*types.Instance) {
 	netClient, err := testutil.NewSsntpTestClientConnection("StartWorkloadLaunchCNCI", ssntp.NETAGENT, testutil.NetAgentUUID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// caller of TestStartWorkloadLaunchCNCI() owns doing the close
+	// caller of testStartWorkloadLaunchCNCI() owns doing the close
 	//defer netClient.Ssntp.Close()
 
 	wls, err := context.ds.GetWorkloads()
@@ -712,14 +726,20 @@ func testStartWorkloadLaunchCNCI(t *testing.T, num int) (*testutil.SsntpTestClie
 		t.Fatal("No workloads, expected len(wls) > 0, got len(wls) == 0")
 	}
 
-	c := server.AddCmdChan(ssntp.START)
+	serverCmdCh := server.AddCmdChan(ssntp.START)
+	netClientCmdCh := netClient.AddCmdChan(ssntp.START)
 
-	id := uuid.Generate().String()
+	newTenant := uuid.Generate().String() // random ~= new tenant and thus triggers start of a CNCI
 
+	// trigger the START command flow, and await results
+	// NOTE: "instances" is shared with the go subroutine and we must
+	// insure consistency between parent and child processes
 	var instances []*types.Instance
 
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
-		instances, err = context.startWorkload(wls[0].ID, id, 1, false, "")
+		instances, err = context.startWorkload(wls[0].ID, newTenant, 1, false, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -727,13 +747,19 @@ func testStartWorkloadLaunchCNCI(t *testing.T, num int) (*testutil.SsntpTestClie
 		if len(instances) != 1 {
 			t.Fatalf("Wrong number of instances, expected 1, got %d", len(instances))
 		}
+		wg.Done()
 	}()
 
-	result, err := server.GetCmdChanResult(c, ssntp.START)
+	_, err = netClient.GetCmdChanResult(netClientCmdCh, ssntp.START)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.TenantUUID != id {
+	result, err := server.GetCmdChanResult(serverCmdCh, ssntp.START)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.TenantUUID != newTenant {
 		t.Fatal("Did not get correct tenant ID")
 	}
 
@@ -741,14 +767,14 @@ func testStartWorkloadLaunchCNCI(t *testing.T, num int) (*testutil.SsntpTestClie
 		t.Fatal("this is not a CNCI launch request")
 	}
 
-	c = server.AddCmdChan(ssntp.START)
-
-	result, err = server.GetCmdChanResult(c, ssntp.START)
-	if err != nil {
-		t.Fatal(err)
+	tenantCNCI, _ := context.ds.GetTenantCNCISummary(result.InstanceUUID)
+	if result.InstanceUUID != tenantCNCI[0].InstanceID {
+		t.Fatalf("Did not get correct Instance ID, got %s, expected %s", result.InstanceUUID, tenantCNCI[0].InstanceID)
 	}
-	if result.InstanceUUID != instances[0].ID {
-		t.Fatal("Did not get correct Instance ID")
+
+	wg.Wait() // for "instances"
+	if instances == nil {
+		t.Fatal("did not receive instance")
 	}
 
 	return netClient, instances

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -763,7 +763,6 @@ func TestMain(m *testing.M) {
 
 	// create fake ssntp server
 	testutil.StartTestServer(&server)
-	defer server.Ssntp.Stop()
 
 	context = new(controller)
 	context.ds = new(datastore.Datastore)
@@ -797,7 +796,6 @@ func TestMain(m *testing.M) {
 	}
 
 	id := testutil.StartIdentityServer(testIdentityConfig)
-	defer id.Close()
 
 	idConfig := identityConfig{
 		endpoint:        id.URL,
@@ -820,6 +818,8 @@ func TestMain(m *testing.M) {
 
 	context.client.Disconnect()
 	context.ds.Exit()
+	id.Close()
+	server.Ssntp.Stop()
 
 	os.Remove("./ciao-controller-test.db")
 	os.Remove("./ciao-controller-test.db-shm")

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -480,10 +480,6 @@ func (sched *ssntpSchedulerServer) getConcentratorUUID(event ssntp.Event, payloa
 		var ev payloads.EventTenantRemoved
 		err := yaml.Unmarshal(payload, &ev)
 		return ev.TenantRemoved.ConcentratorUUID, err
-	case ssntp.PublicIPAssigned:
-		var ev payloads.EventPublicIPAssigned
-		err := yaml.Unmarshal(payload, &ev)
-		return ev.AssignedIP.ConcentratorUUID, err
 	}
 }
 
@@ -723,8 +719,6 @@ func (sched *ssntpSchedulerServer) EventForward(uuid string, event ssntp.Event, 
 	case ssntp.TenantAdded:
 		fallthrough
 	case ssntp.TenantRemoved:
-		fallthrough
-	case ssntp.PublicIPAssigned:
 		dest = sched.fwdEventToCNCI(event, payload)
 	}
 
@@ -958,6 +952,10 @@ func setSSNTPForwardRules(sched *ssntpSchedulerServer) {
 			Operand: ssntp.DeleteFailure,
 			Dest:    ssntp.Controller,
 		},
+		{ // all PublicIPAssigned events go to all Controllers
+			Operand: ssntp.PublicIPAssigned,
+			Dest:    ssntp.Controller,
+		},
 		{ // all START command are processed by the Command forwarder
 			Operand:        ssntp.START,
 			CommandForward: sched,
@@ -984,10 +982,6 @@ func setSSNTPForwardRules(sched *ssntpSchedulerServer) {
 		},
 		{ // all TenantRemoved events are processed by the Event forwarder
 			Operand:      ssntp.TenantRemoved,
-			EventForward: sched,
-		},
-		{ // all PublicIPAssigned events are processed by the Event forwarder
-			Operand:      ssntp.PublicIPAssigned,
 			EventForward: sched,
 		},
 	}

--- a/ciao-scheduler/scheduler_internal_test.go
+++ b/ciao-scheduler/scheduler_internal_test.go
@@ -579,9 +579,11 @@ func TestStartWorkload(t *testing.T) {
 	fwd, uuid := startWorkload(sched, controllerUUID, []byte(testutil.CNCIStartYaml))
 	decision := fwd.Decision()
 	recipients := fwd.Recipients()
-	if decision != ssntp.Forward ||
-		uuid != testutil.CNCIUUID {
-		t.Errorf("unable to start CNCI, got decision=0x%x, workload uuid=%s", decision, uuid)
+	if decision != ssntp.Forward {
+		t.Errorf("bad decision, got 0x%x, expected 0x%x", decision, ssntp.Forward)
+	}
+	if uuid != testutil.CNCIInstanceUUID {
+		t.Errorf("bad uuid, got %s, expected %s", uuid, testutil.CNCIInstanceUUID)
 	}
 	for _, dest = range recipients[:] {
 		if sched.nnMap[dest] == nil {

--- a/ciao-scheduler/scheduler_ssntp_test.go
+++ b/ciao-scheduler/scheduler_ssntp_test.go
@@ -404,6 +404,7 @@ func restartServer() error {
 	controllerCh := controller.AddEventChan(ssntp.NodeConnected)
 	netAgentCh := netAgent.AddEventChan(ssntp.NodeConnected)
 	agentCh := agent.AddEventChan(ssntp.NodeConnected)
+	cnciAgentCh := cnciAgent.AddEventChan(ssntp.NodeConnected)
 
 	server = configSchedulerServer()
 	if server == nil {
@@ -412,17 +413,29 @@ func restartServer() error {
 	go server.ssntp.Serve(server.config, server)
 	//go heartBeatLoop(server)  ...handy for debugging
 
-	_, err := controller.GetEventChanResult(controllerCh, ssntp.NodeConnected)
-	if err != nil {
-		return err
+	if controller != nil {
+		_, err := controller.GetEventChanResult(controllerCh, ssntp.NodeConnected)
+		if err != nil {
+			return err
+		}
 	}
-	_, err = netAgent.GetEventChanResult(netAgentCh, ssntp.NodeConnected)
-	if err != nil {
-		return err
+	if netAgent != nil {
+		_, err := netAgent.GetEventChanResult(netAgentCh, ssntp.NodeConnected)
+		if err != nil {
+			return err
+		}
 	}
-	_, err = agent.GetEventChanResult(agentCh, ssntp.NodeConnected)
-	if err != nil {
-		return err
+	if agent != nil {
+		_, err := agent.GetEventChanResult(agentCh, ssntp.NodeConnected)
+		if err != nil {
+			return err
+		}
+	}
+	if cnciAgent != nil {
+		_, err := cnciAgent.GetEventChanResult(cnciAgentCh, ssntp.NodeConnected)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/ciao-scheduler/scheduler_ssntp_test.go
+++ b/ciao-scheduler/scheduler_ssntp_test.go
@@ -454,6 +454,39 @@ func TestReconnects(t *testing.T) {
 	}
 }
 
+func TestTenantAdded(t *testing.T) {
+	cnciAgentCh := cnciAgent.AddEventChan(ssntp.TenantAdded)
+
+	go agent.SendTenantAddedEvent()
+
+	_, err := cnciAgent.GetEventChanResult(cnciAgentCh, ssntp.TenantAdded)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTenantRemoved(t *testing.T) {
+	cnciAgentCh := cnciAgent.AddEventChan(ssntp.TenantRemoved)
+
+	go agent.SendTenantRemovedEvent()
+
+	_, err := cnciAgent.GetEventChanResult(cnciAgentCh, ssntp.TenantRemoved)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPublicIPAssigned(t *testing.T) {
+	controllerCh := controller.AddEventChan(ssntp.PublicIPAssigned)
+
+	go cnciAgent.SendPublicIPAssignedEvent()
+
+	_, err := controller.GetEventChanResult(controllerCh, ssntp.PublicIPAssigned)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func waitForController(uuid string) {
 	for {
 		server.controllerMutex.Lock()

--- a/ciao-scheduler/scheduler_ssntp_test.go
+++ b/ciao-scheduler/scheduler_ssntp_test.go
@@ -503,15 +503,28 @@ func ssntpTestsSetup() error {
 
 func ssntpTestsTeardown() {
 	// stop everybody
-	time.Sleep(1 * time.Second)
-	controller.Ssntp.Close()
+	var wg sync.WaitGroup
+	wg.Add(3)
 
-	time.Sleep(1 * time.Second)
-	netAgent.Ssntp.Close()
+	go func() {
+		controller.Ssntp.Close()
+		wg.Done()
+	}()
 
-	time.Sleep(1 * time.Second)
-	agent.Ssntp.Close()
+	go func() {
+		netAgent.Ssntp.Close()
+		wg.Done()
+	}()
 
-	time.Sleep(1 * time.Second)
+	go func() {
+		agent.Ssntp.Close()
+		wg.Done()
+	}()
+
+	fmt.Println("Awaiting clients' shutdown")
+	wg.Wait()
+	fmt.Println("Got clients' shutdown")
+	fmt.Println("Awaiting server shutdown")
 	server.ssntp.Stop()
+	fmt.Println("Got server shutdown")
 }

--- a/ssntp/ssntp_test.go
+++ b/ssntp/ssntp_test.go
@@ -2557,6 +2557,29 @@ func TestErrorStringer(t *testing.T) {
 	}
 }
 
+func TestRoleToDefaultCertName(t *testing.T) {
+	var stringTests = []struct {
+		r        Role
+		expected string
+	}{
+		{Controller, "/etc/pki/ciao/cert-Controller-localhost.pem"},
+		{AGENT, "/etc/pki/ciao/cert-CNAgent-localhost.pem"},
+		{CNCIAGENT, "/etc/pki/ciao/cert-CNCIAgent-localhost.pem"},
+		{NETAGENT, "/etc/pki/ciao/cert-NetworkingAgent-localhost.pem"},
+		{AGENT | NETAGENT, "/etc/pki/ciao/cert-CNAgent-NetworkingAgent-localhost.pem"},
+		{SERVER, "/etc/pki/ciao/cert-Server-localhost.pem"},
+		{SCHEDULER, "/etc/pki/ciao/cert-Scheduler-localhost.pem"},
+		{UNKNOWN, ""},
+	}
+
+	for _, test := range stringTests {
+		certname := RoleToDefaultCertName(test.r)
+		if certname != test.expected {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expected, certname)
+		}
+	}
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 

--- a/ssntp/ssntp_test.go
+++ b/ssntp/ssntp_test.go
@@ -2580,6 +2580,46 @@ func TestRoleToDefaultCertName(t *testing.T) {
 	}
 }
 
+func TestRoleSet(t *testing.T) {
+	var stringTests = []struct {
+		r        string
+		expected Role
+	}{
+		{"unknown", UNKNOWN},
+		{"server", SERVER},
+		{"controller", Controller},
+		{"agent", AGENT},
+		{"netagent", NETAGENT},
+		{"scheduler", SCHEDULER},
+		{"cnciagent", CNCIAGENT},
+	}
+
+	for _, test := range stringTests {
+		var role Role
+		role.Set(test.r)
+		if role != test.expected {
+			t.Errorf("expected \"%x\", got \"%x\"", test.expected, role)
+		}
+	}
+
+	var role Role
+	err := role.Set("asdf")
+	if err == nil {
+		t.Error("expected \"Unknown role\" error, got nil")
+	}
+
+	role.Set("agent")
+	role.Set("netagent")
+	if role != AGENT|NETAGENT {
+		t.Error("didn't correctly sequantially assign role")
+	}
+
+	role.Set("agent, netagent")
+	if role != AGENT|NETAGENT {
+		t.Error("didn't correctly multi-assign role")
+	}
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 

--- a/ssntp/ssntp_test.go
+++ b/ssntp/ssntp_test.go
@@ -21,14 +21,15 @@ import (
 	"encoding/asn1"
 	"flag"
 	"fmt"
-	. "github.com/01org/ciao/ssntp"
-	"github.com/01org/ciao/testutil"
 	"io/ioutil"
 	"os"
 	"path"
 	"sync"
 	"testing"
 	"time"
+
+	. "github.com/01org/ciao/ssntp"
+	"github.com/01org/ciao/testutil"
 )
 
 const tempCertPath = "/tmp/ssntp-test-certs"
@@ -2464,6 +2465,97 @@ var (
 	frames      = flag.Int("frames", 1000, "Number of frames per client to send")
 	payloadSize = flag.Int("payload", 1<<11, "Frames payload size")
 )
+
+func TestCommandStringer(t *testing.T) {
+	var stringTests = []struct {
+		cmd      Command
+		expected string
+	}{
+		{CONNECT, "CONNECT"},
+		{START, "START"},
+		{STOP, "STOP"},
+		{STATS, "STATISTICS"},
+		{EVACUATE, "EVACUATE"},
+		{DELETE, "DELETE"},
+		{RESTART, "RESTART"},
+		{AssignPublicIP, "Assign public IP"},
+		{ReleasePublicIP, "Release public IP"},
+		{CONFIGURE, "CONFIGURE"},
+	}
+
+	for _, test := range stringTests {
+		str := test.cmd.String()
+		if str != test.expected {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expected, str)
+		}
+	}
+}
+
+func TestStatusStringer(t *testing.T) {
+	var stringTests = []struct {
+		sta      Status
+		expected string
+	}{
+		{CONNECTED, "CONNECTED"},
+		{READY, "READY"},
+		{FULL, "FULL"},
+		{OFFLINE, "OFFLINE"},
+		{MAINTENANCE, "MAINTENANCE"},
+	}
+
+	for _, test := range stringTests {
+		str := test.sta.String()
+		if str != test.expected {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expected, str)
+		}
+	}
+}
+
+func TestEventStringer(t *testing.T) {
+	var stringTests = []struct {
+		evt      Event
+		expected string
+	}{
+		{TenantAdded, "Tenant Added"},
+		{TenantRemoved, "Tenant Removed"},
+		{InstanceDeleted, "Instance Deleted"},
+		{ConcentratorInstanceAdded, "Network Concentrator Instance Added"},
+		{PublicIPAssigned, "Public IP Assigned"},
+		{TraceReport, "Trace Report"},
+		{NodeConnected, "Node Connected"},
+		{NodeDisconnected, "Node Disconnected"},
+	}
+
+	for _, test := range stringTests {
+		str := test.evt.String()
+		if str != test.expected {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expected, str)
+		}
+	}
+}
+
+func TestErrorStringer(t *testing.T) {
+	var stringTests = []struct {
+		err      Error
+		expected string
+	}{
+		{InvalidFrameType, "Invalid SSNTP frame type"},
+		{StartFailure, "Could not start instance"},
+		{StopFailure, "Could not stop instance"},
+		{ConnectionFailure, "SSNTP Connection failed"},
+		{RestartFailure, "Could not restart instance"},
+		{DeleteFailure, "Could not delete instance"},
+		{ConnectionAborted, "SSNTP Connection aborted"},
+		{InvalidConfiguration, "Cluster configuration is invalid"},
+	}
+
+	for _, test := range stringTests {
+		str := test.err.String()
+		if str != test.expected {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expected, str)
+		}
+	}
+}
 
 func TestMain(m *testing.M) {
 	flag.Parse()

--- a/testutil/agent.go
+++ b/testutil/agent.go
@@ -426,7 +426,7 @@ func (client *SsntpTestClient) CommandNotify(command ssntp.Command, frame *ssntp
 		result = client.handleDelete(payload)
 
 	default:
-		fmt.Printf("client unhandled command %s\n", command.String())
+		fmt.Printf("client %s unhandled command %s\n", client.Role.String(), command.String())
 	}
 
 	client.SendResultAndDelCmdChan(command, result)
@@ -452,7 +452,7 @@ func (client *SsntpTestClient) EventNotify(event ssntp.Event, frame *ssntp.Frame
 			result.Err = err
 		}
 	default:
-		fmt.Printf("client unhandled event: %s\n", event.String())
+		fmt.Printf("client %s unhandled event: %s\n", client.Role.String(), event.String())
 	}
 
 	client.SendResultAndDelEventChan(event, result)

--- a/testutil/agent.go
+++ b/testutil/agent.go
@@ -581,6 +581,19 @@ func (client *SsntpTestClient) SendTenantRemovedEvent() {
 
 	client.SendResultAndDelEventChan(ssntp.TenantRemoved, result)
 }
+
+// SendPublicIPAssignedEvent allows an SsntpTestClient to push an ssntp.PublicIPAssigned event frame
+func (client *SsntpTestClient) SendPublicIPAssignedEvent() {
+	var result Result
+
+	_, err := client.Ssntp.SendEvent(ssntp.PublicIPAssigned, []byte(AssignedIPYaml))
+	if err != nil {
+		result.Err = err
+	}
+
+	client.SendResultAndDelEventChan(ssntp.PublicIPAssigned, result)
+}
+
 // SendConcentratorAddedEvent allows an SsntpTestClient to push an ssntp.ConcentratorInstanceAdded event frame
 func (client *SsntpTestClient) SendConcentratorAddedEvent(instanceUUID string, tenantUUID string, ip string, vnicMAC string) {
 	var result Result

--- a/testutil/agent.go
+++ b/testutil/agent.go
@@ -434,6 +434,21 @@ func (client *SsntpTestClient) CommandNotify(command ssntp.Command, frame *ssntp
 
 // EventNotify is an SSNTP callback stub for SsntpTestClient
 func (client *SsntpTestClient) EventNotify(event ssntp.Event, frame *ssntp.Frame) {
+	var result Result
+
+	switch event {
+	case ssntp.TenantAdded:
+		var tenantAddedEvent payloads.EventTenantAdded
+
+		err := yaml.Unmarshal(frame.Payload, &tenantAddedEvent)
+		if err != nil {
+			result.Err = err
+		}
+	default:
+		fmt.Printf("client unhandled event: %s\n", event.String())
+	}
+
+	client.SendResultAndDelEventChan(event, result)
 }
 
 // ErrorNotify is an SSNTP callback stub for SsntpTestClient
@@ -534,6 +549,18 @@ func (client *SsntpTestClient) SendDeleteEvent(uuid string) {
 	}
 
 	client.SendResultAndDelEventChan(ssntp.InstanceDeleted, result)
+}
+
+// SendTenantAddedEvent allows an SsntpTestClient to push an ssntp.TenantAdded event frame
+func (client *SsntpTestClient) SendTenantAddedEvent() {
+	var result Result
+
+	_, err := client.Ssntp.SendEvent(ssntp.TenantAdded, []byte(TenantAddedYaml))
+	if err != nil {
+		result.Err = err
+	}
+
+	client.SendResultAndDelEventChan(ssntp.TenantAdded, result)
 }
 
 // SendConcentratorAddedEvent allows an SsntpTestClient to push an ssntp.ConcentratorInstanceAdded event frame

--- a/testutil/agent.go
+++ b/testutil/agent.go
@@ -444,6 +444,13 @@ func (client *SsntpTestClient) EventNotify(event ssntp.Event, frame *ssntp.Frame
 		if err != nil {
 			result.Err = err
 		}
+	case ssntp.TenantRemoved:
+		var tenantRemovedEvent payloads.EventTenantRemoved
+
+		err := yaml.Unmarshal(frame.Payload, &tenantRemovedEvent)
+		if err != nil {
+			result.Err = err
+		}
 	default:
 		fmt.Printf("client unhandled event: %s\n", event.String())
 	}
@@ -563,6 +570,17 @@ func (client *SsntpTestClient) SendTenantAddedEvent() {
 	client.SendResultAndDelEventChan(ssntp.TenantAdded, result)
 }
 
+// SendTenantRemovedEvent allows an SsntpTestClient to push an ssntp.TenantRemoved event frame
+func (client *SsntpTestClient) SendTenantRemovedEvent() {
+	var result Result
+
+	_, err := client.Ssntp.SendEvent(ssntp.TenantRemoved, []byte(TenantRemovedYaml))
+	if err != nil {
+		result.Err = err
+	}
+
+	client.SendResultAndDelEventChan(ssntp.TenantRemoved, result)
+}
 // SendConcentratorAddedEvent allows an SsntpTestClient to push an ssntp.ConcentratorInstanceAdded event frame
 func (client *SsntpTestClient) SendConcentratorAddedEvent(instanceUUID string, tenantUUID string, ip string, vnicMAC string) {
 	var result Result

--- a/testutil/client_server_test.go
+++ b/testutil/client_server_test.go
@@ -523,6 +523,21 @@ func TestReconnects(t *testing.T) {
 	}
 }
 
+func TestTenantRemoved(t *testing.T) {
+	serverCh := server.AddEventChan(ssntp.TenantRemoved)
+	cnciAgentCh := cnciAgent.AddEventChan(ssntp.TenantRemoved)
+
+	go agent.SendTenantRemovedEvent()
+
+	_, err := server.GetEventChanResult(serverCh, ssntp.TenantRemoved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = cnciAgent.GetEventChanResult(cnciAgentCh, ssntp.TenantRemoved)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
 func TestMain(m *testing.M) {
 	var err error
 

--- a/testutil/client_server_test.go
+++ b/testutil/client_server_test.go
@@ -538,6 +538,23 @@ func TestTenantRemoved(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestPublicIPAssigned(t *testing.T) {
+	serverCh := server.AddEventChan(ssntp.PublicIPAssigned)
+	controllerCh := controller.AddEventChan(ssntp.PublicIPAssigned)
+
+	go cnciAgent.SendPublicIPAssignedEvent()
+
+	_, err := server.GetEventChanResult(serverCh, ssntp.PublicIPAssigned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = controller.GetEventChanResult(controllerCh, ssntp.PublicIPAssigned)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestMain(m *testing.M) {
 	var err error
 

--- a/testutil/client_server_test.go
+++ b/testutil/client_server_test.go
@@ -429,6 +429,22 @@ func TestDeleteFailure(t *testing.T) {
 	}
 }
 
+func TestTenantAdded(t *testing.T) {
+	serverCh := server.AddEventChan(ssntp.TenantAdded)
+	cnciAgentCh := cnciAgent.AddEventChan(ssntp.TenantAdded)
+
+	go agent.SendTenantAddedEvent()
+
+	_, err := server.GetEventChanResult(serverCh, ssntp.TenantAdded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = cnciAgent.GetEventChanResult(cnciAgentCh, ssntp.TenantAdded)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func stopServer() error {
 	controllerCh := controller.AddEventChan(ssntp.NodeDisconnected)
 	netAgentCh := netAgent.AddEventChan(ssntp.NodeDisconnected)

--- a/testutil/client_server_test.go
+++ b/testutil/client_server_test.go
@@ -471,25 +471,38 @@ func restartServer() error {
 	controllerCh := controller.AddEventChan(ssntp.NodeConnected)
 	netAgentCh := netAgent.AddEventChan(ssntp.NodeConnected)
 	agentCh := agent.AddEventChan(ssntp.NodeConnected)
+	cnciAgentCh := cnciAgent.AddEventChan(ssntp.NodeConnected)
 
 	StartTestServer(&server)
 
 	//MUST be after StartTestServer becase the channels are initialized on start
 	serverCh := server.AddEventChan(ssntp.NodeConnected)
 
-	_, err := controller.GetEventChanResult(controllerCh, ssntp.NodeConnected)
-	if err != nil {
-		return err
+	if controller != nil {
+		_, err := controller.GetEventChanResult(controllerCh, ssntp.NodeConnected)
+		if err != nil {
+			return err
+		}
 	}
-	_, err = netAgent.GetEventChanResult(netAgentCh, ssntp.NodeConnected)
-	if err != nil {
-		return err
+	if netAgent != nil {
+		_, err := netAgent.GetEventChanResult(netAgentCh, ssntp.NodeConnected)
+		if err != nil {
+			return err
+		}
 	}
-	_, err = agent.GetEventChanResult(agentCh, ssntp.NodeConnected)
-	if err != nil {
-		return err
+	if agent != nil {
+		_, err := agent.GetEventChanResult(agentCh, ssntp.NodeConnected)
+		if err != nil {
+			return err
+		}
 	}
-	_, err = server.GetEventChanResult(serverCh, ssntp.NodeConnected)
+	if cnciAgent != nil {
+		_, err := cnciAgent.GetEventChanResult(cnciAgentCh, ssntp.NodeConnected)
+		if err != nil {
+			return err
+		}
+	}
+	_, err := server.GetEventChanResult(serverCh, ssntp.NodeConnected)
 	if err != nil {
 		return err
 	}

--- a/testutil/client_server_test.go
+++ b/testutil/client_server_test.go
@@ -61,11 +61,11 @@ func TestStart(t *testing.T) {
 
 	go controller.Ssntp.SendCommand(ssntp.START, []byte(StartYaml))
 
-	_, err := agent.GetCmdChanResult(agentCh, ssntp.START)
+	_, err := server.GetCmdChanResult(serverCh, ssntp.START)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = server.GetCmdChanResult(serverCh, ssntp.START)
+	_, err = agent.GetCmdChanResult(agentCh, ssntp.START)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testutil/controller.go
+++ b/testutil/controller.go
@@ -242,6 +242,7 @@ func (ctl *SsntpTestController) EventNotify(event ssntp.Event, frame *ssntp.Fram
 	// case ssntp.NodeConnected:	handled by ConnectNotify()
 	// case ssntp.NodeDisconnected:	handled by DisconnectNotify()
 	// case ssntp.TenantAdded: does not reach controller
+	// case ssntp.TenantRemoved: does not reach controller
 	case ssntp.InstanceDeleted:
 		var deleteEvent payloads.EventInstanceDeleted
 

--- a/testutil/controller.go
+++ b/testutil/controller.go
@@ -239,6 +239,8 @@ func (ctl *SsntpTestController) EventNotify(event ssntp.Event, frame *ssntp.Fram
 	var result Result
 
 	switch event {
+	// case ssntp.NodeConnected:	handled by ConnectNotify()
+	// case ssntp.NodeDisconnected:	handled by DisconnectNotify()
 	case ssntp.InstanceDeleted:
 		var deleteEvent payloads.EventInstanceDeleted
 

--- a/testutil/controller.go
+++ b/testutil/controller.go
@@ -241,6 +241,7 @@ func (ctl *SsntpTestController) EventNotify(event ssntp.Event, frame *ssntp.Fram
 	switch event {
 	// case ssntp.NodeConnected:	handled by ConnectNotify()
 	// case ssntp.NodeDisconnected:	handled by DisconnectNotify()
+	// case ssntp.TenantAdded: does not reach controller
 	case ssntp.InstanceDeleted:
 		var deleteEvent payloads.EventInstanceDeleted
 

--- a/testutil/controller.go
+++ b/testutil/controller.go
@@ -243,6 +243,13 @@ func (ctl *SsntpTestController) EventNotify(event ssntp.Event, frame *ssntp.Fram
 	// case ssntp.NodeDisconnected:	handled by DisconnectNotify()
 	// case ssntp.TenantAdded: does not reach controller
 	// case ssntp.TenantRemoved: does not reach controller
+	case ssntp.PublicIPAssigned:
+		var publicIPAssignedEvent payloads.EventPublicIPAssigned
+
+		err := yaml.Unmarshal(frame.Payload, &publicIPAssignedEvent)
+		if err != nil {
+			result.Err = err
+		}
 	case ssntp.InstanceDeleted:
 		var deleteEvent payloads.EventInstanceDeleted
 

--- a/testutil/identity.go
+++ b/testutil/identity.go
@@ -267,6 +267,7 @@ type IdentityConfig struct {
 }
 
 // StartIdentityServer starts a fake keystone service for unit testing ciao.
+// Caller must call Close() on the returned *httptest.Server.
 func StartIdentityServer(config IdentityConfig) *httptest.Server {
 	id := httptest.NewServer(IdentityHandlers())
 	if id == nil {

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -36,6 +36,9 @@ const InstancePrivateIP = "192.168.1.2"
 // VNICMAC is a test instance VNIC MAC address
 const VNICMAC = "aa:bb:cc:01:02:03"
 
+// VNICUUID is a test instance VNIC UUID
+const VNICUUID = "7f49d00d-1995-4156-8c79-5f5ab24ce138"
+
 // TenantUUID is a test tenant UUID
 const TenantUUID = "2491851d-dce9-48d6-b83a-a717417072ce"
 
@@ -90,6 +93,9 @@ const ImageUUID = "59460b8a-5f53-4e3e-b5ce-b71fed8c7e64"
 // InstanceUUID is an instance UUID for use in start/stop/restart/delete tests
 const InstanceUUID = "3390740c-dce9-48d6-b83a-a717417072ce"
 
+// CNCIInstanceUUID is a CNCI instance UUID for use in start/stop/restart/delete tests
+const CNCIInstanceUUID = "c6beb8b5-0bfc-43fd-9638-7dd788179fd8"
+
 // NetAgentUUID is a network node UUID for coordinated tests
 const NetAgentUUID = "6be56328-92e2-4ecd-b426-8fe529c04e0c"
 
@@ -138,7 +144,7 @@ const StartYaml = `start:
 
 // CNCIStartYaml is a sample CNCI workload START ssntp.Command payload for test cases
 const CNCIStartYaml = `start:
-  instance_uuid: ` + CNCIUUID + `
+  instance_uuid: ` + CNCIInstanceUUID + `
   image_uuid: ` + ImageUUID + `
   fw_type: efi
   persistence: host
@@ -153,6 +159,16 @@ const CNCIStartYaml = `start:
     - type: network_node
       value: 1
       mandatory: true
+  networking:
+    vnic_mac: ` + VNICMAC + `
+    vnic_uuid: ` + VNICUUID + `
+    concentrator_uuid: ` + CNCIUUID + `
+    concentrator_ip: ` + CNCIIP + `
+    subnet: ` + TenantSubnet + `
+    subnet_key: ` + SubnetKey + `
+    subnet_uuid: ""
+    private_ip: ""
+    public_ip: false
 `
 
 // PartialStartYaml is a sample minimal workload START ssntp.Command payload for test cases

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -365,7 +365,7 @@ func (server *SsntpTestServer) EventNotify(uuid string, event ssntp.Event, frame
 	case ssntp.TenantRemoved:
 		// forwards to CNCI via server.EventForward()
 	case ssntp.PublicIPAssigned:
-		// forwards to CNCI via server.EventForward()
+		// forwards from CNCI Controller(s) via server.EventForward()
 	default:
 		fmt.Printf("server unhandled event %s\n", event.String())
 	}

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -340,14 +340,8 @@ func (server *SsntpTestServer) EventNotify(uuid string, event ssntp.Event, frame
 	payload := frame.Payload
 
 	switch event {
-	case ssntp.NodeConnected:
-		var connectEvent payloads.NodeConnected
-
-		result.Err = yaml.Unmarshal(payload, &connectEvent)
-	case ssntp.NodeDisconnected:
-		var disconnectEvent payloads.NodeDisconnected
-
-		result.Err = yaml.Unmarshal(payload, &disconnectEvent)
+	// case ssntp.NodeConnected:	handled by ConnectNotify()
+	// case ssntp.NodeDisconnected:	handled by DisconnectNotify()
 	case ssntp.TraceReport:
 		var traceEvent payloads.Trace
 

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -408,6 +408,7 @@ func fwdEventToCNCI(event ssntp.Event, payload []byte) (ssntp.ForwardDestination
 func (server *SsntpTestServer) EventForward(uuid string, event ssntp.Event, frame *ssntp.Frame) ssntp.ForwardDestination {
 	var err error
 	var dest ssntp.ForwardDestination
+	var result Result
 
 	switch event {
 	case ssntp.TenantAdded:
@@ -420,7 +421,10 @@ func (server *SsntpTestServer) EventForward(uuid string, event ssntp.Event, fram
 
 	if err != nil {
 		fmt.Println("server error parsing event yaml for forwarding")
+		result.Err = err
 	}
+
+	server.SendResultAndDelEventChan(event, result)
 
 	return dest
 }

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -385,10 +385,6 @@ func getConcentratorUUID(event ssntp.Event, payload []byte) (string, error) {
 		var ev payloads.EventTenantRemoved
 		err := yaml.Unmarshal(payload, &ev)
 		return ev.TenantRemoved.ConcentratorUUID, err
-	case ssntp.PublicIPAssigned:
-		var ev payloads.EventPublicIPAssigned
-		err := yaml.Unmarshal(payload, &ev)
-		return ev.AssignedIP.ConcentratorUUID, err
 	}
 }
 
@@ -414,8 +410,6 @@ func (server *SsntpTestServer) EventForward(uuid string, event ssntp.Event, fram
 	case ssntp.TenantAdded:
 		fallthrough
 	case ssntp.TenantRemoved:
-		fallthrough
-	case ssntp.PublicIPAssigned:
 		dest, err = fwdEventToCNCI(event, frame.Payload)
 	}
 
@@ -582,6 +576,10 @@ func StartTestServer(server *SsntpTestServer) {
 				Operand: ssntp.DeleteFailure,
 				Dest:    ssntp.Controller,
 			},
+			{ // all PublicIPAssigned events go to all Controllers
+				Operand: ssntp.PublicIPAssigned,
+				Dest:    ssntp.Controller,
+			},
 			{ // all START command are processed by the Command forwarder
 				Operand:        ssntp.START,
 				CommandForward: server,
@@ -608,10 +606,6 @@ func StartTestServer(server *SsntpTestServer) {
 			},
 			{ // all TenantRemoved events are processed by the Event forwarder
 				Operand:      ssntp.TenantRemoved,
-				EventForward: server,
-			},
-			{ // all PublicIPAssigned events are processed by the Event forwarder
-				Operand:      ssntp.PublicIPAssigned,
 				EventForward: server,
 			},
 		},


### PR DESCRIPTION
This series adds a bunch of bugfixing in test cases in ciao-controller, ciao-scheduler and testutil for issues observed will adding coverage for SSNTP ConcentratorInstanceAdded, TenantAdded, TenantRemoved and PublicIPAssigned event flows.