### PR TITLE
Unittests: race fixes

### DIFF
--- a/ssntp/client.go
+++ b/ssntp/client.go
@@ -130,7 +130,15 @@ func (client *Client) handleSSNTPServer() {
 				break
 			}
 
+			client.status.Lock()
+			if client.status.status == ssntpClosed {
+				client.status.Unlock()
+				return
+			}
+			//insure new frame doesn't race with client.Close()
 			client.frameWg.Add(1)
+			client.status.Unlock()
+
 			go client.processSSNTPFrame(&frame)
 		}
 


### PR DESCRIPTION
This PR is a partial response to issue 83.  That issue included 5 data race reports from go-race.  2 no longer reproduce with my earlier unit test cleaning.  2 are fixed here.  1 remains in discussion with @kaccardi 

The two races fixed here are fairly straight forward:  an anonymous function goroutine was sharing unprotected data with its parent in an actually safe fashion imho but easily resolved with a channel, and ssntp clients usage of waitgroups could theoretically race due to no exclusion of readers/writers.