### PR TITLE
Kaccardi/topic/storage

### DIFF
--- a/ciao-launcher/tests/ciao-launcher-server/server.go
+++ b/ciao-launcher/tests/ciao-launcher-server/server.go
@@ -454,6 +454,14 @@ func serve(done chan os.Signal) {
 			func(w http.ResponseWriter, r *http.Request) {
 				yamlCommand(w, r, ssntp.DELETE)
 			})
+		http.HandleFunc("/attach",
+			func(w http.ResponseWriter, r *http.Request) {
+				yamlCommand(w, r, ssntp.AttachVolume)
+			})
+		http.HandleFunc("/detach",
+			func(w http.ResponseWriter, r *http.Request) {
+				yamlCommand(w, r, ssntp.DetachVolume)
+			})
 		http.HandleFunc("/stats", stats)
 		http.HandleFunc("/status", status)
 		http.HandleFunc("/drain", drain)

--- a/ciao-launcher/tests/ciaolc/ciaolc.go
+++ b/ciao-launcher/tests/ciaolc/ciaolc.go
@@ -49,6 +49,8 @@ func init() {
 		fmt.Fprintln(os.Stderr, "\tstats")
 		fmt.Fprintln(os.Stderr, "\tistats")
 		fmt.Fprintln(os.Stderr, "\tstatus")
+		fmt.Fprintln(os.Stderr, "\tattach")
+		fmt.Fprintln(os.Stderr, "\tdetach")
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Flags:")
 		flag.PrintDefaults()
@@ -357,6 +359,28 @@ func getSimplePostArgs(cmd string) (string, string, error) {
 	return cp, instance, nil
 }
 
+func getVolumePostArgs(cmd string) (string, string, string, error) {
+	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
+	cp := ""
+	fs.StringVar(&cp, "client", "", "UUID of client")
+
+	if err := fs.Parse(flag.Args()[1:]); err != nil {
+		return "", "", "", err
+	}
+
+	instance := fs.Arg(0)
+	if instance == "" {
+		return "", "", "", fmt.Errorf("Missing instance-uuid")
+	}
+
+	volume := fs.Arg(1)
+	if volume == "" {
+		return "", "", "", fmt.Errorf("Missing volume-uuid")
+	}
+
+	return cp, instance, volume, nil
+}
+
 func postYaml(host, cmd, client string, data interface{}) error {
 	u := queryURL(host, cmd, client, "")
 	payload, err := yaml.Marshal(data)
@@ -421,6 +445,30 @@ func del(host string) error {
 	return postYaml(host, "delete", client, &del)
 }
 
+func attach(host string) error {
+	var attach payloads.AttachVolume
+	client, instance, volume, err := getVolumePostArgs("attach")
+	if err != nil {
+		return err
+	}
+
+	attach.Attach.InstanceUUID = instance
+	attach.Attach.VolumeUUID = volume
+	return postYaml(host, "attach", client, &attach)
+}
+
+func detach(host string) error {
+	var detach payloads.DetachVolume
+	client, instance, volume, err := getVolumePostArgs("detach")
+	if err != nil {
+		return err
+	}
+
+	detach.Detach.InstanceUUID = instance
+	detach.Detach.VolumeUUID = volume
+	return postYaml(host, "detach", client, &detach)
+}
+
 func main() {
 
 	flag.Parse()
@@ -440,6 +488,8 @@ func main() {
 		"delete":    del,
 		"drain":     drain,
 		"startf":    startf,
+		"attach":    attach,
+		"detach":    detach,
 	}
 
 	cmd := cmdMap[os.Args[1]]

--- a/payloads/attachvolumefailure.go
+++ b/payloads/attachvolumefailure.go
@@ -1,0 +1,68 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package payloads
+
+// AttachVolumeFailureReason denotes the underlying error that prevented
+// an SSNTP AttachVolume command from attaching a volume to an instance.
+type AttachVolumeFailureReason string
+
+const (
+	// AttachVolumeNoInstance indicates that a volume could not be attached
+	// to an instance as the instance does not exist on the node to
+	// which the AttachVolume command was sent.
+	AttachVolumeNoInstance AttachVolumeFailureReason = "no_instance"
+
+	// AttachVolumeInvalidPayload indicates that the payload of the SSNTP
+	// AttachVolume command was corrupt and could not be unmarshalled.
+	AttachVolumeInvalidPayload = "invalid_payload"
+
+	// AttachVolumeInvalidData is returned by ciao-launcher if the contents
+	// of the AttachVolume payload are incorrect, e.g., the instance_uuid
+	// is missing.
+	AttachVolumeInvalidData = "invalid_data"
+
+	// AttachVolumeAttachFailure indicates that the attempt to attach a
+	// volume to an instance failed.
+	AttachVolumeAttachFailure = "attach_failure"
+)
+
+// ErrorAttachVolumeFailure represents the unmarshalled version of the contents of a
+// SSNTP ERROR frame whose type is set to ssntp.AttachVolumeFailure.
+type ErrorAttachVolumeFailure struct {
+	// InstanceUUID is the UUID of the instance to which a volume could not be
+	// attached.
+	InstanceUUID string `yaml:"instance_uuid"`
+
+	// Reason provides the reason for the attach failure, e.g.,
+	// AttachVolumehNoInstance.
+	Reason AttachVolumeFailureReason `yaml:"reason"`
+}
+
+func (r AttachVolumeFailureReason) String() string {
+	switch r {
+	case AttachVolumeNoInstance:
+		return "Instance does not exist"
+	case AttachVolumeInvalidPayload:
+		return "YAML payload is corrupt"
+	case AttachVolumeInvalidData:
+		return "Command section of YAML payload is corrupt or missing required information"
+	case AttachVolumeAttachFailure:
+		return "Failed to attach volume to instance"
+	}
+
+	return ""
+}

--- a/payloads/attachvolumefailure_test.go
+++ b/payloads/attachvolumefailure_test.go
@@ -1,0 +1,80 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package payloads_test
+
+import (
+	"testing"
+
+	. "github.com/01org/ciao/payloads"
+	"github.com/01org/ciao/testutil"
+	"gopkg.in/yaml.v2"
+)
+
+func TestAttachVolumeFailureUnmarshal(t *testing.T) {
+	var error ErrorAttachVolumeFailure
+	err := yaml.Unmarshal([]byte(testutil.AttachVolumeFailureYaml), &error)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if error.InstanceUUID != testutil.InstanceUUID {
+		t.Error("Wrong UUID field")
+	}
+
+	if error.Reason != AttachVolumeAttachFailure {
+		t.Error("Wrong Error field")
+	}
+}
+
+func TestAttachVolumeFailureMarshal(t *testing.T) {
+	error := ErrorAttachVolumeFailure{
+		InstanceUUID: testutil.InstanceUUID,
+		Reason:       AttachVolumeAttachFailure,
+	}
+
+	y, err := yaml.Marshal(&error)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if string(y) != testutil.AttachVolumeFailureYaml {
+		t.Errorf("AttachVolumeFailure marshalling failed\n[%s]\n vs\n[%s]",
+			string(y), testutil.AttachVolumeFailureYaml)
+	}
+}
+
+func TestAttachVolmeFailureString(t *testing.T) {
+	var stringTests = []struct {
+		r        AttachVolumeFailureReason
+		expected string
+	}{
+		{AttachVolumeNoInstance, "Instance does not exist"},
+		{AttachVolumeInvalidPayload, "YAML payload is corrupt"},
+		{AttachVolumeInvalidData, "Command section of YAML payload is corrupt or missing required information"},
+		{AttachVolumeAttachFailure, "Failed to attach volume to instance"},
+	}
+	error := ErrorAttachVolumeFailure{
+		InstanceUUID: testutil.InstanceUUID,
+	}
+	for _, test := range stringTests {
+		error.Reason = test.r
+		s := error.Reason.String()
+		if s != test.expected {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expected, s)
+		}
+	}
+}

--- a/payloads/detachvolumefailure.go
+++ b/payloads/detachvolumefailure.go
@@ -1,0 +1,68 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package payloads
+
+// DetachVolumeFailureReason denotes the underlying error that prevented
+// an SSNTP DetachVolume command from detaching a volume from an instance.
+type DetachVolumeFailureReason string
+
+const (
+	// DetachVolumeNoInstance indicates that a volume could not be detached
+	// from an instance as the instance does not exist on the node to
+	// which the DetachVolume command was sent.
+	DetachVolumeNoInstance DetachVolumeFailureReason = "no_instance"
+
+	// DetachVolumeInvalidPayload indicates that the payload of the SSNTP
+	// DetachVolume command was corrupt and could not be unmarshalled.
+	DetachVolumeInvalidPayload = "invalid_payload"
+
+	// DetachVolumeInvalidData is returned by ciao-launcher if the contents
+	// of the DetachVolume payload are incorrect, e.g., the instance_uuid
+	// is missing.
+	DetachVolumeInvalidData = "invalid_data"
+
+	// DetachVolumeDetachFailure indicates that the attempt to detach a
+	// volume from an instance failed.
+	DetachVolumeDetachFailure = "detach_failure"
+)
+
+// ErrorDetachVolumeFailure represents the unmarshalled version of the contents of a
+// SSNTP ERROR frame whose type is set to ssntp.DetachVolumeFailure.
+type ErrorDetachVolumeFailure struct {
+	// InstanceUUID is the UUID of the instance from which a volume could not be
+	// detached.
+	InstanceUUID string `yaml:"instance_uuid"`
+
+	// Reason provides the reason for the detach failure, e.g.,
+	// DetachVolumeNoInstance.
+	Reason DetachVolumeFailureReason `yaml:"reason"`
+}
+
+func (r DetachVolumeFailureReason) String() string {
+	switch r {
+	case DetachVolumeNoInstance:
+		return "Instance does not exist"
+	case DetachVolumeInvalidPayload:
+		return "YAML payload is corrupt"
+	case DetachVolumeInvalidData:
+		return "Command section of YAML payload is corrupt or missing required information"
+	case DetachVolumeDetachFailure:
+		return "Failed to detach volume from instance"
+	}
+
+	return ""
+}

--- a/payloads/detachvolumefailure_test.go
+++ b/payloads/detachvolumefailure_test.go
@@ -1,0 +1,80 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package payloads_test
+
+import (
+	"testing"
+
+	. "github.com/01org/ciao/payloads"
+	"github.com/01org/ciao/testutil"
+	"gopkg.in/yaml.v2"
+)
+
+func TestDetachVolumeFailureUnmarshal(t *testing.T) {
+	var error ErrorDetachVolumeFailure
+	err := yaml.Unmarshal([]byte(testutil.DetachVolumeFailureYaml), &error)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if error.InstanceUUID != testutil.InstanceUUID {
+		t.Error("Wrong UUID field")
+	}
+
+	if error.Reason != DetachVolumeDetachFailure {
+		t.Error("Wrong Error field")
+	}
+}
+
+func TestDetachVolumeFailureMarshal(t *testing.T) {
+	error := ErrorDetachVolumeFailure{
+		InstanceUUID: testutil.InstanceUUID,
+		Reason:       DetachVolumeDetachFailure,
+	}
+
+	y, err := yaml.Marshal(&error)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if string(y) != testutil.DetachVolumeFailureYaml {
+		t.Errorf("DetachVolumeFailure marshalling failed\n[%s]\n vs\n[%s]",
+			string(y), testutil.DetachVolumeFailureYaml)
+	}
+}
+
+func TestDetachVolmeFailureString(t *testing.T) {
+	var stringTests = []struct {
+		r        DetachVolumeFailureReason
+		expected string
+	}{
+		{DetachVolumeNoInstance, "Instance does not exist"},
+		{DetachVolumeInvalidPayload, "YAML payload is corrupt"},
+		{DetachVolumeInvalidData, "Command section of YAML payload is corrupt or missing required information"},
+		{DetachVolumeDetachFailure, "Failed to detach volume from instance"},
+	}
+	error := ErrorDetachVolumeFailure{
+		InstanceUUID: testutil.InstanceUUID,
+	}
+	for _, test := range stringTests {
+		error.Reason = test.r
+		s := error.Reason.String()
+		if s != test.expected {
+			t.Errorf("expected \"%s\", got \"%s\"", test.expected, s)
+		}
+	}
+}

--- a/payloads/storage.go
+++ b/payloads/storage.go
@@ -1,0 +1,42 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package payloads
+
+// VolumeCmd contains all the information needed to attach a volume
+// to or detach a volume from an existing instance.
+type VolumeCmd struct {
+	// InstanceUUID is the UUID of the instance to which the volume is to be
+	// attached.
+	InstanceUUID string `yaml:"instance_uuid"`
+
+	// VolumeUUID is the UUID of the volume to attach.
+	VolumeUUID string `yaml:"volume_uuid"`
+}
+
+// AttachVolume represents the unmarshalled version of the contents of a SSNTP
+// AttachVolume payload.  The structure contains enough information to attach a
+// volume to an existing instance.
+type AttachVolume struct {
+	Attach VolumeCmd `yaml:"attach_volume"`
+}
+
+// DetachVolume represents the unmarshalled version of the contents of a SSNTP
+// DetachVolume payload.  The structure contains enough information to detach a
+// volume from an existing instance.
+type DetachVolume struct {
+	Detach VolumeCmd `yaml:"detach_volume"`
+}

--- a/payloads/storage_test.go
+++ b/payloads/storage_test.go
@@ -1,0 +1,89 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package payloads_test
+
+import (
+	"testing"
+
+	. "github.com/01org/ciao/payloads"
+	"github.com/01org/ciao/testutil"
+	"gopkg.in/yaml.v2"
+)
+
+func TestAttachVolumeUnmarshal(t *testing.T) {
+	var attach AttachVolume
+	err := yaml.Unmarshal([]byte(testutil.AttachVolumeYaml), &attach)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if attach.Attach.InstanceUUID != testutil.InstanceUUID {
+		t.Errorf("Wrong instance UUID field [%s]", attach.Attach.InstanceUUID)
+	}
+
+	if attach.Attach.VolumeUUID != testutil.VolumeUUID {
+		t.Errorf("Wrong Volume UUID field [%s]", attach.Attach.VolumeUUID)
+	}
+}
+
+func TestDetachVolumeUnmarshal(t *testing.T) {
+	var detach DetachVolume
+	err := yaml.Unmarshal([]byte(testutil.DetachVolumeYaml), &detach)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if detach.Detach.InstanceUUID != testutil.InstanceUUID {
+		t.Errorf("Wrong instance UUID field [%s]", detach.Detach.InstanceUUID)
+	}
+
+	if detach.Detach.VolumeUUID != testutil.VolumeUUID {
+		t.Errorf("Wrong Volume UUID field [%s]", detach.Detach.VolumeUUID)
+	}
+}
+
+func TestAttachVolmeMarshal(t *testing.T) {
+	var attach AttachVolume
+	attach.Attach.InstanceUUID = testutil.InstanceUUID
+	attach.Attach.VolumeUUID = testutil.VolumeUUID
+
+	y, err := yaml.Marshal(&attach)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if string(y) != testutil.AttachVolumeYaml {
+		t.Errorf("AttachVolume marshalling failed\n[%s]\n vs\n[%s]",
+			string(y), testutil.AttachVolumeYaml)
+	}
+}
+
+func TestDetachVolmeMarshal(t *testing.T) {
+	var detach DetachVolume
+	detach.Detach.InstanceUUID = testutil.InstanceUUID
+	detach.Detach.VolumeUUID = testutil.VolumeUUID
+
+	y, err := yaml.Marshal(&detach)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if string(y) != testutil.DetachVolumeYaml {
+		t.Errorf("DetachVolume marshalling failed\n[%s]\n vs\n[%s]",
+			string(y), testutil.DetachVolumeYaml)
+	}
+}

--- a/ssntp/ssntp.go
+++ b/ssntp/ssntp.go
@@ -517,6 +517,14 @@ const (
 	// When the scheduler receives such error back from any client it should revert
 	// back to the previous valid configuration.
 	InvalidConfiguration
+
+	// AttachVolumeFailure is sent by launcher agents to report a failure to attach
+	// a volume to an instance.
+	AttachVolumeFailure
+
+	// DetachVolumeFailure is sent by launcher agents to report a failure to detach
+	// a volume from an instance.
+	DetachVolumeFailure
 )
 
 // Major is the SSNTP protocol major version

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -102,6 +102,9 @@ const NetAgentUUID = "6be56328-92e2-4ecd-b426-8fe529c04e0c"
 // AgentUUID is a node UUID for coordinated stop/restart/delete tests
 const AgentUUID = "4cb19522-1e18-439a-883a-f9b2a3a95f5e"
 
+// VolumeUUID is a node UUID for storage tests
+const VolumeUUID = "67d86208-b46c-4465-9018-e14187d4010"
+
 //////////////////////////////////////////////////////////////////////////////
 
 // StartYaml is a sample workload START ssntp.Command payload for test usage
@@ -522,4 +525,26 @@ networks:
 // with limited node statistics and no per-instance statistics
 const PartialStatsYaml = `node_uuid: ` + AgentUUID + `
 load: 1
+`
+
+// AttachVolumeYaml is a sample yaml payload for the ssntp Attach Volume command.
+const AttachVolumeYaml = `attach_volume:
+  instance_uuid: ` + InstanceUUID + `
+  volume_uuid: ` + VolumeUUID + `
+`
+
+// DetachVolumeYaml is a sample yaml payload for the ssntp Detach Volume command.
+const DetachVolumeYaml = `detach_volume:
+  instance_uuid: ` + InstanceUUID + `
+  volume_uuid: ` + VolumeUUID + `
+`
+
+// AttachVolumeFailureYaml is a sample AttachVolumeFailure ssntp.Error payload for test cases
+const AttachVolumeFailureYaml = `instance_uuid: ` + InstanceUUID + `
+reason: attach_failure
+`
+
+// DetachVolumeFailureYaml is a sample DetachVolumeFailure ssntp.Error payload for test cases
+const DetachVolumeFailureYaml = `instance_uuid: ` + InstanceUUID + `
+reason: detach_failure
 `


### PR DESCRIPTION
This PR adds the AttachVolume and DetachVolume commands to payloads, adds AttachVolume and DetachVolume errors to SSNTP, and adds support to the launcher's test harness for these commands.