### PR TITLE
ciao-controller: modify payloads to include storage resource

### DIFF
--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -107,6 +107,9 @@ type persistentStore interface {
 	addFrameStat(stat payloads.FrameTrace) (err error)
 	getBatchFrameSummary() (stats []types.BatchFrameSummary, err error)
 	getBatchFrameStatistics(label string) (stats []types.BatchFrameStat, err error)
+
+	// storage interfaces
+	getWorkloadStorage(ID string) (*types.StorageResource, error)
 }
 
 // Datastore provides context for the datastore package.

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -1500,8 +1500,8 @@ func TestMain(m *testing.M) {
 	ds = new(Datastore)
 
 	dsConfig := Config{
-		PersistentURI:     "ciao-controller-test.db",
-		TransientURI:      "ciao-controller-test-tdb.db",
+		PersistentURI:     "file:memdb1?mode=memory&cache=shared",
+		TransientURI:      "file:memdb2?mode=memory&cache=shared",
 		InitTablesPath:    *tablesInitPath,
 		InitWorkloadsPath: *workloadsPath,
 	}
@@ -1514,12 +1514,6 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 
 	ds.Exit()
-	os.Remove("./ciao-controller-test.db")
-	os.Remove("./ciao-controller-test.db-wal")
-	os.Remove("./ciao-controller-test.db-shm")
-	os.Remove("./ciao-controller-test-tdb.db")
-	os.Remove("./ciao-controller-test-tdb.db-wal")
-	os.Remove("./ciao-controller-test-tdb.db-shm")
 
 	os.Exit(code)
 }

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import (
+	"testing"
+)
+
+func TestGetWorkloadStorage(t *testing.T) {
+	config := Config{
+		PersistentURI: "file:memdb3?mode=memory&cache=shared",
+		TransientURI:  "file:memdb4?mode=memory&cache=shared",
+	}
+
+	db, err := getPersistentStore(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = db.getWorkloadStorage("validid")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -23,10 +23,10 @@ func (c *controller) CreateVolume(tenant string, req block.RequestedVolume) (blo
 	// TBD - do we really need to do this, or can we associate
 	// the block device data with the device itself?
 	data := types.BlockData{
-		ID:         bd.ID,
-		Size:       req.Size,
-		CreateTime: time.Now(),
-		TenantID:   tenant,
+		BlockDevice: bd,
+		Size:        req.Size,
+		CreateTime:  time.Now(),
+		TenantID:    tenant,
 	}
 	err = c.ds.AddBlockDevice(data)
 	if err != nil {

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -19,8 +19,43 @@ package types
 import (
 	"time"
 
+	"github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/payloads"
 )
+
+// SourceType contains the valid values of the storage source.
+type SourceType string
+
+const (
+	// ImageService indicates the source comes from the image service.
+	ImageService SourceType = "image"
+
+	// VolumeService indicates the source comes from the volume service.
+	VolumeService SourceType = "volume"
+)
+
+// StorageResource defines a storage resource for a workload.
+// TBD: should the workload support multiple of these?
+type StorageResource struct {
+	// ID indicates a volumeID. If ID is blank, then it needs to be created.
+	ID string
+
+	// Bootable indicates whether should the resource be used for booting
+	Bootable bool
+
+	// Persistent indicates whether the storage is temporary
+	// TBD: do we bother to save info about temp storage?
+	//      does it count against quota?
+	Persistent bool
+
+	// Size is the size of the storage to be created if new.
+	Size int
+
+	// ImageType indicates whether we are making a new resource
+	// based on an image or existing volume.
+	// Needed only for new storage.
+	SourceType SourceType
+}
 
 // Workload contains resource and configuration information for a user
 // workload.
@@ -33,6 +68,7 @@ type Workload struct {
 	ImageName   string                       `json:"-"`
 	Config      string                       `json:"-"`
 	Defaults    []payloads.RequestedResource `json:"-"`
+	Storage     *StorageResource             `json:"-"`
 }
 
 // Instance contains information about an instance of a workload.
@@ -172,7 +208,7 @@ type BlockState string
 // TBD - do we really need to store this as actual data,
 // or can we use a set of interfaces to get the info?
 type BlockData struct {
-	ID         string     // a uuid
+	storage.BlockDevice
 	TenantID   string     // the tenant who owns this volume
 	Instances  []Instance // any instances using this volume
 	Size       int        // size in GB

--- a/payloads/start.go
+++ b/payloads/start.go
@@ -83,6 +83,15 @@ const (
 	Docker = "docker"
 )
 
+// StorageResources represents a requested storage resource for a workload.
+type StorageResources struct {
+	// ID is passed to the Block Driver to operate on the resource
+	ID string `yaml:"id"`
+
+	// Bootable indicates that this is a bootable storage device.
+	Bootable bool `yaml:"boot"`
+}
+
 // RequestedResource is used to specify an individual resource contained within
 // a Start or Restart command.  Example of resources include number of VCPUs or
 // MBs of RAM to assign to an instance
@@ -180,6 +189,10 @@ type StartCmd struct {
 	// Networking contains all the information required to set up networking
 	// for the new instance.
 	Networking NetworkResources `yaml:"networking"`
+
+	// Storage contains all the information required to attach or boot
+	// from storage for the new instance.
+	Storage StorageResources `yaml:"storage,omitempty"`
 }
 
 // Start represents the unmarshalled version of the contents of a SSNTP START


### PR DESCRIPTION
Add a definition of a storage resource that may be requested
as one of the RequestedResources in our start payload.
Modify ciao-controller workloads to include storage resources.
Modify ciao-controller to generate yaml for storage resources.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>