### PR TITLE
ssntp: Add volumes attaching and detaching commands

### DIFF
--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -869,6 +869,11 @@ func (ds *sqliteDB) getTenantNoCache(ID string) (*tenant, error) {
 	}
 
 	t.instances, err = ds.getTenantInstances(t.ID)
+	if err != nil {
+		glog.V(2).Info(err)
+	}
+
+	t.devices, err = ds.getTenantDevices(t.ID)
 
 	return t, err
 }
@@ -2016,4 +2021,8 @@ func (ds *sqliteDB) getBatchFrameStatistics(label string) ([]types.BatchFrameSta
 	ds.tdbLock.RUnlock()
 
 	return stats, err
+}
+
+func (ds *sqliteDB) getTenantDevices(tenantID string) (map[string]types.BlockData, error) {
+	return make(map[string]types.BlockData), nil
 }

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	datastore "github.com/01org/ciao/ciao-controller/internal/datastore"
+	storage "github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/ssntp"
 	"github.com/01org/ciao/testutil"
 	"github.com/golang/glog"
@@ -32,6 +33,7 @@ type controller struct {
 	client *ssntpClient
 	ds     *datastore.Datastore
 	id     *identity
+	storage.BlockDriver
 }
 
 var singleMachine = flag.Bool("single", false, "Enable single machine test")
