### PR TITLE
ciao-cli: Add tenant name evironment variable

### DIFF
--- a/ciao-cli/README.md
+++ b/ciao-cli/README.md
@@ -69,6 +69,7 @@ credentials and networking information:
 * `CIAO_COMPUTEPORT` exports the Ciao compute alternative port
 * `CIAO_USERNAME` exports the Ciao username
 * `CIAO_PASSWORD` export the Ciao password for `CIAO_USERNAME`
+* `CIAO_TENANT_NAME` export the Ciao tenant name for `CIAO_USERNAME`
 
 All those environment variables can be set through an rc file.
 For example:
@@ -80,6 +81,7 @@ export CIAO_CONTROLLER=ciao-ctl.intel.com
 export CIAO_IDENTITY=https://ciao-identity.intel.com:35357
 export CIAO_USERNAME=user
 export CIAO_PASSWORD=ciaouser
+export CIAO_TENANT_NAME=admin
 ```
 
 Exporting those variables is not compulsory and they can be defined
@@ -146,6 +148,7 @@ Let's assume we're running a Ciao cluster with the following settings:
 * The `user` user is part of only one project: `project1`
 * The password for `user` is `ciaouser`
 * `project1` UUID is `68a76514-5c8e-40a8-8c9e-0570a11d035b`
+*
 
 This can be defined through the following Ciao rc file:
 
@@ -156,6 +159,7 @@ export CIAO_CONTROLLER=ciao-ctl.intel.com
 export CIAO_IDENTITY=https://ciao-identity.intel.com:35357
 export CIAO_USERNAME=user
 export CIAO_PASSWORD=ciaouser
+export CIAO_TENANT_NAME=project1
 ```
 
 ### Cluster status (Privileged)

--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -136,6 +136,7 @@ const (
 	ciaoUsernameEnv    = "CIAO_USERNAME"
 	ciaoPasswordEnv    = "CIAO_PASSWORD"
 	ciaoComputePortEnv = "CIAO_COMPUTEPORT"
+	ciaoTenantNameEnv  = "CIAO_TENANT_NAME"
 )
 
 type queryValue struct {
@@ -262,6 +263,7 @@ func getCiaoEnvVariables() {
 	username := os.Getenv(ciaoUsernameEnv)
 	password := os.Getenv(ciaoPasswordEnv)
 	port := os.Getenv(ciaoComputePortEnv)
+	tenant := os.Getenv(ciaoTenantNameEnv)
 
 	infof("Ciao environment variables:\n")
 	infof("\t%s:%s\n", ciaoIdentityEnv, identity)
@@ -269,6 +271,7 @@ func getCiaoEnvVariables() {
 	infof("\t%s:%s\n", ciaoUsernameEnv, username)
 	infof("\t%s:%s\n", ciaoPasswordEnv, password)
 	infof("\t%s:%s\n", ciaoComputePortEnv, port)
+	infof("\t%s:%s\n", ciaoTenantNameEnv, tenantName)
 
 	if identity != "" && *identityURL == "" {
 		*identityURL = identity
@@ -290,6 +293,9 @@ func getCiaoEnvVariables() {
 		*computePort, _ = strconv.Atoi(port)
 	}
 
+	if tenant != "" && *tenantName == "" {
+		*tenantName = tenant
+	}
 }
 
 func checkCompulsoryOptions() {


### PR DESCRIPTION
When user is part of more than one project (tenant), it
allows to use environment variables for passing the proper
project name instead of using the ``tenant-name`` or ``tenant-id``
parameters in ``ciao-cli`` command. It would verify if the
``CIAO_TENANT_NAME`` environment variable exists, it would use it;
if not, everything would normally proceed.

Signed-off-by: Munoz, Obed N <obed.n.munoz@intel.com>