### PR TITLE
ciao-launcher: Update statistics interval and fix profiling

### DIFF
--- a/ciao-launcher/instance.go
+++ b/ciao-launcher/instance.go
@@ -270,7 +270,7 @@ DONE:
 		case <-id.statsTimer:
 			d, m, c := id.vm.stats()
 			id.ovsCh <- &ovsStatsUpdateCmd{id.instance, m, d, c}
-			id.statsTimer = time.After(time.Second * statsPeriod)
+			id.statsTimer = time.After(time.Second * resourcePeriod)
 		case cmd := <-id.cmdCh:
 			if !id.instanceCommand(cmd) {
 				break DONE
@@ -296,7 +296,7 @@ DONE:
 			id.ovsCh <- &ovsStateChange{id.instance, ovsRunning}
 			d, m, c := id.vm.stats()
 			id.ovsCh <- &ovsStatsUpdateCmd{id.instance, m, d, c}
-			id.statsTimer = time.After(time.Second * statsPeriod)
+			id.statsTimer = time.After(time.Second * resourcePeriod)
 		}
 	}
 

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -75,12 +75,13 @@ func init() {
 }
 
 const (
-	lockDir       = "/tmp/lock/ciao"
-	instancesDir  = "/var/lib/ciao/instances"
-	logDir        = "/var/lib/ciao/logs/launcher"
-	instanceState = "state"
-	lockFile      = "client-agent.lock"
-	statsPeriod   = 30
+	lockDir        = "/tmp/lock/ciao"
+	instancesDir   = "/var/lib/ciao/instances"
+	logDir         = "/var/lib/ciao/logs/launcher"
+	instanceState  = "state"
+	lockFile       = "client-agent.lock"
+	statsPeriod    = 6
+	resourcePeriod = 30
 )
 
 type cmdWrapper struct {


### PR DESCRIPTION
This PR contains two commits that

1. Update the statistics reporting interval to 6 seconds, the value used in the demo branch.
2. Fixes the cpuprofiling in launcher by ensuring that pprof.StopCPUProfile is called.