@@ -76,6 +78,8 @@ func main() {
 
 	context := new(controller)
 	context.ds = new(datastore.Datastore)
+
+	context.BlockDriver = storage.GetBlockDriver()
 
 	dsConfig := datastore.Config{
 		PersistentURI:     *persistentDatastoreLocation,

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"time"
+
+	"github.com/01org/ciao/ciao-controller/types"
+	"github.com/01org/ciao/openstack/block"
+)
+
+// Implement the Block Service interface
+func (c *controller) GetAbsoluteLimits(tenant string) (block.AbsoluteLimits, error) {
+	return block.AbsoluteLimits{}, nil
+}
+
+func (c *controller) CreateVolume(tenant string, req block.RequestedVolume) (block.Volume, error) {
+	// no limits checking for now.
+	bd, err := c.CreateBlockDevice(req.ImageRef, req.Size)
+	if err != nil {
+		return block.Volume{}, err
+	}
+
+	// store block device data in datastore
+	// TBD - do we really need to do this, or can we associate
+	// the block device data with the device itself?
+	data := types.BlockData{
+		ID:         bd.ID,
+		Size:       req.Size,
+		CreateTime: time.Now(),
+		TenantID:   tenant,
+	}
+	err = c.ds.AddBlockDevice(data)
+	if err != nil {
+		c.DeleteBlockDevice(bd.ID)
+		return block.Volume{}, err
+	}
+
+	// convert our volume info into the openstack desired format.
+	return block.Volume{
+		Status:      block.Available,
+		UserID:      tenant,
+		Attachments: make([]block.Attachment, 0),
+		Links:       make([]block.Link, 0),
+		CreatedAt:   &data.CreateTime,
+		ID:          bd.ID,
+		Size:        data.Size,
+	}, nil
+}
+
+func (c *controller) DeleteVolume(tenant string, volume string) error {
+	return nil
+}
+
+func (c *controller) AttachVolume(tenant string, volume string, instance string, mountpoint string) error {
+	return nil
+}
+
+func (c *controller) ListVolumes(tenant string) ([]block.ListVolume, error) {
+	vols := make([]block.ListVolume, 0)
+
+	data, err := c.ds.GetBlockDevices(tenant)
+	if err != nil {
+		return vols, err
+	}
+
+	for _, bd := range data {
+		// TBD create links
+		vol := block.ListVolume{
+			ID: bd.ID,
+		}
+		vols = append(vols, vol)
+	}
+
+	return vols, nil
+}
+
+func (c *controller) ListVolumesDetail(tenant string) ([]block.VolumeDetail, error) {
+	return make([]block.VolumeDetail, 0), nil
+}
+
+func (c *controller) ShowVolumeDetails(tenant string) (block.VolumeDetail, error) {
+	return block.VolumeDetail{}, nil
+}

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -163,3 +163,16 @@ type Node struct {
 	IPAddr   string `json:"ip_address"`
 	Hostname string `json:"hostname"`
 }
+
+type BlockState string
+
+// TBD - do we really need to store this as actual data,
+// or can we use a set of interfaces to get the info?
+type BlockData struct {
+	ID         string     // a uuid
+	TenantID   string     // the tenant who owns this volume
+	Instances  []Instance // any instances using this volume
+	Size       int        // size in GB
+	State      BlockState // status of
+	CreateTime time.Time  // when we created the volume
+}

--- a/ciao-image/datastore/datastore.go
+++ b/ciao-image/datastore/datastore.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import (
+	"sync"
+
+	"github.com/01org/ciao/ciao-image/service"
+)
+
+// Datastore implements the datastore interface for the ciao-image service
+//
+// TBD: This is an in-memory store only, persistence needs to be added.
+type Datastore struct {
+	images     map[string]service.Image
+	imagesLock *sync.RWMutex
+}
+
+func New() service.Datastore {
+	var ds = &Datastore{}
+
+	ds.Init()
+
+	return ds
+}
+
+// Init initializes the datastore struct and must be called before anything.
+func (d *Datastore) Init() {
+	d.images = make(map[string]service.Image)
+	d.imagesLock = &sync.RWMutex{}
+}
+
+// Create will add an image to the datastore.
+func (d *Datastore) Create(i service.Image) error {
+	d.imagesLock.Lock()
+	d.images[i.ID] = i
+	d.imagesLock.Unlock()
+	return nil
+}
+
+// RetrieveAll gets returns all the known images.
+func (d *Datastore) RetrieveAll() ([]service.Image, error) {
+	var images []service.Image
+
+	d.imagesLock.RLock()
+
+	for _, i := range d.images {
+		images = append(images, i)
+	}
+
+	d.imagesLock.RUnlock()
+
+	return images, nil
+}
+
+// Retrieve returns the image specified by the ID string.
+func (d *Datastore) Retrieve(ID string) (service.Image, error) {
+	d.imagesLock.RLock()
+	i, ok := d.images[ID]
+	d.imagesLock.RUnlock()
+
+	if !ok {
+		return service.Image{}, service.ErrNoImage
+	}
+
+	return i, nil
+}
+
+// Update will modify an existing image.
+func (d *Datastore) Update(i service.Image) error {
+	d.imagesLock.Lock()
+
+	_, ok := d.images[i.ID]
+	if ok {
+		d.images[i.ID] = i
+	}
+
+	d.imagesLock.Unlock()
+
+	if !ok {
+		return service.ErrNoImage
+	}
+
+	return nil
+}
+
+// Delete will delete an existing image.
+func (d *Datastore) Delete(ID string) error {
+	d.imagesLock.Lock()
+
+	_, ok := d.images[ID]
+	if ok {
+		delete(d.images, ID)
+	}
+
+	d.imagesLock.Unlock()
+
+	if !ok {
+		return service.ErrNoImage
+	}
+
+	return nil
+}

--- a/ciao-image/datastore/datastore_test.go
+++ b/ciao-image/datastore/datastore_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import (
+	"testing"
+
+	"github.com/01org/ciao/ciao-image/service"
+)
+
+func TestCreateAndRetrieve(t *testing.T) {
+	i := service.Image{
+		ID:    "validID",
+		State: service.Created,
+	}
+
+	d := Datastore{}
+	d.Init()
+
+	// create the entry
+	err := d.Create(i)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// retrieve the entry
+	image, err := d.Retrieve(i.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if image.ID != i.ID {
+		t.Fatal(err)
+	}
+}
+
+func TestRetrieveAll(t *testing.T) {
+	i := service.Image{
+		ID:    "validID",
+		State: service.Created,
+	}
+
+	d := Datastore{}
+	d.Init()
+
+	// create the entry
+	err := d.Create(i)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// retrieve the entry
+	images, err := d.RetrieveAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(images) != 1 {
+		t.Fatalf("len is actually %d\n", len(images))
+	}
+
+	if images[0].ID != i.ID {
+		t.Fatal(err)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	i := service.Image{
+		ID:    "validID",
+		State: service.Created,
+	}
+
+	d := Datastore{}
+	d.Init()
+
+	// create the entry
+	err := d.Create(i)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// delete the entry
+	err = d.Delete(i.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// now attempt to retrive the entry
+	_, err = d.Retrieve(i.ID)
+	if err == nil {
+		t.Fatal(err)
+	}
+}

--- a/ciao-image/main.go
+++ b/ciao-image/main.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+
+	"github.com/01org/ciao/ciao-image/datastore"
+	"github.com/01org/ciao/ciao-image/service"
+	"github.com/01org/ciao/openstack/image"
+	"github.com/golang/glog"
+)
+
+var httpsCAcert = "/etc/pki/ciao/ciao-image-cacert.pem"
+var httpsKey = "/etc/pki/ciao/ciao-image-key.pem"
+var port = image.APIPort
+var logDir = "/var/lib/ciao/logs/ciao-image"
+var identity = "https://localhost:35357"
+var userName = "ciao"
+var password = "hello"
+
+var identityURL = flag.String("identity", identity, "URL of keystone service")
+
+func init() {
+	flag.Parse()
+
+	if *identityURL != identity {
+		identity = *identityURL
+	}
+}
+
+func main() {
+	ds := datastore.New()
+
+	config := service.Config{
+		Port:             port,
+		HTTPSCACert:      httpsCAcert,
+		HTTPSKey:         httpsKey,
+		Datastore:        ds,
+		IdentityEndpoint: identity,
+		Username:         userName,
+		Password:         password,
+	}
+
+	glog.Fatal(service.Start(config))
+}

--- a/ciao-image/service/service.go
+++ b/ciao-image/service/service.go
@@ -1,0 +1,224 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/01org/ciao/openstack/identity"
+	"github.com/01org/ciao/openstack/image"
+	"github.com/01org/ciao/ssntp/uuid"
+	"github.com/gorilla/mux"
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/openstack"
+)
+
+type State string
+
+const (
+	Created State = "created"
+)
+
+func stateToStatus(state State) image.ImageStatus {
+	switch state {
+	case Created:
+		return image.Queued
+	}
+
+	return image.Active
+}
+
+func visibility(i Image) image.ImageVisibility {
+	if i.TenantID == "" {
+		return image.Public
+	}
+	return image.Private
+}
+
+type Type string
+
+const (
+	Raw  Type = "raw"
+	QCow Type = "qcow2"
+	ISO  Type = "iso"
+)
+
+// Image contains the information that ciao will store about the image
+type Image struct {
+	ID         string
+	State      State
+	TenantID   string
+	Name       string
+	CreateTime time.Time
+	Type       Type
+}
+
+type Datastore interface {
+	Create(Image) error
+	RetrieveAll() ([]Image, error)
+	Retrieve(ID string) (Image, error)
+	Update(Image) error
+	Delete(ID string) error
+}
+
+var (
+	ErrNoImage = errors.New("Image not found")
+)
+
+type ImageService struct {
+	ds Datastore
+}
+
+func (is ImageService) CreateImage(req image.CreateImageRequest) (image.CreateImageResponse, error) {
+	// create an ImageInfo struct and store it in our image
+	// datastore.
+	i := Image{
+		ID:         uuid.Generate().String(),
+		State:      Created,
+		Name:       req.Name,
+		CreateTime: time.Now(),
+	}
+
+	err := is.ds.Create(i)
+	if err != nil {
+		return image.CreateImageResponse{}, err
+	}
+
+	return image.CreateImageResponse{
+		Status:     image.Queued,
+		CreatedAt:  i.CreateTime,
+		Tags:       make([]string, 0),
+		Locations:  make([]string, 0),
+		DiskFormat: image.Raw,
+		Visibility: visibility(i),
+		Self:       fmt.Sprintf("/v2/images/%s", i.ID),
+		Protected:  false,
+		ID:         i.ID,
+		File:       fmt.Sprintf("/v2/images/%s/file", i.ID),
+		Schema:     "/v2/schemas/image",
+		Name:       &i.Name,
+	}, nil
+}
+
+func (is ImageService) ListImages() ([]image.CreateImageResponse, error) {
+	response := make([]image.CreateImageResponse, 0)
+
+	images, err := is.ds.RetrieveAll()
+	if err != nil {
+		return response, err
+	}
+
+	for _, img := range images {
+		i := image.CreateImageResponse{
+			Status:     stateToStatus(img.State),
+			CreatedAt:  img.CreateTime,
+			Tags:       make([]string, 0),
+			Locations:  make([]string, 0),
+			DiskFormat: image.DiskFormat(img.Type),
+			Visibility: visibility(img),
+			Self:       fmt.Sprintf("/v2/images/%s", img.ID),
+			Protected:  false,
+			ID:         img.ID,
+			File:       fmt.Sprintf("/v2/images/%s/file", img.ID),
+			Schema:     "/v2/schemas/image",
+			Name:       &img.Name,
+		}
+
+		response = append(response, i)
+	}
+
+	return response, nil
+}
+
+type Config struct {
+	Port             int
+	HTTPSCACert      string
+	HTTPSKey         string
+	Datastore        Datastore
+	IdentityEndpoint string
+	Username         string
+	Password         string
+}
+
+func getIdentityClient(config Config) (*gophercloud.ServiceClient, error) {
+	opt := gophercloud.AuthOptions{
+		IdentityEndpoint: config.IdentityEndpoint + "v3/",
+		Username:         config.Username,
+		Password:         config.Password,
+		TenantName:       "service",
+		DomainID:         "default",
+		AllowReauth:      true,
+	}
+	provider, err := openstack.AuthenticatedClient(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	v3client := openstack.NewIdentityV3(provider)
+	if v3client == nil {
+		return nil, errors.New("Unable to get keystone V3 client")
+	}
+
+	return v3client, nil
+}
+
+func Start(config Config) error {
+	is := ImageService{config.Datastore}
+
+	apiConfig := image.APIConfig{
+		Port:         config.Port,
+		ImageService: is,
+	}
+
+	// get our routes.
+	r := image.Routes(apiConfig)
+
+	// setup identity for these routes.
+	validServices := []identity.ValidService{
+		{"image", "ciao"},
+		{"image", "glance"},
+	}
+
+	validAdmins := []identity.ValidAdmin{
+		{"service", "admin"},
+		{"admin", "admin"},
+	}
+
+	client, err := getIdentityClient(config)
+	if err != nil {
+		return err
+	}
+
+	err = r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+		h := identity.Handler{
+			Client:        client,
+			Next:          route.GetHandler(),
+			ValidServices: validServices,
+			ValidAdmins:   validAdmins,
+		}
+
+		route.Handler(h)
+
+		return nil
+	})
+
+	// start service.
+	service := fmt.Sprintf(":%d", config.Port)
+
+	return http.ListenAndServeTLS(service, config.HTTPSCACert, config.HTTPSKey, r)
+}

--- a/ciao-storage/block.go
+++ b/ciao-storage/block.go
@@ -1,0 +1,14 @@
+package storage
+
+type BlockDriver interface {
+	CreateBlockDevice(image *string, sizeGB int) (BlockDevice, error)
+	DeleteBlockDevice(string) error
+}
+
+type BlockDevice struct {
+	ID string
+}
+
+func GetBlockDriver() BlockDriver {
+	return noopDriver{}
+}

--- a/ciao-storage/noop.go
+++ b/ciao-storage/noop.go
@@ -1,0 +1,17 @@
+// add build flag
+
+package storage
+
+import (
+	"github.com/01org/ciao/ssntp/uuid"
+)
+
+type noopDriver struct{}
+
+func (d noopDriver) CreateBlockDevice(image *string, size int) (BlockDevice, error) {
+	return BlockDevice{ID: uuid.Generate().String()}, nil
+}
+
+func (d noopDriver) DeleteBlockDevice(string) error {
+	return nil
+}

--- a/openstack/block/api.go
+++ b/openstack/block/api.go
@@ -1,0 +1,645 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package block
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/gorilla/mux"
+)
+
+// VersionStatus defines whether a reported version is supported or not.
+type VersionStatus string
+
+const (
+	// Deprecated indicates the api deprecates the spec version.
+	Deprecated VersionStatus = "DEPRECATED"
+
+	// Supported indicates a spec version is supported by the api
+	Supported VersionStatus = "SUPPORTED"
+
+	// Current indicates the current spec version of the api
+	// TBD: can this be eliminated? do we need both supported & current?
+	Current VersionStatus = "CURRENT"
+)
+
+// Link is used by the API to create the link json strings.
+type Link struct {
+	Href string `json:"href"`
+	Type string `json:"type,omitempty"`
+	Rel  string `json:"rel,omitempty"`
+}
+
+// MediaType indicates whether the api supports json or xml
+type MediaType struct {
+	Base string `json:"base"`
+	Type string `json:"type"`
+}
+
+// Version contains information about the api version that is supported.
+type Version struct {
+	Status     VersionStatus `json:"status"`
+	Updated    string        `json:"updated"`
+	Links      []Link        `json:"links"`
+	MinVersion string        `json:"min_version"`
+	Version    string        `json:"version"`
+	MediaTypes []MediaType   `json:"media-types"`
+	ID         string        `json:"id"`
+}
+
+// Versions is used to create the version api strings.
+type Versions struct {
+	Versions []Version `json:"versions"`
+}
+
+// Choice is used to indicate the api choices that are supported.
+type Choice struct {
+	Status     VersionStatus `json:"status"`
+	MediaTypes []MediaType   `json:"media-types"`
+	ID         string        `json:"id"`
+	Links      []Link        `json:"links"`
+}
+
+// Choices is used to create the choices json strings.
+type Choices struct {
+	Choices []Choice `json:"choices"`
+}
+
+// AbsoluteLimits implements the block api absolute limits object.
+// http://developer.openstack.org/api-ref-blockstorage-v2.html#showAbsoluteLimits
+// Note that an absolute limit value of -1 indicates that the limit is infinite.
+type AbsoluteLimits struct {
+	TotalSnapshotsUsed       int `json:"totalSnapshotsUsed"`
+	MaxTotalBackups          int `json:"maxTotalBackups"`
+	MaxTotalVolumeGigabytes  int `json:"maxTotalVolumeGigabytes"`
+	MaxTotalSnapshots        int `json:"maxTotalSnapshots"`
+	MaxTotalBackupGigabytes  int `json:"maxTotalBackupGigabytes"`
+	TotalBackupGigabytesUsed int `json:"totalBackupGigabytesUsed"`
+	MaxTotalVolumes          int `json:"maxTotalVolumes"`
+	TotalVolumesUsed         int `json:"totalVolumesUsed"`
+	TotalBackupsUsed         int `json:"totalBackupsUsed"`
+	TotalGigabytesUsed       int `json:"totalGigabytesUsed"`
+}
+
+// Limit implements the limit object.
+// http://developer.openstack.org/api-ref-blockstorage-v2.html#showAbsoluteLimits
+type Limit struct {
+	Rate     []string       `json:"rate"`
+	Absolute AbsoluteLimits `json:"absolute"`
+}
+
+// Limits implements the limits object.
+// http://developer.openstack.org/api-ref-blockstorage-v2.html#showAbsoluteLimits
+type Limits struct {
+	Limits Limit `json:"limits"`
+}
+
+// VolumeStatus is the status of create, list, update, or delete volumes.
+// http://developer.openstack.org/api-ref-blockstorage-v2.html#volumes-v2-volumes
+type VolumeStatus string
+
+const (
+	// Creating indicates that a volume is being created.
+	Creating VolumeStatus = "creating"
+
+	// Available indicates that a volume is ready to be used.
+	Available VolumeStatus = "available"
+
+	// Attaching indicates that a volume is being attached.
+	Attaching VolumeStatus = "attaching"
+
+	// InUse indicates that a volume is attached to an instance.
+	InUse VolumeStatus = "in-use"
+
+	// Deleting indicates that a volume is being deleted.
+	Deleting VolumeStatus = "deleting"
+
+	// Error indicates that a volume creation error occurred.
+	Error VolumeStatus = "error"
+
+	// ErrorDeleting indicates that a volume deletion error occurred.
+	ErrorDeleting VolumeStatus = "error_deleting"
+
+	// BackingUp indicates that the volume is being backed up.
+	BackingUp VolumeStatus = "backing-up"
+
+	// RestoringBackup indicates that a backup is being restored
+	// to the volume.
+	RestoringBackup VolumeStatus = "restoring-backup"
+
+	// ErrorRestoring indicates that a backup restoration error occurred.
+	ErrorRestoring VolumeStatus = "error_restoring"
+
+	// ErrorExtending indicates that an error occurred
+	// while attempting to extend a volume.
+	ErrorExtending VolumeStatus = "error_extending"
+)
+
+// MetaData is defined as a set of arbitrary key value structs.
+type MetaData interface{}
+
+// RequestedVolume contains information about a volume to be created.
+// http://developer.openstack.org/api-ref-blockstorage-v2.html#createVolume
+type RequestedVolume struct {
+	Size               int      `json:"size"`
+	AvailabilityZone   string   `json:"availability_zone"`
+	SourceVolID        *string  `json:"source_volid"`
+	Description        *string  `json:"description"`
+	MultiAttach        bool     `json:"multiattach"`
+	SnapshotID         *string  `json:"snapshot_id"`
+	Name               *string  `json:"name"`
+	ImageRef           *string  `json:"imageRef"`
+	VolumeType         *string  `json:"volume_type"`
+	MetaData           MetaData `json:"metadata"`
+	SourceReplica      *string  `json:"source_replica"`
+	ConsistencyGroupID *string  `json:"consistencygroup_id"`
+}
+
+// VolumeCreateRequest is the json request for the createVolume endpoint.
+// http://developer.openstack.org/api-ref-blockstorage-v2.html#createVolume
+type VolumeCreateRequest struct {
+	Volume RequestedVolume `json:"volume"`
+}
+
+// Attachment contains instance attachment information.
+// If this volume is attached to a server, the attachment contains
+// information about the attachment.
+type Attachment struct {
+	ServerUUID     string  `json:"server_id"`
+	AttachmentUUID string  `json:"attachment_id"`
+	HostName       *string `json:"host_name"`
+	VolumeUUID     string  `json:"volume_id"`
+	Device         string  `json:"device"`
+	DeviceUUID     string  `json:"id"`
+}
+
+const (
+	// ReplicationDisabled indicates that replication is not enabled.
+	ReplicationDisabled string = "disabled"
+)
+
+// Volume contains information about a volume that has been created or updated.
+// http://developer.openstack.org/api-ref-blockstorage-v2.html#createVolume
+// http://developer.openstack.org/api-ref-blockstorage-v2.html#updateVolume
+type Volume struct {
+	Status             VolumeStatus `json:"status"`
+	MigrationStatus    *string      `json:"migration_status"`
+	UserID             string       `json:"user_id"`
+	Attachments        []Attachment `json:"attachments"`
+	Links              []Link       `json:"links"`
+	AvailabilityZone   *string      `json:"availability_zone"`
+	Bootable           bool         `json:"bootable"`
+	Encrypted          bool         `json:"encrypted"`
+	CreatedAt          *time.Time   `json:"created_at"`
+	Description        *string      `json:"description"`
+	UpdatedAt          *time.Time   `json:"updated_at"`
+	VolumeType         *string      `json:"volume_type"`
+	Name               *string      `json:"name"`
+	ReplicationStatus  string       `json:"replication_status"`
+	ConsistencyGroupID *string      `json:"consistencygroup_id"`
+	SourceVolID        *string      `json:"source_volid"`
+	SnapshotID         *string      `json:"snapshot_id"`
+	MultiAttach        bool         `json:"multiattach"`
+	MetaData           MetaData     `json:"metadata"`
+	ID                 string       `json:"id"`
+	Size               int          `json:"size"`
+}
+
+// VolumeResponse is the json response for the createVolume, and updateVolume endpoint.
+// http://developer.openstack.org/api-ref-blockstorage-v2.html#createVolume
+// http://developer.openstack.org/api-ref-blockstorage-v2.html#updateVolume
+type VolumeResponse struct {
+	Volume Volume `json:"volume"`
+}
+
+// ListVolume is the containes volume information for the listVolume endpoint.
+// http://developer.openstack.org/api-ref-blockstorage-v2.html#listVolumes
+type ListVolume struct {
+	ID    string `json:"id"`
+	Links []Link `json:"links"`
+	Name  string `json:"name"`
+}
+
+// ListVolumes is the json response for the listVolume endpoint.
+// http://developer.openstack.org/api-ref-blockstorage-v2.html#listVolumes
+type ListVolumes struct {
+	Volumes []ListVolume `json:"volumes"`
+}
+
+// VolumeDetail contains volume information for the listVolumeDetails endpoint.
+// http://developer.openstack.org/api-ref-blockstorage-v2.html#listVolumesDetail
+type VolumeDetail struct {
+	MigrationStatus          *string      `json:"migration_status"`
+	Attachments              []Attachment `json:"attachments"`
+	Links                    []Link       `json:"links"`
+	AvailabilityZone         *string      `json:"availability_zone"`
+	OSVolHostAttr            string       `json:"os-vol-host-attr:host"`
+	Encrypted                bool         `json:"encrypted"`
+	UpdatedAt                *time.Time   `json:"updated_at"`
+	OSVolReplicationExStatus string       `json:"os-volume-replication:extended_status,omitempty"`
+	ReplicationStatus        string       `json:"replication_status"`
+	SnapshotID               *string      `json:"snapshot_id"`
+	ID                       string       `json:"id"`
+	Size                     int          `json:"size"`
+	UserID                   string       `json:"user_id"`
+	OSVolTenantAttr          string       `json:"os-vol-tenant-attr:tenant_id"`
+	OSVolMigStatusAttrStatus *string      `json:"os-vol-mig-status-attr:migstat"`
+	MetaData                 MetaData     `json:"metadata"`
+	Status                   VolumeStatus `json:"status"`
+	Description              *string      `json:"description"`
+	MultiAttach              bool         `json:"multiattach"`
+	OSVolReplicationDriver   string       `json:"os-volume-replication:driver_data,omitempty"`
+	SourceVolID              *string      `json:"source_volid"`
+	ConsistencyGroupID       *string      `json:"consistencygroup_id"`
+	OSVolMigStatusAttrNameID *string      `json:"os-vol-mig-status-attr:name_id"`
+	Name                     *string      `json:"name"`
+	Bootable                 bool         `json:"bootable"`
+	CreatedAt                *time.Time   `json:"created_at"`
+	VolumeType               *string      `json:"volume_type"`
+}
+
+// ListVolumesDetail is the json response for the listVolumeDetails endpoint.
+// http://developer.openstack.org/api-ref-blockstorage-v2.html#listVolumesDetail
+type ListVolumesDetail struct {
+	Volumes []VolumeDetail `json:"volumes"`
+}
+
+// ShowVolumeDetails is the json response for the showVolumeDetail endpoint.
+// http://developer.openstack.org/api-ref-blockstorage-v2.html#showVolume
+type ShowVolumeDetails struct {
+	Volume VolumeDetail `json:"volume"`
+}
+
+// These errors can be returned by the Service interface
+var (
+	ErrQuota            = errors.New("Tenant over quota")
+	ErrTenantNotFound   = errors.New("Tenant not found")
+	ErrVolumeNotFound   = errors.New("Volume not found")
+	ErrInstanceNotFound = errors.New("Instance not found")
+)
+
+// errorResponse maps service error responses to http responses.
+// this helper function can help functions avoid having to switch
+// on return values all the time.
+func errorResponse(err error) APIResponse {
+	switch err {
+	case ErrQuota:
+		return APIResponse{http.StatusForbidden, nil}
+	case ErrTenantNotFound:
+		return APIResponse{http.StatusNotFound, nil}
+	case ErrVolumeNotFound:
+		return APIResponse{http.StatusNotFound, nil}
+	case ErrInstanceNotFound:
+		return APIResponse{http.StatusNotFound, nil}
+	default:
+		return APIResponse{http.StatusInternalServerError, nil}
+	}
+}
+
+// APIConfig contains information needed to start the block api service.
+type APIConfig struct {
+	Port        int     // the https port of the block api service
+	HTTPSCACert string  // the https CA certificate
+	HTTPSKey    string  // the https key for the certificate
+	VolService  Service // the service interface
+}
+
+// Service contains the required interface to the block service.
+// The caller who is starting the api service needs to provide this
+// interface.
+type Service interface {
+	GetAbsoluteLimits(string) (AbsoluteLimits, error)
+	CreateVolume(string, RequestedVolume) (Volume, error)
+	DeleteVolume(string, string) error
+	AttachVolume(string, string, string, string) error
+	ListVolumes(string) ([]ListVolume, error)
+	ListVolumesDetail(string) ([]VolumeDetail, error)
+	ShowVolumeDetails(string, string) (VolumeDetail, error)
+}
+
+// Context contains data and interfaces that the block api will need.
+// TBD: do we really need this, or is just a service interface sufficient?
+type Context struct {
+	port int
+	Service
+}
+
+// APIResponse is returned from the API handlers.
+type APIResponse struct {
+	status   int
+	response interface{}
+}
+
+// APIHandler is a custom handler for the block APIs.
+// This custom handler allows us to more cleanly return an error and response,
+// and pass some package level context into the handler.
+type APIHandler struct {
+	*Context
+	Handler func(*Context, http.ResponseWriter, *http.Request) (APIResponse, error)
+}
+
+// ServeHTTP satisfies the http Handler interface.
+// It wraps our api response in json as well.
+func (h APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.Handler(h.Context, w, r)
+	if err != nil {
+		http.Error(w, http.StatusText(resp.status), resp.status)
+	}
+
+	b, err := json.Marshal(resp.response)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.status)
+	w.Write(b)
+}
+
+// not completed
+func listAPIVersions(context *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
+	host, err := os.Hostname()
+	if err != nil {
+		return APIResponse{http.StatusInternalServerError, nil}, err
+	}
+
+	// maybe we should just put href in context
+	href := fmt.Sprintf("https://%s:%d/v2/", host, context.port)
+
+	// TBD clean up this code
+	var resp Versions
+
+	// need to create Links
+	docLink := Link{
+		Href: "http://docs.openstack.org/",
+		Type: "text/html",
+		Rel:  "describedby",
+	}
+
+	selfLink := Link{
+		Href: href,
+		Rel:  "self",
+	}
+
+	jsonType := MediaType{
+		Base: "application/json",
+		Type: "application/vnd.openstack.volume+json;version=1",
+	}
+
+	// I'm not sure how much of this struct is important
+	v := Version{
+		Status:     Supported,
+		ID:         "v2.0",
+		Links:      []Link{docLink, selfLink},
+		MediaTypes: []MediaType{jsonType},
+		Updated:    "2014-06-28T12:20:21Z",
+	}
+
+	resp.Versions = append(resp.Versions, v)
+
+	return APIResponse{http.StatusOK, resp}, nil
+}
+
+// not completed
+func showAPIv2Details(context *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
+	host, err := os.Hostname()
+	if err != nil {
+		return APIResponse{http.StatusInternalServerError, nil}, err
+	}
+
+	href := fmt.Sprintf("https://%s:%d/v2/v2.json", host, context.port)
+
+	// we only support json
+	mt := MediaType{
+		Base: "application/json",
+		Type: "application/vnd.openstack.volume+json;version=1",
+	}
+
+	selfLink := Link{
+		Href: href,
+		Rel:  "self",
+	}
+
+	choice := Choice{
+		Status:     Current,
+		ID:         "v2.0",
+		MediaTypes: []MediaType{mt},
+		Links:      []Link{selfLink},
+	}
+
+	resp := Choices{Choices: []Choice{choice}}
+
+	return APIResponse{http.StatusOK, resp}, nil
+}
+
+func showAbsoluteLimits(bc *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
+	vars := mux.Vars(r)
+	tenant := vars["tenant"]
+
+	abs, err := bc.GetAbsoluteLimits(tenant)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	resp := Limits{Limit{make([]string, 0), abs}}
+
+	return APIResponse{http.StatusOK, resp}, nil
+}
+
+func createVolume(bc *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
+	vars := mux.Vars(r)
+	tenant := vars["tenant"]
+
+	defer r.Body.Close()
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return APIResponse{http.StatusBadRequest, nil}, err
+	}
+
+	var req VolumeCreateRequest
+	err = json.Unmarshal(body, &req)
+	if err != nil {
+		return APIResponse{http.StatusInternalServerError, nil}, err
+	}
+
+	var resp VolumeResponse
+
+	vol, err := bc.CreateVolume(tenant, req.Volume)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	resp.Volume = vol
+
+	return APIResponse{http.StatusAccepted, resp}, nil
+}
+
+func listVolumes(bc *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
+	vars := mux.Vars(r)
+	tenant := vars["tenant"]
+
+	// TBD: support sorting and paging
+
+	vols, err := bc.ListVolumes(tenant)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	resp := ListVolumes{Volumes: vols}
+
+	return APIResponse{http.StatusOK, resp}, nil
+}
+
+func listVolumesDetail(bc *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
+	vars := mux.Vars(r)
+	tenant := vars["tenant"]
+
+	// TBD: support sorting and paging
+
+	vols, err := bc.ListVolumesDetail(tenant)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	resp := ListVolumesDetail{Volumes: vols}
+
+	return APIResponse{http.StatusOK, resp}, nil
+}
+
+func showVolumeDetails(bc *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
+	vars := mux.Vars(r)
+	tenant := vars["tenant"]
+	volume := vars["volume_id"]
+
+	vol, err := bc.ShowVolumeDetails(tenant, volume)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	resp := ShowVolumeDetails{Volume: vol}
+
+	return APIResponse{http.StatusOK, resp}, nil
+}
+
+func deleteVolume(bc *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
+	vars := mux.Vars(r)
+	tenant := vars["tenant"]
+	volume := vars["volume_id"]
+
+	// TBD - satisfy preconditions here, or in interface?
+	err := bc.DeleteVolume(tenant, volume)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	return APIResponse{http.StatusAccepted, nil}, nil
+}
+
+func volumeAction(bc *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
+	vars := mux.Vars(r)
+	tenant := vars["tenant"]
+	volume := vars["volume_id"]
+
+	var req interface{}
+
+	defer r.Body.Close()
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return APIResponse{http.StatusBadRequest, nil}, err
+	}
+
+	err = json.Unmarshal(body, &req)
+	if err != nil {
+		return APIResponse{http.StatusInternalServerError, nil}, err
+	}
+
+	m := req.(map[string]interface{})
+
+	// for now, we will support only attach
+	val, ok := m["os-attach"]
+	if !ok {
+		return APIResponse{http.StatusBadRequest, nil}, err
+	}
+
+	m = val.(map[string]interface{})
+
+	val, ok = m["instance_uuid"]
+	if !ok {
+		// we have to have the instance uuid
+		return APIResponse{http.StatusBadRequest, nil}, err
+	}
+	instance := val.(string)
+
+	val, ok = m["mountpoint"]
+	if !ok {
+		// we have to have the mountpoint ?
+		return APIResponse{http.StatusBadRequest, nil}, err
+	}
+	mountPoint := val.(string)
+
+	err = bc.AttachVolume(tenant, volume, instance, mountPoint)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	return APIResponse{http.StatusAccepted, nil}, nil
+}
+
+// StartAPI starts the block API v2 http service.
+func StartAPI(config APIConfig) {
+	// make new Context
+	context := &Context{config.Port, config.VolService}
+
+	// TBD: it'd be nice to return the handlers somehow and then
+	// add the keystone middleware layer somewhere else somehow.
+	r := mux.NewRouter()
+
+	// API versions
+	r.Handle("/", APIHandler{context, listAPIVersions}).Methods("GET")
+	r.Handle("/v2", APIHandler{context, showAPIv2Details}).Methods("GET")
+
+	// Limits
+	r.Handle("/v2/{tenant}/limits",
+		APIHandler{context, showAbsoluteLimits}).Methods("GET")
+
+	// Volumes
+	r.Handle("/v2/{tenant}/volumes",
+		APIHandler{context, createVolume}).Methods("POST")
+	r.Handle("/v2/{tenant}/volumes",
+		APIHandler{context, listVolumes}).Methods("GET")
+	r.Handle("/v2/{tenant}/volumes/detail",
+		APIHandler{context, listVolumesDetail}).Methods("GET")
+	r.Handle("/v2/{tenant}/volumes/{volume_id}",
+		APIHandler{context, showVolumeDetails}).Methods("GET")
+	r.Handle("/v2/{tenant}/volumes/{volume_id}",
+		APIHandler{context, deleteVolume}).Methods("DELETE")
+
+	// Volume actions
+	r.Handle("/v2/{tenant}/volumes/{volume_id}/action",
+		APIHandler{context, volumeAction}).Methods("POST")
+
+	service := fmt.Sprintf(":%d", config.Port)
+	glog.Fatal(http.ListenAndServeTLS(service, config.HTTPSCACert,
+		config.HTTPSKey, r))
+}

