### PR TITLE
Topic/storage pull request

### DIFF
--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/01org/ciao/ciao-controller/types"
+	image "github.com/01org/ciao/ciao-image/client"
 	"github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp/uuid"
@@ -155,7 +156,13 @@ func getStorage(c *controller, wl *types.Workload, tenant string) (payloads.Stor
 		// assume always persistent for now.
 		// assume we have already checked quotas.
 		// ID of source is the image id.
-		device, err := c.CreateBlockDevice(&wl.ImageID, s.Size)
+		path, err := image.GetImagePath(c.image, wl.ImageID)
+		if err != nil {
+			// this image doesn't exist
+			return payloads.StorageResources{}, err
+		}
+
+		device, err := c.CreateBlockDevice(&path, s.Size)
 		if err != nil {
 			return payloads.StorageResources{}, err
 		}

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	datastore "github.com/01org/ciao/ciao-controller/internal/datastore"
+	image "github.com/01org/ciao/ciao-image/client"
 	storage "github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/ssntp"
 	"github.com/01org/ciao/testutil"
@@ -30,10 +31,12 @@ import (
 )
 
 type controller struct {
+	storage.BlockDriver
+
 	client *ssntpClient
 	ds     *datastore.Datastore
 	id     *identity
-	storage.BlockDriver
+	image  image.Client
 }
 
 var singleMachine = flag.Bool("single", false, "Enable single machine test")
@@ -52,6 +55,11 @@ var noNetwork = flag.Bool("nonetwork", false, "Debug with no networking")
 var persistentDatastoreLocation = flag.String("database_path", "./ciao-controller.db", "path to persistent database")
 var transientDatastoreLocation = flag.String("stats_path", "/tmp/ciao-controller-stats.db", "path to stats database")
 var logDir = "/var/lib/ciao/logs/controller"
+
+var imagesPath = flag.String("images_path", "/var/lib/ciao/images", "path to ciao images")
+
+var keyringPath = flag.String("ceph_keyring", "/etc/ceph/ceph.client.ciao.keyring", "path to ceph client keyring")
+var cephID = flag.String("ceph_id", "ciao", "ceph client id")
 
 func init() {
 	flag.Parse()
@@ -79,7 +87,15 @@ func main() {
 	context := new(controller)
 	context.ds = new(datastore.Datastore)
 
-	context.BlockDriver = storage.GetBlockDriver()
+	context.BlockDriver = func() storage.BlockDriver {
+		driver := storage.CephDriver{
+			SecretPath: *keyringPath,
+			ID:         *cephID,
+		}
+		return driver
+	}()
+
+	context.image = image.Client{MountPoint: *imagesPath}
 
 	dsConfig := datastore.Config{
 		PersistentURI:     *persistentDatastoreLocation,

--- a/ciao-image/client/client.go
+++ b/ciao-image/client/client.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"fmt"
+	"os"
+)
+
+// Client maintains context for ciao clients of the image service
+type Client struct {
+	// MountPoint specifies where the images are located
+	// in the filesystem.
+	MountPoint string
+}
+
+// GetImagePath returns the file system location of the image
+func GetImagePath(c Client, ID string) (string, error) {
+	path := fmt.Sprintf("%s/%s", c.MountPoint, ID)
+
+	_, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+
+	return path, nil
+}

--- a/ciao-storage/ceph.go
+++ b/ciao-storage/ceph.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"os/exec"
+
+	"github.com/01org/ciao/ssntp/uuid"
+)
+
+// CephDriver maintains context for the ceph driver interface.
+type CephDriver struct {
+	// SecretPath is the full path to the cephx keyring file.
+	SecretPath string
+
+	// ID is the cephx user ID to use
+	ID string
+}
+
+// CreateBlockDevice will create a rbd image in the ceph cluster.
+func (d CephDriver) CreateBlockDevice(imagePath *string, size int) (BlockDevice, error) {
+	if imagePath == nil {
+		// we'd need to have more details about what kind
+		// of device to create. So, we need to change
+		// the API to support this - with some opts.
+		return BlockDevice{}, ErrNoDevice
+	}
+
+	// generate a UUID to use for this image.
+	ID := uuid.Generate().String()
+
+	cmd := exec.Command("rbd", "--keyring", d.SecretPath, "--id", d.ID, "--image-format", "2", "import", *imagePath, ID)
+
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		return BlockDevice{}, err
+	}
+
+	return BlockDevice{ID: ID}, nil
+}
+
+// DeleteBlockDevice will remove a rbd image from the ceph cluster.
+// Not implemented yet.
+func (d CephDriver) DeleteBlockDevice(string) error {
+	return nil
+}

--- a/ciao-storage/ceph_test.go
+++ b/ciao-storage/ceph_test.go
@@ -15,21 +15,22 @@
 package storage
 
 import (
-	"errors"
+	"fmt"
+	"testing"
 )
 
-var (
-	// ErrNoDevice is returned from a driver
-	ErrNoDevice = errors.New("Not able to create device")
-)
+func TestCreateBlockDevice(t *testing.T) {
+	driver := cephDriver{
+		SecretPath: "/etc/ceph/ceph.client.kristen.keyring",
+		ID:         "kristen",
+	}
 
-// BlockDriver is the interface that all block drivers must implement.
-type BlockDriver interface {
-	CreateBlockDevice(image *string, sizeGB int) (BlockDevice, error)
-	DeleteBlockDevice(string) error
-}
+	imagePath := "/var/lib/ciao/images/73a86d7e-93c0-480e-9c41-ab42f69b7799"
 
-// BlockDevice contains information about a block devices.
-type BlockDevice struct {
-	ID string
+	device, err := driver.CreateBlockDevice(&imagePath, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(device.ID)
 }

--- a/ciao-storage/noop.go
+++ b/ciao-storage/noop.go
@@ -1,4 +1,16 @@
-// add build flag
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package storage
 
@@ -6,12 +18,15 @@ import (
 	"github.com/01org/ciao/ssntp/uuid"
 )
 
-type noopDriver struct{}
+// NoopDriver is a driver which does nothing.
+type NoopDriver struct{}
 
-func (d noopDriver) CreateBlockDevice(image *string, size int) (BlockDevice, error) {
+// CreateBlockDevice pretends to create a block device.
+func (d NoopDriver) CreateBlockDevice(image *string, size int) (BlockDevice, error) {
 	return BlockDevice{ID: uuid.Generate().String()}, nil
 }
 
-func (d noopDriver) DeleteBlockDevice(string) error {
+// DeleteBlockDevice pretends to delete a block device.
+func (d NoopDriver) DeleteBlockDevice(string) error {
 	return nil
 }


### PR DESCRIPTION
This pull request adds a cluster client package for our image service. Components of the cluster should be able to access the image filesystem directly without contacting the image api service. The client package is just a wrapper around some operations so that we can change filesystem layout without having each component need to be modified.  ciao-controller will use this client to check for an image's existence prior to creating a start workload request. This pull request also creates an initial ceph driver and adds configuration for cephx authentication to ciao-controller.