### PR TITLE
ssntp: Add volumes attaching and detaching commands

### DIFF
--- a/ssntp/README.md
+++ b/ssntp/README.md
@@ -359,6 +359,32 @@ compared to the last CONFIGURE command sent.
 +-----------------------------------------------------------------------------+
 ```
 
+#### AttachVolume ####
+AttachVolume is a command sent to ciao-launcher for attaching a storage volume
+to a specific running or paused instance.
+
+The AttachVolume command payload includes a volume UUID and an instance UUID.
+
+```
++-----------------------------------------------------------------------------+
+| Major | Minor | Type  | Operand |  Payload Length | YAML formatted payload  |
+|       |       | (0x0) |  (0xa)  |                 |                         |
++-----------------------------------------------------------------------------+
+```
+
+#### DetachVolume ####
+DetachVolume is a command sent to ciao-launcher for detaching a storage volume
+from a specific running or paused instance.
+
+The DetachVolume command payload includes a volume UUID and an instance UUID.
+
+```
++-----------------------------------------------------------------------------+
+| Major | Minor | Type  | Operand |  Payload Length | YAML formatted payload  |
+|       |       | (0x0) |  (0xb)  |                 |                         |
++-----------------------------------------------------------------------------+
+```
+
 ### SSNTP STATUS frames ###
 
 There are 5 different SSNTP STATUS frames:

--- a/ssntp/ssntp.go
+++ b/ssntp/ssntp.go
@@ -42,7 +42,7 @@ type Type uint8
 
 // Command is the SSNTP Command operand.
 // It can be CONNECT, START, STOP, STATS, EVACUATE, DELETE, RESTART,
-// AssignPublicIP, ReleasePublicIP or CONFIGURE.
+// AssignPublicIP, ReleasePublicIP, CONFIGURE, AttachVolume or DetachVolume.
 type Command uint8
 
 // Status is the SSNTP Status operand.
@@ -229,6 +229,30 @@ const (
 	//	|       |       | (0x0) |  (0x9)  |                 |                         |
 	//	+-----------------------------------------------------------------------------+
 	CONFIGURE
+
+	// AttachVolume is a command sent to ciao-launcher for attaching a storage volume
+	// to a specific running or paused instance.
+	//
+	// The AttachVolume command payload includes a volume UUID and an instance UUID.
+	//
+	//                                       SSNTP AttachVolume Command frame
+	//	+-----------------------------------------------------------------------------+
+	//	| Major | Minor | Type  | Operand |  Payload Length | YAML formatted payload  |
+	//	|       |       | (0x0) |  (0xa)  |                 |                         |
+	//	+-----------------------------------------------------------------------------+
+	AttachVolume
+
+	// DetachVolume is a command sent to ciao-launcher for detaching a storage volume
+	// from a specific running or paused instance.
+	//
+	// The DetachVolume command payload includes a volume UUID and an instance UUID.
+	//
+	//                                       SSNTP DetachVolume Command frame
+	//	+-----------------------------------------------------------------------------+
+	//	| Major | Minor | Type  | Operand |  Payload Length | YAML formatted payload  |
+	//	|       |       | (0x0) |  (0xb)  |                 |                         |
+	//	+-----------------------------------------------------------------------------+
+	DetachVolume
 )
 
 const (
@@ -544,6 +568,10 @@ func (command Command) String() string {
 		return "Release public IP"
 	case CONFIGURE:
 		return "CONFIGURE"
+	case AttachVolume:
+		return "Attach storage volume"
+	case DetachVolume:
+		return "Detach storage volume"
 	}
 
 	return ""

--- a/ssntp/ssntp_test.go
+++ b/ssntp/ssntp_test.go
@@ -2481,6 +2481,8 @@ func TestCommandStringer(t *testing.T) {
 		{AssignPublicIP, "Assign public IP"},
 		{ReleasePublicIP, "Release public IP"},
 		{CONFIGURE, "CONFIGURE"},
+		{AttachVolume, "Attach storage volume"},
+		{DetachVolume, "Detach storage volume"},
 	}
 
 	for _, test := range stringTests {


### PR DESCRIPTION
The AttachVolume and DetachVolume commands will be
typically sent by ciao-controller down to ciao-launcher
in order to respectively attach and detach storage
volumes to running instances.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>