--- a/openstack/block/api.go
+++ b/openstack/block/api.go
@@ -324,13 +324,13 @@ type APIConfig struct {
 // The caller who is starting the api service needs to provide this
 // interface.
 type Service interface {
-	GetAbsoluteLimits(string) (AbsoluteLimits, error)
-	CreateVolume(string, RequestedVolume) (Volume, error)
-	DeleteVolume(string, string) error
-	AttachVolume(string, string, string, string) error
-	ListVolumes(string) ([]ListVolume, error)
-	ListVolumesDetail(string) ([]VolumeDetail, error)
-	ShowVolumeDetails(string, string) (VolumeDetail, error)
+	GetAbsoluteLimits(tenant string) (AbsoluteLimits, error)
+	CreateVolume(tenant string, req RequestedVolume) (Volume, error)
+	DeleteVolume(tenant string, volume string) error
+	AttachVolume(tenant string, volume string, instance string, mountpoint string) error
+	ListVolumes(tenant string) ([]ListVolume, error)
+	ListVolumesDetail(tenant string) ([]VolumeDetail, error)
+	ShowVolumeDetails(tenant string, volume string) (VolumeDetail, error)
 }
 
 // Context contains data and interfaces that the block api will need.

--- a/openstack/block/api.go
+++ b/openstack/block/api.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/gorilla/mux"
 )
 
