### PR TITLE
ciao-launcher: Enable tracing

### DIFF
--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -35,6 +35,7 @@ import (
 )
 
 var profileFN func() func()
+var traceFN func() func()
 
 type uiFlag string
 
@@ -536,6 +537,11 @@ func main() {
 		stopProfile = profileFN()
 	}
 
+	var stopTrace func()
+	if traceFN != nil {
+		stopTrace = traceFN()
+	}
+
 	if hardReset {
 		purgeLauncherState()
 	} else {
@@ -548,6 +554,10 @@ func main() {
 		}
 
 		exitCode = startLauncher()
+	}
+
+	if stopTrace != nil {
+		stopTrace()
 	}
 
 	if stopProfile != nil {


### PR DESCRIPTION
This commit adds tracing support to ciao-launcher.  When built with the
profile tag a new flag is added called --trace.  This flag can be used
to provide a file into which trace data can be written.  The data can
be analysed at a later stage using go tool trace.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>