### PR TITLE
ciao-launcher: remove unecessary asigment of chanel and return

### DIFF
--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -336,8 +336,6 @@ func connectToServer(doneCh chan struct{}, statusCh chan struct{}) {
 		err := client.conn.Dial(cfg, client)
 		if err != nil {
 			glog.Errorf("Unable to connect to server %v", err)
-			dialCh <- err
-			return
 		}
 
 		dialCh <- err


### PR DESCRIPTION
Removing unecessary asigment to chanel and also return, since
after the if the asigment to the chanel dialCh still is valid and
the return is not necessary cause the left asignment of dialCh is the
last instruction and the anonymous function ends.

Signed-off-by: Leoswaldo Macias <leoswaldo.macias@intel.com>