@@ -317,10 +316,8 @@ func errorResponse(err error) APIResponse {
 
 // APIConfig contains information needed to start the block api service.
 type APIConfig struct {
-	Port        int     // the https port of the block api service
-	HTTPSCACert string  // the https CA certificate
-	HTTPSKey    string  // the https key for the certificate
-	VolService  Service // the service interface
+	Port       int     // the https port of the block api service
+	VolService Service // the service interface
 }
 
 // Service contains the required interface to the block service.
@@ -606,13 +603,11 @@ func volumeAction(bc *Context, w http.ResponseWriter, r *http.Request) (APIRespo
 	return APIResponse{http.StatusAccepted, nil}, nil
 }
 
-// StartAPI starts the block API v2 http service.
-func StartAPI(config APIConfig) {
+// Routes provides gorilla mux routes for the supported endpoints.
+func Routes(config APIConfig) *mux.Router {
 	// make new Context
 	context := &Context{config.Port, config.VolService}
 
-	// TBD: it'd be nice to return the handlers somehow and then
-	// add the keystone middleware layer somewhere else somehow.
 	r := mux.NewRouter()
 
 	// API versions
@@ -639,7 +634,5 @@ func StartAPI(config APIConfig) {
 	r.Handle("/v2/{tenant}/volumes/{volume_id}/action",
 		APIHandler{context, volumeAction}).Methods("POST")
 
-	service := fmt.Sprintf(":%d", config.Port)
-	glog.Fatal(http.ListenAndServeTLS(service, config.HTTPSCACert,
-		config.HTTPSKey, r))
+	return r
 }

--- a/openstack/block/api_test.go
+++ b/openstack/block/api_test.go
@@ -262,3 +262,13 @@ func TestAPIResponse(t *testing.T) {
 		}
 	}
 }
+
+func TestRoutes(t *testing.T) {
+	var vs testVolumeService
+	config := APIConfig{8776, vs}
+
+	r := Routes(config)
+	if r == nil {
+		t.Fatalf("No routes returned")
+	}
+}

--- a/openstack/block/api_test.go
+++ b/openstack/block/api_test.go
@@ -1,0 +1,264 @@
+package block
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+type test struct {
+	method           string
+	pattern          string
+	handler          func(*Context, http.ResponseWriter, *http.Request) (APIResponse, error)
+	request          string
+	expectedStatus   int
+	expectedResponse string
+}
+
+func myHostname() string {
+	host, _ := os.Hostname()
+	return host
+}
+
+var tests = []test{
+	{
+		"GET",
+		"/",
+		listAPIVersions,
+		"",
+		http.StatusOK,
+		`{"versions":[{"status":"SUPPORTED","updated":"2014-06-28T12:20:21Z","links":[{"href":"http://docs.openstack.org/","type":"text/html","rel":"describedby"},{"href":"` + fmt.Sprintf("https://%s:8776/v2/", myHostname()) + `","rel":"self"}],"min_version":"","version":"","media-types":[{"base":"application/json","type":"application/vnd.openstack.volume+json;version=1"}],"id":"v2.0"}]}`,
+	},
+	{
+		"GET",
+		"/v2",
+		showAPIv2Details,
+		"",
+		http.StatusOK,
+		`{"choices":[{"status":"CURRENT","media-types":[{"base":"application/json","type":"application/vnd.openstack.volume+json;version=1"}],"id":"v2.0","links":[{"href":"https://kcaccard-mobl3.jf.intel.com:8776/v2/v2.json","rel":"self"}]}]}`,
+	},
+	{
+		"GET",
+		"/v2/validtenantid/limits",
+		showAbsoluteLimits,
+		"",
+		http.StatusOK,
+		`{"limits":{"rate":[],"absolute":{"totalSnapshotsUsed":0,"maxTotalBackups":-1,"maxTotalVolumeGigabytes":-1,"maxTotalSnapshots":-1,"maxTotalBackupGigabytes":-1,"totalBackupGigabytesUsed":0,"maxTotalVolumes":-1,"totalVolumesUsed":0,"totalBackupsUsed":0,"totalGigabytesUsed":0}}}`,
+	},
+	{
+		"POST",
+		"/v2/validtenantid/volumes",
+		createVolume,
+		`{"volume":{"size": 10,"availability_zone": null,"source_volid": null,"description":null,"multiattach ":false,"snapshot_id":null,"name":null,"imageRef":null,"volume_type":null,"metadata":{},"source_replica":null,"consistencygroup_id":null}}`,
+		http.StatusAccepted,
+		`{"volume":{"status":"creating","migration_status":null,"user_id":"validuserid","attachments":[],"links":[],"availability_zone":null,"bootable":false,"encrypted":false,"created_at":null,"description":null,"updated_at":null,"volume_type":null,"name":null,"replication_status":"disabled","consistencygroup_id":null,"source_volid":null,"snapshot_id":null,"multiattach":false,"metadata":{},"id":"validvolumeid","size":10}}`,
+	},
+	{
+		"GET",
+		"/v2/validtenantid/volumes",
+		listVolumes,
+		"",
+		http.StatusOK,
+		`{"volumes":[{"id":"validvolumeid1","links":[],"name":"vol-001"},{"id":"validvolumeid2","links":[],"name":"vol-002"},{"id":"validvolumeid3","links":[],"name":"vol-003"}]}`,
+	},
+	{
+		"GET",
+		"/v2/validtenantid/volumes/detail",
+		listVolumesDetail,
+		"",
+		http.StatusOK,
+		`{"volumes":[{"migration_status":null,"attachments":[{"server_id":"f4fda93b-06e0-4743-8117-bc8bcecd651b","attachment_id":"3b4db356-253d-4fab-bfa0-e3626c0b8405","host_name":null,"volume_id":"6edbc2f4-1507-44f8-ac0d-eed1d2608d38","device":"/dev/vdb","id":"6edbc2f4-1507-44f8-ac0d-eed1d2608d38"}],"links":[{"href":"http://23.253.248.171:8776/v2/bab7d5c60cd041a0a36f7c4b6e1dd978/volumes/6edbc2f4-1507-44f8-ac0d-eed1d2608d38","rel":"self"},{"href":"http://23.253.248.171:8776/bab7d5c60cd041a0a36f7c4b6e1dd978/volumes/6edbc2f4-1507-44f8-ac0d-eed1d2608d38","rel":"bookmark"}],"availability_zone":"nova","os-vol-host-attr:host":"cephcluster","encrypted":false,"updated_at":null,"replication_status":"disabled","snapshot_id":null,"id":"6edbc2f4-1507-44f8-ac0d-eed1d2608d38","size":2,"user_id":"32779452fcd34ae1a53a797ac8a1e064","os-vol-tenant-attr:tenant_id":"bab7d5c60cd041a0a36f7c4b6e1dd978","os-vol-mig-status-attr:migstat":null,"metadata":{"attached_mode":"rw","readonly":false},"status":"in-use","description":null,"multiattach":true,"source_volid":null,"consistencygroup_id":null,"os-vol-mig-status-attr:name_id":null,"name":"vol-001","bootable":false,"created_at":null,"volume_type":null}]}`,
+	},
+	{
+		"GET",
+		"/v2/validtenantid/volumes/validvolumeid",
+		showVolumeDetails,
+		"",
+		http.StatusOK,
+		`{"volume":{"migration_status":null,"attachments":[],"links":[{"href":"http://localhost:8776/v2/0c2eba2c5af04d3f9e9d0d410b371fde/volumes/5aa119a8-d25b-45a7-8d1b-88e127885635","rel":"self"},{"href":"http://localhost:8776/0c2eba2c5af04d3f9e9d0d410b371fde/volumes/5aa119a8-d25b-45a7-8d1b-88e127885635","rel":"bookmark"}],"availability_zone":"nova","os-vol-host-attr:host":"ip-10-168-107-25","encrypted":false,"updated_at":null,"replication_status":"disabled","snapshot_id":null,"id":"5aa119a8-d25b-45a7-8d1b-88e127885635","size":1,"user_id":"32779452fcd34ae1a53a797ac8a1e064","os-vol-tenant-attr:tenant_id":"0c2eba2c5af04d3f9e9d0d410b371fde","os-vol-mig-status-attr:migstat":null,"metadata":{"contents":"not junk"},"status":"available","description":"Super volume.","multiattach":false,"source_volid":null,"consistencygroup_id":null,"os-vol-mig-status-attr:name_id":null,"name":"vol-002","bootable":false,"created_at":null,"volume_type":"None"}}`,
+	},
+	{
+		"DELETE",
+		"/v2/validtenantid/volumes/validvolumeid",
+		deleteVolume,
+		"",
+		http.StatusAccepted,
+		"null",
+	},
+	{
+		"POST",
+		"/v2/validtenantid/volumes/validvolumeid/action",
+		volumeAction,
+		`{"os-attach":{"instance_uuid":"validinstanceid","mountpoint":"/dev/vdc"}}`,
+		http.StatusAccepted,
+		"null",
+	},
+}
+
+type testVolumeService struct{}
+
+func (vs testVolumeService) GetAbsoluteLimits(tenant string) (AbsoluteLimits, error) {
+	return AbsoluteLimits{
+		MaxTotalBackups:         -1,
+		MaxTotalVolumeGigabytes: -1,
+		MaxTotalSnapshots:       -1,
+		MaxTotalBackupGigabytes: -1,
+		MaxTotalVolumes:         -1,
+	}, nil
+}
+
+func (vs testVolumeService) ShowVolumeDetails(tenant string, volume string) (VolumeDetail, error) {
+	volName := "vol-002"
+
+	selfLink := Link{
+		Href: "http://localhost:8776/v2/0c2eba2c5af04d3f9e9d0d410b371fde/volumes/5aa119a8-d25b-45a7-8d1b-88e127885635",
+		Rel:  "self",
+	}
+
+	bookLink := Link{
+		Href: "http://localhost:8776/0c2eba2c5af04d3f9e9d0d410b371fde/volumes/5aa119a8-d25b-45a7-8d1b-88e127885635",
+		Rel:  "bookmark",
+	}
+
+	zone := "nova"
+	description := "Super volume."
+	volType := "None"
+
+	meta := map[string]interface{}{
+		"contents": "not junk",
+	}
+
+	return VolumeDetail{
+		Attachments:       make([]Attachment, 0),
+		Links:             []Link{selfLink, bookLink},
+		ReplicationStatus: ReplicationDisabled,
+		ID:                "5aa119a8-d25b-45a7-8d1b-88e127885635",
+		Status:            Available,
+		Name:              &volName,
+		AvailabilityZone:  &zone,
+		OSVolHostAttr:     "ip-10-168-107-25",
+		Size:              1,
+		UserID:            "32779452fcd34ae1a53a797ac8a1e064",
+		OSVolTenantAttr:   "0c2eba2c5af04d3f9e9d0d410b371fde",
+		MetaData:          meta,
+		MultiAttach:       false,
+		VolumeType:        &volType,
+		Description:       &description,
+	}, nil
+}
+
+func (vs testVolumeService) CreateVolume(tenant string, req RequestedVolume) (Volume, error) {
+	return Volume{
+		Status:            Creating,
+		UserID:            "validuserid",
+		Attachments:       make([]Attachment, 0),
+		Links:             make([]Link, 0),
+		Bootable:          (req.ImageRef != nil),
+		Description:       req.Description,
+		VolumeType:        req.VolumeType,
+		Name:              req.Name,
+		ReplicationStatus: ReplicationDisabled,
+		SourceVolID:       req.SourceVolID,
+		SnapshotID:        req.SnapshotID,
+		MultiAttach:       req.MultiAttach,
+		MetaData:          req.MetaData,
+		ID:                "validvolumeid",
+		Size:              req.Size,
+	}, nil
+}
+
+func (vs testVolumeService) DeleteVolume(tenant string, volume string) error {
+	return nil
+}
+
+func (vs testVolumeService) AttachVolume(tenant string, volume string, instance string, mountpoint string) error {
+	return nil
+}
+
+func (vs testVolumeService) ListVolumes(tenant string) ([]ListVolume, error) {
+	return []ListVolume{
+		{"validvolumeid1", make([]Link, 0), "vol-001"},
+		{"validvolumeid2", make([]Link, 0), "vol-002"},
+		{"validvolumeid3", make([]Link, 0), "vol-003"},
+	}, nil
+}
+
+func (vs testVolumeService) ListVolumesDetail(tenant string) ([]VolumeDetail, error) {
+	volName := "vol-001"
+
+	attachment := Attachment{
+		ServerUUID:     "f4fda93b-06e0-4743-8117-bc8bcecd651b",
+		AttachmentUUID: "3b4db356-253d-4fab-bfa0-e3626c0b8405",
+		VolumeUUID:     "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+		Device:         "/dev/vdb",
+		DeviceUUID:     "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+	}
+
+	selfLink := Link{
+		Href: "http://23.253.248.171:8776/v2/bab7d5c60cd041a0a36f7c4b6e1dd978/volumes/6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+		Rel:  "self",
+	}
+
+	bookLink := Link{
+		Href: "http://23.253.248.171:8776/bab7d5c60cd041a0a36f7c4b6e1dd978/volumes/6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+		Rel:  "bookmark",
+	}
+
+	zone := "nova"
+
+	meta := map[string]interface{}{
+		"attached_mode": "rw",
+		"readonly":      false,
+	}
+
+	return []VolumeDetail{
+		VolumeDetail{
+			Attachments:       []Attachment{attachment},
+			Links:             []Link{selfLink, bookLink},
+			ReplicationStatus: ReplicationDisabled,
+			ID:                "6edbc2f4-1507-44f8-ac0d-eed1d2608d38",
+			Status:            InUse,
+			Name:              &volName,
+			AvailabilityZone:  &zone,
+			OSVolHostAttr:     "cephcluster",
+			Size:              2,
+			UserID:            "32779452fcd34ae1a53a797ac8a1e064",
+			OSVolTenantAttr:   "bab7d5c60cd041a0a36f7c4b6e1dd978",
+			MetaData:          meta,
+			MultiAttach:       true,
+		},
+	}, nil
+}
+
+func TestAPIResponse(t *testing.T) {
+	var vs testVolumeService
+
+	// TBD: add context to test definition so it can be created per
+	// endpoint with either a pass testVolumeService or a failure
+	// one.
+	context := &Context{8776, vs}
+
+	for _, tt := range tests {
+		req, err := http.NewRequest(tt.method, tt.pattern, bytes.NewBuffer([]byte(tt.request)))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+		handler := APIHandler{context, tt.handler}
+
+		handler.ServeHTTP(rr, req)
+
+		status := rr.Code
+		if status != tt.expectedStatus {
+			t.Errorf("got %v, expected %v", status, tt.expectedStatus)
+		}
+
+		if rr.Body.String() != tt.expectedResponse {
+			t.Errorf("%s: failed\ngot: %v\nexp: %v", tt.pattern, rr.Body.String(), tt.expectedResponse)
+		}
+	}
+}

--- a/openstack/identity/identity.go
+++ b/openstack/identity/identity.go
@@ -1,0 +1,307 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identity
+
+import (
+	"net/http"
+
+	"github.com/golang/glog"
+	"github.com/gorilla/mux"
+	"github.com/mitchellh/mapstructure"
+	"github.com/rackspace/gophercloud"
+	v3tokens "github.com/rackspace/gophercloud/openstack/identity/v3/tokens"
+)
+
+// Project holds project information extracted from the keystone response.
+type Project struct {
+	ID   string `mapstructure:"id"`
+	Name string `mapstructure:"name"`
+}
+
+// RoleEntry contains the name of a role extracted from the keystone response.
+type RoleEntry struct {
+	Name string `mapstructure:"name"`
+}
+
+// Roles contains a list of role names extracted from the keystone response.
+type Roles struct {
+	Entries []RoleEntry
+}
+
+// Endpoint contains endpoint information extracted from the keystone response.
+type Endpoint struct {
+	ID        string `mapstructure:"id"`
+	Region    string `mapstructure:"region"`
+	Interface string `mapstructure:"interface"`
+	URL       string `mapstructure:"url"`
+}
+
+// ServiceEntry contains information about a service extracted from the keystone response.
+type ServiceEntry struct {
+	ID        string     `mapstructure:"id"`
+	Name      string     `mapstructure:"name"`
+	Type      string     `mapstructure:"type"`
+	Endpoints []Endpoint `mapstructure:"endpoints"`
+}
+
+// Services is a list of ServiceEntry structs
+// These structs contain information about the services keystone knows about.
+type Services struct {
+	Entries []ServiceEntry
+}
+
+type getResult struct {
+	v3tokens.GetResult
+}
+
+// extractProject
+// Ideally we would actually contribute this functionality
+// back to the gophercloud project, but for now we extend
+// their object to allow us to get project information out
+// of the response from the GET token validation request.
+func (r getResult) extractProject() (*Project, error) {
+	if r.Err != nil {
+		glog.V(2).Info(r.Err)
+		return nil, r.Err
+	}
+
+	// can there be more than one project?  You need to test.
+	var response struct {
+		Token struct {
+			ValidProject Project `mapstructure:"project"`
+		} `mapstructure:"token"`
+	}
+
+	err := mapstructure.Decode(r.Body, &response)
+	if err != nil {
+		glog.V(2).Info(err)
+		return nil, err
+	}
+
+	return &Project{
+		ID:   response.Token.ValidProject.ID,
+		Name: response.Token.ValidProject.Name,
+	}, nil
+}
+
+func (r getResult) extractServices() (*Services, error) {
+	if r.Err != nil {
+		glog.V(2).Info(r.Err)
+		return nil, r.Err
+	}
+
+	var response struct {
+		Token struct {
+			Entries []ServiceEntry `mapstructure:"catalog"`
+		} `mapstructure:"token"`
+	}
+
+	err := mapstructure.Decode(r.Body, &response)
+	if err != nil {
+		glog.Errorf(err.Error())
+		return nil, err
+	}
+
+	return &Services{Entries: response.Token.Entries}, nil
+}
+
+// extractRole
+// Ideally we would actually contribute this functionality
+// back to the gophercloud project, but for now we extend
+// their object to allow us to get project information out
+// of the response from the GET token validation request.
+func (r getResult) extractRoles() (*Roles, error) {
+	if r.Err != nil {
+		glog.V(2).Info(r.Err)
+		return nil, r.Err
+	}
+
+	var response struct {
+		Token struct {
+			ValidRoles []RoleEntry `mapstructure:"roles"`
+		} `mapstructure:"token"`
+	}
+
+	err := mapstructure.Decode(r.Body, &response)
+	if err != nil {
+		glog.V(2).Info(err)
+		return nil, err
+	}
+
+	return &Roles{Entries: response.Token.ValidRoles}, nil
+}
+
+// validateServices
+// Validates that a given user belonging to a tenant
+// can access a service specified by its type and name.
+func validateService(client *gophercloud.ServiceClient, token string, tenantID string, serviceType string, serviceName string) bool {
+	r := v3tokens.Get(client, token)
+	result := getResult{r}
+
+	p, err := result.extractProject()
+	if err != nil {
+		return false
+	}
+
+	if p.ID != tenantID {
+		glog.Errorf("expected %s got %s\n", tenantID, p.ID)
+		return false
+	}
+
+	services, err := result.extractServices()
+	if err != nil {
+		return false
+	}
+
+	for _, e := range services.Entries {
+		if e.Type == serviceType {
+			if serviceName == "" {
+				return true
+			}
+
+			if e.Name == serviceName {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func validateProjectRole(client *gophercloud.ServiceClient, token string, project string, role string) bool {
+	r := v3tokens.Get(client, token)
+	result := getResult{r}
+	p, err := result.extractProject()
+	if err != nil {
+		return false
+	}
+
+	if project != "" && p.Name != project {
+		return false
+	}
+
+	roles, err := result.extractRoles()
+	if err != nil {
+		return false
+	}
+
+	for i := range roles.Entries {
+		if roles.Entries[i].Name == role {
+			return true
+		}
+	}
+	return false
+}
+
+func (h Handler) tenantToken(r *http.Request, tenant string) bool {
+	token := r.Header["X-Auth-Token"]
+	if token == nil {
+		return false
+	}
+
+	/* TODO Caching or PKI */
+	for _, s := range h.ValidServices {
+		if validateService(h.Client, token[0], tenant, s.ServiceType, s.ServiceName) == true {
+			return true
+		}
+
+	}
+
+	for _, s := range h.ValidServices {
+		if validateService(h.Client, token[0], tenant, s.ServiceType, "") == true {
+			return true
+		}
+
+	}
+
+	return false
+}
+
+func (h Handler) adminToken(r *http.Request) bool {
+	token := r.Header["X-Auth-Token"]
+	if token == nil {
+		return false
+	}
+
+	/* TODO Caching or PKI */
+	for _, a := range h.ValidAdmins {
+		if validateProjectRole(h.Client, token[0], a.Project, a.Role) == true {
+			return true
+		}
+	}
+
+	vars := mux.Vars(r)
+	tenant := vars["tenant"]
+	glog.V(2).Infof("Invalid token for [%s]", tenant)
+	return false
+}
+
+func (h Handler) validateToken(r *http.Request) bool {
+	vars := mux.Vars(r)
+	tenant := vars["tenant"]
+
+	glog.V(2).Infof("Token validation for [%s]", tenant)
+
+	// We do not want to unconditionally check for an admin token, this is inefficient.
+	// We check for an admin token iff:
+	// - We do not have a tenant variable
+	// - We do have one but it does not match the token
+
+	/* If we don't have a tenant parameter, are we admin ? */
+	if tenant == "" {
+		return h.adminToken(r)
+	}
+
+	/* If we have a tenant parameter that does not match the token are we admin ? */
+	if h.tenantToken(r, tenant) == false {
+		return h.adminToken(r)
+	}
+
+	return true
+}
+
+// ValidService defines service name and type of the api service
+type ValidService struct {
+	ServiceType string
+	ServiceName string
+}
+
+// ValidAdmin defines which project and roles are considered valid for admin.
+type ValidAdmin struct {
+	Project string
+	Role    string
+}
+
+// Handler is a custom handler for APIs which would like keystone validation.
+// This custom handler allows us to more cleanly return an error and response,
+// and pass some package level context into the handler.
+type Handler struct {
+	Client        *gophercloud.ServiceClient
+	Next          http.Handler
+	ValidServices []ValidService
+	ValidAdmins   []ValidAdmin
+}
+
+// ServeHTTP satisfies the http handler interface.
+// It will check to make sure that the api caller is validated with
+// keystone before allowing the next handler in the chain to be called.
+func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.validateToken(r) == false {
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		return
+	}
+
+	h.Next.ServeHTTP(w, r)
+}

--- a/openstack/identity/identity_test.go
+++ b/openstack/identity/identity_test.go
@@ -1,0 +1,186 @@
+package identity
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/01org/ciao/testutil"
+	"github.com/gorilla/mux"
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/openstack"
+)
+
+var validServices = []ValidService{
+	{"compute", "ciao"},
+	{"compute", "nova"},
+}
+
+var validAdmins = []ValidAdmin{
+	{"service", "admin"},
+	{"admin", "admin"},
+}
+
+var invalidAdmins = []ValidAdmin{
+	{"test", "test"},
+}
+
+var invalidServices = []ValidService{
+	{"test", "test"},
+}
+
+var anyOldComputeServices = []ValidService{
+	{"compute", "whatevahs"},
+}
+
+type test struct {
+	URL              string
+	route            string
+	validServices    []ValidService
+	validAdmins      []ValidAdmin
+	expectedResponse int
+}
+
+var tests = []test{
+	{fmt.Sprintf("/v2/%s/volumes", testutil.ComputeUser), "/v2/{tenant}/volumes", validServices, validAdmins, 200},
+	{"/v2.1/tenants", "/v2.1/tenants", validServices, validAdmins, 200},
+	{"/v2.1/tenants", "/v2.1/tenants", validServices, invalidAdmins, 401},
+	{fmt.Sprintf("/v2/%s/volumes", testutil.ComputeUser), "/v2/{tenant}/volumes", invalidServices, invalidAdmins, 401},
+	{fmt.Sprintf("/v2/%s/volumes", testutil.ComputeUser), "/v2/{tenant}/volumes", anyOldComputeServices, invalidAdmins, 200},
+	{fmt.Sprintf("/v2/%s/volumes", "unknowntenantid"), "/v2/{tenant}/volumes", validServices, invalidAdmins, 401},
+}
+
+func getIdentityClient(endpoint string) (*gophercloud.ServiceClient, error) {
+	opt := gophercloud.AuthOptions{
+		IdentityEndpoint: endpoint + "v3/",
+		Username:         "ciao",
+		Password:         "iheartciao",
+		TenantName:       "service",
+		DomainID:         "default",
+		AllowReauth:      true,
+	}
+	provider, err := openstack.AuthenticatedClient(opt)
+	if err != nil {
+		return nil, err
+	}
+
+	v3client := openstack.NewIdentityV3(provider)
+	if v3client == nil {
+		return nil, errors.New("Unable to get keystone V3 client")
+	}
+
+	return v3client, nil
+}
+
+func TestNoToken(t *testing.T) {
+	testIdentityConfig := testutil.IdentityConfig{
+		ComputeURL: testutil.ComputeURL,
+		ProjectID:  testutil.ComputeUser,
+	}
+
+	id := testutil.StartIdentityServer(testIdentityConfig)
+	if id == nil {
+		t.Fatal("Could not start test identity server")
+	}
+
+	defer id.Close()
+
+	client, err := getIdentityClient(id.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Println("hello")
+	})
+
+	validServices := []ValidService{
+		{"compute", "ciao"},
+		{"compute", "nova"},
+	}
+
+	validAdmins := []ValidAdmin{
+		{"service", "admin"},
+		{"admin", "admin"},
+	}
+
+	h := Handler{
+		Client:        client,
+		Next:          &testHandler,
+		ValidServices: validServices,
+		ValidAdmins:   validAdmins,
+	}
+
+	for _, tt := range tests {
+		req, err := http.NewRequest("GET", tt.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+
+		r := mux.NewRouter()
+
+		r.Handle(tt.route, h).Methods("GET")
+
+		r.ServeHTTP(rr, req)
+
+		status := rr.Code
+		if status != http.StatusUnauthorized {
+			t.Errorf("got %v: expected %v", status, http.StatusUnauthorized)
+		}
+	}
+}
+
+func TestHandler(t *testing.T) {
+	testIdentityConfig := testutil.IdentityConfig{
+		ComputeURL: testutil.ComputeURL,
+		ProjectID:  testutil.ComputeUser,
+	}
+
+	id := testutil.StartIdentityServer(testIdentityConfig)
+	if id == nil {
+		t.Fatal("Could not start test identity server")
+	}
+
+	defer id.Close()
+
+	client, err := getIdentityClient(id.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		return
+	})
+
+	for _, tt := range tests {
+		h := Handler{
+			Client:        client,
+			Next:          &testHandler,
+			ValidServices: tt.validServices,
+			ValidAdmins:   tt.validAdmins,
+		}
+
+		req, err := http.NewRequest("GET", tt.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("X-Auth-Token", "imaninvalidtoken")
+
+		rr := httptest.NewRecorder()
+
+		r := mux.NewRouter()
+
+		r.Handle(tt.route, h).Methods("GET")
+
+		r.ServeHTTP(rr, req)
+
+		status := rr.Code
+		if status != tt.expectedResponse {
+			t.Errorf("got %v: expected %v", status, tt.expectedResponse)
+		}
+	}
+}

--- a/openstack/image/api.go
+++ b/openstack/image/api.go
@@ -1,0 +1,300 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package image
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+// TBD - are these thing shared enough between OpenStack services
+// to be pulled out to a common area?
+// ---------
+
+// VersionStatus defines whether a reported version is supported or not.
+type VersionStatus string
+
+const (
+	// Deprecated indicates the api deprecates the spec version.
+	Deprecated VersionStatus = "DEPRECATED"
+
+	// Supported indicates a spec version is supported by the api
+	Supported VersionStatus = "SUPPORTED"
+
+	// Current indicates the current spec version of the api
+	// TBD: can this be eliminated? do we need both supported & current?
+	Current VersionStatus = "CURRENT"
+)
+
+// Link is used by the API to create the link json strings.
+type Link struct {
+	Href string `json:"href"`
+	Type string `json:"type,omitempty"`
+	Rel  string `json:"rel,omitempty"`
+}
+
+// Version is used by the API to create the version json strings
+type Version struct {
+	Status VersionStatus `json:"status"`
+	ID     string        `json:"id"`
+	Links  []Link        `json:"links"`
+}
+
+// Versions creates multiple version json strings
+type Versions struct {
+	Versions []Version `json:"versions"`
+}
+
+// --------
+// end possible common json
+
+// ImageStatus defines the possible states for an image
+type ImageStatus string
+
+const (
+	// The image service reserved an image ID for the image but did
+	// not yet upload any image data.
+	Queued ImageStatus = "queued"
+
+	// the image service is currently uploading the raw data for the image.
+	Saving ImageStatus = "saving"
+
+	// The image is active and fully available in the image service
+	Active ImageStatus = "active"
+
+	// An image data upload error occurred
+	Killed ImageStatus = "killed"
+
+	// The image service retains information abou tthe image but the image
+	// is no longer available for use.
+	Deleted ImageStatus = "deleted"
+
+	// Similar to the deleted status. An image in this state is not
+	// recoverable.
+	PendingDelete ImageStatus = "pending_delete"
+)
+
+// ImageVisibility defines whether an image is per tenant or public
+type ImageVisibility string
+
+const (
+	// Public indicates that the image can be used by anyone.
+	Public ImageVisibility = "public"
+
+	// Private indicates that the image is only available to a tenant.
+	Private ImageVisibility = "private"
+)
+
+// ContainerFormat defines the acceptable container format strings.
+type ContainerFormat string
+
+const (
+	// we support the bare format only
+	Bare ContainerFormat = "bare"
+)
+
+// DiskFormat defines the valid values for the disk_format string
+type DiskFormat string
+
+// we support the following disk formats
+const (
+	// Raw
+	Raw DiskFormat = "raw"
+
+	// QCow
+	QCow DiskFormat = "qcow2"
+
+	// ISO
+	ISO DiskFormat = "iso"
+)
+
+// CreateImageRequest contains information for a create image request.
+// http://developer.openstack.org/api-ref-image-v2.html#createImage-v2
+type CreateImageRequest struct {
+	Name            string          `json:"name,omitempty"`
+	ID              string          `json:"id,omitempty"`
+	Visibility      ImageVisibility `json:"visibility,omitempty"`
+	Tags            []string        `json:"tags,omitempty"`
+	ContainerFormat ContainerFormat `json:"container_format,omitempty"`
+	DiskFormat      DiskFormat      `json:"disk_format,omitempty"`
+	MinDisk         int             `json:"min_disk,omitempty"`
+	MinRAM          int             `json:"min_ram,omitempty"`
+	Protected       bool            `json:"protected,omitempty"`
+	Properties      interface{}     `json:"properties,omitempty"`
+}
+
+// CreateImageResponse contains information about a created image
+// http://developer.openstack.org/api-ref-image-v2.html#createImage-v2
+type CreateImageResponse struct {
+	Status          ImageStatus      `json:"status"`
+	ContainerFormat *ContainerFormat `json:"container_format"`
+	MinRAM          *int             `json:"min_ram"`
+	UpdatedAt       *time.Time       `json:"updated_at"`
+	Owner           *string          `json:"owner"`
+	MinDisk         *int             `json:"min_disk"`
+	Tags            []string         `json:"tags"`
+	Locations       []string         `json:"locations"`
+	Visibility      ImageVisibility  `json:"visibility"`
+	ID              string           `json:"id"`
+	Size            *int             `json:"size"`
+	VirtualSize     *int             `json:"virtual_size"`
+	Name            *string          `json:"name"`
+	CheckSum        *string          `json:"checksum"`
+	CreatedAt       time.Time        `json:"created_at"`
+	DiskFormat      DiskFormat       `json:"disk_format"`
+	Properties      interface{}      `json:"properties"`
+	Protected       bool             `json:"protected"`
+	Self            string           `json:"self"`
+	File            string           `json:"file"`
+	Schema          string           `json:"schema"`
+}
+
+// TBD - can we pull these structs out into some sort of common
+// api service file?
+// ----------
+
+// APIConfig contains information needed to start the block api service.
+type APIConfig struct {
+	Port         int     // the https port of the block api service
+	ImageService Service // the service interface
+}
+
+type Service interface {
+	CreateImage(CreateImageRequest) (CreateImageResponse, error)
+}
+
+// Context contains data and interfaces that the image api will need.
+// TBD: do we really need this, or is just a service interface sufficient?
+type Context struct {
+	port int
+	Service
+}
+
+// APIResponse is returned from the API handlers.
+type APIResponse struct {
+	status   int
+	response interface{}
+}
+
+// APIHandler is a custom handler for the image APIs.
+// This custom handler allows us to more cleanly return an error and response,
+// and pass some package level context into the handler.
+type APIHandler struct {
+	*Context
+	Handler func(*Context, http.ResponseWriter, *http.Request) (APIResponse, error)
+}
+
+// ServeHTTP satisfies the http Handler interface.
+// It wraps our api response in json as well.
+func (h APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	resp, err := h.Handler(h.Context, w, r)
+	if err != nil {
+		http.Error(w, http.StatusText(resp.status), resp.status)
+	}
+
+	b, err := json.Marshal(resp.response)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.status)
+	w.Write(b)
+}
+
+// ---------------
+// end possible common service api stuff
+
+// errorResponse maps service error responses to http responses.
+// this helper function can help functions avoid having to switch
+// on return values all the time.
+func errorResponse(err error) APIResponse {
+	switch err {
+	default:
+		return APIResponse{http.StatusInternalServerError, nil}
+	}
+}
+
+// endpoints
+func listAPIVersions(context *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
+	host, err := os.Hostname()
+	if err != nil {
+		return APIResponse{http.StatusInternalServerError, nil}, err
+	}
+
+	// maybe we should just put href in context
+	href := fmt.Sprintf("https://%s:%d/v2/", host, context.port)
+
+	// TBD clean up this code
+	var resp Versions
+
+	selfLink := Link{
+		Href: href,
+		Rel:  "self",
+	}
+
+	v := Version{
+		Status: Current,
+		ID:     "v2.3",
+		Links:  []Link{selfLink},
+	}
+
+	resp.Versions = append(resp.Versions, v)
+
+	return APIResponse{http.StatusOK, resp}, nil
+}
+
+func createImage(context *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
+	defer r.Body.Close()
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return APIResponse{http.StatusBadRequest, nil}, err
+	}
+
+	var req CreateImageRequest
+
+	err = json.Unmarshal(body, &req)
+	if err != nil {
+		return APIResponse{http.StatusInternalServerError, nil}, err
+	}
+
+	resp, err := context.CreateImage(req)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	return APIResponse{http.StatusCreated, resp}, nil
+}
+
+// Routes provides gorilla mux routes for the supported endpoints.
+func Routes(config APIConfig) *mux.Router {
+	// make new Context
+	context := &Context{config.Port, config.ImageService}
+
+	r := mux.NewRouter()
+
+	// API versions
+	r.Handle("/", APIHandler{context, listAPIVersions}).Methods("GET")
+	r.Handle("/v2/images", APIHandler{context, createImage}).Methods("POST")
+
+	return r
+}

--- a/openstack/image/api_test.go
+++ b/openstack/image/api_test.go
@@ -51,6 +51,14 @@ var tests = []test{
 		http.StatusCreated,
 		`{"status":"queued","container_format":"bare","min_ram":0,"updated_at":"2015-11-29T22:21:42Z","owner":"bab7d5c60cd041a0a36f7c4b6e1dd978","min_disk":0,"tags":[],"locations":[],"visibility":"private","id":"b2173dd3-7ad6-4362-baa6-a68bce3565cb","size":null,"virtual_size":null,"name":"Ubuntu","checksum":null,"created_at":"2015-11-29T22:21:42Z","disk_format":"raw","properties":null,"protected":false,"self":"/v2/images/b2173dd3-7ad6-4362-baa6-a68bce3565cb","file":"/v2/images/b2173dd3-7ad6-4362-baa6-a68bce3565cb/file","schema":"/v2/schemas/image"}`,
 	},
+	{
+		"GET",
+		"/v2/images",
+		listImages,
+		"",
+		http.StatusOK,
+		`{"images":[{"status":"queued","container_format":"bare","min_ram":0,"updated_at":"2015-11-29T22:21:42Z","owner":"bab7d5c60cd041a0a36f7c4b6e1dd978","min_disk":0,"tags":[],"locations":[],"visibility":"private","id":"b2173dd3-7ad6-4362-baa6-a68bce3565cb","size":null,"virtual_size":null,"name":"Ubuntu","checksum":null,"created_at":"2015-11-29T22:21:42Z","disk_format":"raw","properties":null,"protected":false,"self":"/v2/images/b2173dd3-7ad6-4362-baa6-a68bce3565cb","file":"/v2/images/b2173dd3-7ad6-4362-baa6-a68bce3565cb/file","schema":"/v2/schemas/image"}],"schema":"/v2/schemas/images","first":"/v2/images"}`,
+	},
 }
 
 func myHostname() string {
@@ -88,6 +96,41 @@ func (is testImageService) CreateImage(req CreateImageRequest) (CreateImageRespo
 		Schema:          "/v2/schemas/image",
 		Name:            &name,
 	}, nil
+}
+
+func (is testImageService) ListImages() ([]CreateImageResponse, error) {
+	format := Bare
+	name := "Ubuntu"
+	createdAt, _ := time.Parse(time.RFC3339, "2015-11-29T22:21:42Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2015-11-29T22:21:42Z")
+	minDisk := 0
+	minRAM := 0
+	owner := "bab7d5c60cd041a0a36f7c4b6e1dd978"
+
+	image := CreateImageResponse{
+		Status:          Queued,
+		ContainerFormat: &format,
+		CreatedAt:       createdAt,
+		Tags:            make([]string, 0),
+		DiskFormat:      Raw,
+		Visibility:      Private,
+		UpdatedAt:       &updatedAt,
+		Locations:       make([]string, 0),
+		Self:            "/v2/images/b2173dd3-7ad6-4362-baa6-a68bce3565cb",
+		MinDisk:         &minDisk,
+		Protected:       false,
+		ID:              "b2173dd3-7ad6-4362-baa6-a68bce3565cb",
+		File:            "/v2/images/b2173dd3-7ad6-4362-baa6-a68bce3565cb/file",
+		Owner:           &owner,
+		MinRAM:          &minRAM,
+		Schema:          "/v2/schemas/image",
+		Name:            &name,
+	}
+
+	images := make([]CreateImageResponse, 0)
+	images = append(images, image)
+
+	return images, nil
 }
 
 func TestRoutes(t *testing.T) {

--- a/openstack/image/api_test.go
+++ b/openstack/image/api_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package image
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+)
+
+// TBD - can some of this stuff be pulled out into a common test area?
+type test struct {
+	method           string
+	pattern          string
+	handler          func(*Context, http.ResponseWriter, *http.Request) (APIResponse, error)
+	request          string
+	expectedStatus   int
+	expectedResponse string
+}
+
+var tests = []test{
+	{
+		"GET",
+		"/",
+		listAPIVersions,
+		"",
+		http.StatusOK,
+		`{"versions":[{"status":"CURRENT","id":"v2.3","links":[{"href":"` + fmt.Sprintf("https://%s:9292/v2/", myHostname()) + `","rel":"self"}]}]}`,
+	},
+	{
+		"POST",
+		"/v2/images",
+		createImage,
+		`{"container_format":"bare","disk_format":"raw","name":"Ubuntu","id":"b2173dd3-7ad6-4362-baa6-a68bce3565cb"}`,
+		http.StatusCreated,
+		`{"status":"queued","container_format":"bare","min_ram":0,"updated_at":"2015-11-29T22:21:42Z","owner":"bab7d5c60cd041a0a36f7c4b6e1dd978","min_disk":0,"tags":[],"locations":[],"visibility":"private","id":"b2173dd3-7ad6-4362-baa6-a68bce3565cb","size":null,"virtual_size":null,"name":"Ubuntu","checksum":null,"created_at":"2015-11-29T22:21:42Z","disk_format":"raw","properties":null,"protected":false,"self":"/v2/images/b2173dd3-7ad6-4362-baa6-a68bce3565cb","file":"/v2/images/b2173dd3-7ad6-4362-baa6-a68bce3565cb/file","schema":"/v2/schemas/image"}`,
+	},
+}
+
+func myHostname() string {
+	host, _ := os.Hostname()
+	return host
+}
+
+type testImageService struct{}
+
+func (is testImageService) CreateImage(req CreateImageRequest) (CreateImageResponse, error) {
+	format := Bare
+	name := "Ubuntu"
+	createdAt, _ := time.Parse(time.RFC3339, "2015-11-29T22:21:42Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2015-11-29T22:21:42Z")
+	minDisk := 0
+	minRAM := 0
+	owner := "bab7d5c60cd041a0a36f7c4b6e1dd978"
+
+	return CreateImageResponse{
+		Status:          Queued,
+		ContainerFormat: &format,
+		CreatedAt:       createdAt,
+		Tags:            make([]string, 0),
+		DiskFormat:      Raw,
+		Visibility:      Private,
+		UpdatedAt:       &updatedAt,
+		Locations:       make([]string, 0),
+		Self:            "/v2/images/b2173dd3-7ad6-4362-baa6-a68bce3565cb",
+		MinDisk:         &minDisk,
+		Protected:       false,
+		ID:              "b2173dd3-7ad6-4362-baa6-a68bce3565cb",
+		File:            "/v2/images/b2173dd3-7ad6-4362-baa6-a68bce3565cb/file",
+		Owner:           &owner,
+		MinRAM:          &minRAM,
+		Schema:          "/v2/schemas/image",
+		Name:            &name,
+	}, nil
+}
+
+func TestRoutes(t *testing.T) {
+	var is testImageService
+	config := APIConfig{9292, is}
+
+	r := Routes(config)
+	if r == nil {
+		t.Fatalf("No routes returned")
+	}
+}
+
+func TestAPIResponse(t *testing.T) {
+	var is testImageService
+
+	// TBD: add context to test definition so it can be created per
+	// endpoint with either a pass testVolumeService or a failure
+	// one.
+	context := &Context{9292, is}
+
+	for _, tt := range tests {
+		req, err := http.NewRequest(tt.method, tt.pattern, bytes.NewBuffer([]byte(tt.request)))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+		handler := APIHandler{context, tt.handler}
+
+		handler.ServeHTTP(rr, req)
+
+		status := rr.Code
+		if status != tt.expectedStatus {
+			t.Errorf("got %v, expected %v", status, tt.expectedStatus)
+		}
+
+		if rr.Body.String() != tt.expectedResponse {
+			t.Errorf("%s: failed\ngot: %v\nexp: %v", tt.pattern, rr.Body.String(), tt.expectedResponse)
+		}
+	}
+}

--- a/ssntp/README.md
+++ b/ssntp/README.md
@@ -359,6 +359,32 @@ compared to the last CONFIGURE command sent.
 +-----------------------------------------------------------------------------+
 ```
 
+#### AttachVolume ####
+AttachVolume is a command sent to ciao-launcher for attaching a storage volume
+to a specific running or paused instance.
+
+The AttachVolume command payload includes a volume UUID and an instance UUID.
+
+```
++-----------------------------------------------------------------------------+
+| Major | Minor | Type  | Operand |  Payload Length | YAML formatted payload  |
+|       |       | (0x0) |  (0xa)  |                 |                         |
++-----------------------------------------------------------------------------+
+```
+
+#### DetachVolume ####
+DetachVolume is a command sent to ciao-launcher for detaching a storage volume
+from a specific running or paused instance.
+
+The DetachVolume command payload includes a volume UUID and an instance UUID.
+
+```
++-----------------------------------------------------------------------------+
+| Major | Minor | Type  | Operand |  Payload Length | YAML formatted payload  |
+|       |       | (0x0) |  (0xb)  |                 |                         |
++-----------------------------------------------------------------------------+
+```
+
 ### SSNTP STATUS frames ###
 
 There are 5 different SSNTP STATUS frames:

--- a/ssntp/ssntp.go
+++ b/ssntp/ssntp.go
@@ -42,7 +42,7 @@ type Type uint8
 
 // Command is the SSNTP Command operand.
 // It can be CONNECT, START, STOP, STATS, EVACUATE, DELETE, RESTART,
-// AssignPublicIP, ReleasePublicIP or CONFIGURE.
+// AssignPublicIP, ReleasePublicIP, CONFIGURE, AttachVolume or DetachVolume.
 type Command uint8
 
 // Status is the SSNTP Status operand.
@@ -229,6 +229,30 @@ const (
 	//	|       |       | (0x0) |  (0x9)  |                 |                         |
 	//	+-----------------------------------------------------------------------------+
 	CONFIGURE
+
+	// AttachVolume is a command sent to ciao-launcher for attaching a storage volume
+	// to a specific running or paused instance.
+	//
+	// The AttachVolume command payload includes a volume UUID and an instance UUID.
+	//
+	//                                       SSNTP AttachVolume Command frame
+	//	+-----------------------------------------------------------------------------+
+	//	| Major | Minor | Type  | Operand |  Payload Length | YAML formatted payload  |
+	//	|       |       | (0x0) |  (0xa)  |                 |                         |
+	//	+-----------------------------------------------------------------------------+
+	AttachVolume
+
+	// DetachVolume is a command sent to ciao-launcher for detaching a storage volume
+	// from a specific running or paused instance.
+	//
+	// The DetachVolume command payload includes a volume UUID and an instance UUID.
+	//
+	//                                       SSNTP DetachVolume Command frame
+	//	+-----------------------------------------------------------------------------+
+	//	| Major | Minor | Type  | Operand |  Payload Length | YAML formatted payload  |
+	//	|       |       | (0x0) |  (0xb)  |                 |                         |
+	//	+-----------------------------------------------------------------------------+
+	DetachVolume
 )
 
 const (
@@ -544,6 +568,10 @@ func (command Command) String() string {
 		return "Release public IP"
 	case CONFIGURE:
 		return "CONFIGURE"
+	case AttachVolume:
+		return "Attach storage volume"
+	case DetachVolume:
+		return "Detach storage volume"
 	}
 
 	return ""

--- a/ssntp/ssntp_test.go
+++ b/ssntp/ssntp_test.go
@@ -2481,6 +2481,8 @@ func TestCommandStringer(t *testing.T) {
 		{AssignPublicIP, "Assign public IP"},
 		{ReleasePublicIP, "Release public IP"},
 		{CONFIGURE, "CONFIGURE"},
+		{AttachVolume, "Attach storage volume"},
+		{DetachVolume, "Detach storage volume"},
 	}
 
 	for _, test := range stringTests {


### PR DESCRIPTION
The AttachVolume and DetachVolume commands will be
typically sent by ciao-controller down to ciao-launcher
in order to respectively attach and detach storage
volumes to running instances.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>