### PR TITLE
payloads, ciao-launcher: add storage plumbing

### DIFF
--- a/ciao-launcher/attachvolume_error.go
+++ b/ciao-launcher/attachvolume_error.go
@@ -1,0 +1,45 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/01org/ciao/payloads"
+	"github.com/01org/ciao/ssntp"
+	"github.com/golang/glog"
+)
+
+type attachVolumeError struct {
+	err  error
+	code payloads.AttachVolumeFailureReason
+}
+
+func (ave *attachVolumeError) send(conn serverConn, instance, volume string) {
+	if !conn.isConnected() {
+		return
+	}
+
+	payload, err := generateAttachVolumeError(instance, volume, ave)
+	if err != nil {
+		glog.Errorf("Unable to generate payload for attach_volume_failure: %v", err)
+		return
+	}
+
+	_, err = conn.SendError(ssntp.AttachVolumeFailure, payload)
+	if err != nil {
+		glog.Errorf("Unable to send attach_volume_failure: %v", err)
+	}
+}

--- a/ciao-launcher/attachvolume_instance.go
+++ b/ciao-launcher/attachvolume_instance.go
@@ -1,0 +1,44 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/01org/ciao/payloads"
+	"github.com/golang/glog"
+)
+
+func processAttachVolume(vm virtualizer, cfg *vmConfig, instance, instanceDir, volumeUUID string, conn serverConn) *attachVolumeError {
+	if _, found := cfg.Volumes[volumeUUID]; found {
+		attachErr := &attachVolumeError{nil, payloads.AttachVolumeAlreadyAttached}
+		glog.Errorf("%s is already attached to attach instance %s [%s]",
+			volumeUUID, instance, string(attachErr.code))
+		return attachErr
+	}
+
+	cfg.Volumes[volumeUUID] = struct{}{}
+
+	err := cfg.save(instanceDir)
+	if err != nil {
+		delete(cfg.Volumes, volumeUUID)
+		attachErr := &attachVolumeError{err, payloads.AttachVolumeStateFailure}
+		glog.Errorf("Unable to persist instance %s state [%s]: %v",
+			instance, string(attachErr.code), err)
+		return attachErr
+	}
+
+	return nil
+}

--- a/ciao-launcher/detachvolume_error.go
+++ b/ciao-launcher/detachvolume_error.go
@@ -1,0 +1,46 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/01org/ciao/payloads"
+	"github.com/01org/ciao/ssntp"
+	"github.com/golang/glog"
+)
+
+type detachVolumeError struct {
+	err  error
+	code payloads.DetachVolumeFailureReason
+}
+
+func (dve *detachVolumeError) send(conn serverConn, instance, volume string) {
+	if !conn.isConnected() {
+		return
+	}
+
+	payload, err := generateDetachVolumeError(instance, volume, dve)
+	if err != nil {
+		glog.Errorf("Unable to generate payload for detach_volume_failure: %v", err)
+		return
+	}
+
+	_, err = conn.SendError(ssntp.DetachVolumeFailure, payload)
+	if err != nil {
+		glog.Errorf("Unable to send detach_volume_failure: %v", err)
+	}
+
+}

--- a/ciao-launcher/detachvolume_instance.go
+++ b/ciao-launcher/detachvolume_instance.go
@@ -1,0 +1,44 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/01org/ciao/payloads"
+	"github.com/golang/glog"
+)
+
+func processDetachVolume(vm virtualizer, cfg *vmConfig, instance, instanceDir, volumeUUID string, conn serverConn) *detachVolumeError {
+	if _, found := cfg.Volumes[volumeUUID]; !found {
+		detachErr := &detachVolumeError{nil, payloads.DetachVolumeNotAttached}
+		glog.Errorf("%s not attached to attach instance %s [%s]",
+			volumeUUID, instance, string(detachErr.code))
+		return detachErr
+	}
+
+	delete(cfg.Volumes, volumeUUID)
+
+	err := cfg.save(instanceDir)
+	if err != nil {
+		cfg.Volumes[volumeUUID] = struct{}{}
+		detachErr := &detachVolumeError{err, payloads.DetachVolumeDetachFailure}
+		glog.Errorf("Unable to persist instance %s state [%s]: %v",
+			instance, string(detachErr.code), err)
+		return detachErr
+	}
+
+	return nil
+}

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -195,6 +195,30 @@ func (client *agentClient) CommandNotify(cmd ssntp.Command, frame *ssntp.Frame) 
 			return
 		}
 		client.cmdCh <- &cmdWrapper{instance, &insDeleteCmd{}}
+	case ssntp.AttachVolume:
+		instance, volume, payloadErr := parseAttachVolumePayload(payload)
+		if payloadErr != nil {
+			attachVolumeError := &attachVolumeError{
+				payloadErr.err,
+				payloads.AttachVolumeFailureReason(payloadErr.code),
+			}
+			attachVolumeError.send(client.conn, "", "")
+			glog.Errorf("Unable to parse YAML: %s", payloadErr.err)
+			return
+		}
+		client.cmdCh <- &cmdWrapper{instance, &insAttachVolumeCmd{volume}}
+	case ssntp.DetachVolume:
+		instance, volume, payloadErr := parseDetachVolumePayload(payload)
+		if payloadErr != nil {
+			detachVolumeError := &detachVolumeError{
+				payloadErr.err,
+				payloads.DetachVolumeFailureReason(payloadErr.code),
+			}
+			detachVolumeError.send(client.conn, "", "")
+			glog.Errorf("Unable to parse YAML: %s", payloadErr.err)
+			return
+		}
+		client.cmdCh <- &cmdWrapper{instance, &insDetachVolumeCmd{volume}}
 	}
 }
 

--- a/ciao-launcher/payload.go
+++ b/ciao-launcher/payload.go
@@ -19,11 +19,8 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"encoding/gob"
 	"fmt"
 	"net"
-	"os"
-	"path"
 	"regexp"
 	"strings"
 
@@ -36,25 +33,6 @@ import (
 type payloadError struct {
 	err  error
 	code string
-}
-
-type vmConfig struct {
-	Cpus        int
-	Mem         int
-	Disk        int
-	Instance    string
-	Image       string
-	Legacy      bool
-	Container   bool
-	NetworkNode bool
-	VnicMAC     string
-	VnicIP      string
-	ConcIP      string
-	SubnetIP    string
-	TennantUUID string
-	ConcUUID    string
-	VnicUUID    string
-	SSHPort     int
 }
 
 type extractedDoc struct {
@@ -194,6 +172,7 @@ func parseStartPayload(data []byte) (*vmConfig, *payloadError) {
 		ConcUUID:    strings.TrimSpace(net.ConcentratorUUID),
 		VnicUUID:    strings.TrimSpace(net.VnicUUID),
 		SSHPort:     sshPort,
+		Volumes:     make(map[string]struct{}),
 	}, nil
 }
 
@@ -227,6 +206,24 @@ func generateDeleteError(instance string, deleteErr *deleteError) (out []byte, e
 		Reason:       deleteErr.code,
 	}
 	return yaml.Marshal(df)
+}
+
+func generateAttachVolumeError(instance, volume string, ave *attachVolumeError) (out []byte, err error) {
+	avf := &payloads.ErrorAttachVolumeFailure{
+		InstanceUUID: instance,
+		VolumeUUID:   volume,
+		Reason:       ave.code,
+	}
+	return yaml.Marshal(avf)
+}
+
+func generateDetachVolumeError(instance, volume string, dve *detachVolumeError) (out []byte, err error) {
+	dvf := &payloads.ErrorDetachVolumeFailure{
+		InstanceUUID: instance,
+		VolumeUUID:   volume,
+		Reason:       dve.code,
+	}
+	return yaml.Marshal(dvf)
 }
 
 func generateNetEventPayload(ssntpEvent *libsnnet.SsntpEventInfo, agentUUID string) ([]byte, error) {
@@ -307,25 +304,44 @@ func parseStopPayload(data []byte) (string, *payloadError) {
 	return instance, nil
 }
 
-func loadVMConfig(instanceDir string) (*vmConfig, error) {
-	cfgFilePath := path.Join(instanceDir, instanceState)
-	cfgFile, err := os.Open(cfgFilePath)
-	if err != nil {
-		glog.Errorf("Unable to open instance file %s", cfgFilePath)
-		return nil, err
+func extractVolumeInfo(cmd *payloads.VolumeCmd, errString string) (string, string, *payloadError) {
+	instance := strings.TrimSpace(cmd.InstanceUUID)
+	if !uuidRegexp.MatchString(instance) {
+		err := fmt.Errorf("Invalid instance id received: %s", instance)
+		return "", "", &payloadError{err, errString}
 	}
 
-	dec := gob.NewDecoder(cfgFile)
-	cfg := &vmConfig{}
-	err = dec.Decode(cfg)
-	_ = cfgFile.Close()
-
-	if err != nil {
-		glog.Error("Unable to retrieve state info")
-		return nil, err
+	volume := strings.TrimSpace(cmd.VolumeUUID)
+	if !uuidRegexp.MatchString(volume) {
+		err := fmt.Errorf("Invalid instance id received: %s", volume)
+		return "", "", &payloadError{err, errString}
 	}
 
-	return cfg, nil
+	return instance, volume, nil
+}
+
+func parseAttachVolumePayload(data []byte) (string, string, *payloadError) {
+	var clouddata payloads.AttachVolume
+
+	err := yaml.Unmarshal(data, &clouddata)
+	if err != nil {
+		glog.Errorf("YAML error: %v", err)
+		return "", "", &payloadError{err, payloads.AttachVolumeInvalidPayload}
+	}
+
+	return extractVolumeInfo(&clouddata.Attach, payloads.AttachVolumeInvalidData)
+}
+
+func parseDetachVolumePayload(data []byte) (string, string, *payloadError) {
+	var clouddata payloads.DetachVolume
+
+	err := yaml.Unmarshal(data, &clouddata)
+	if err != nil {
+		glog.Errorf("YAML error: %v", err)
+		return "", "", &payloadError{err, payloads.DetachVolumeInvalidPayload}
+	}
+
+	return extractVolumeInfo(&clouddata.Detach, payloads.DetachVolumeInvalidData)
 }
 
 func linesToBytes(doc []string, buf *bytes.Buffer) {

--- a/ciao-launcher/payload_test.go
+++ b/ciao-launcher/payload_test.go
@@ -1,0 +1,64 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/01org/ciao/payloads"
+	"github.com/01org/ciao/testutil"
+)
+
+func TestParseAttachVolumePayload(t *testing.T) {
+	instance, volume, err := parseAttachVolumePayload([]byte(testutil.AttachVolumeYaml))
+	if err != nil {
+		t.Fatalf("parseAttachVolumePayload failed: %v", err)
+	}
+	if instance != testutil.InstanceUUID || volume != testutil.VolumeUUID {
+		t.Fatalf("VolumeUUID or InstanceUUID is invalid")
+	}
+
+	_, _, err = parseAttachVolumePayload([]byte("  -"))
+	if err == nil || err.code != payloads.AttachVolumeInvalidPayload {
+		t.Fatalf("AttachVolumeInvalidPayload error expected")
+	}
+
+	_, _, err = parseAttachVolumePayload([]byte(testutil.BadAttachVolumeYaml))
+	if err == nil || err.code != payloads.AttachVolumeInvalidData {
+		t.Fatalf("AttachVolumeInvalidData error expected")
+	}
+}
+
+func TestParseDetachVolumePayload(t *testing.T) {
+	instance, volume, err := parseDetachVolumePayload([]byte(testutil.DetachVolumeYaml))
+	if err != nil {
+		t.Fatalf("parseDetachVolumePayload failed: %v", err)
+	}
+	if instance != testutil.InstanceUUID || volume != testutil.VolumeUUID {
+		t.Fatalf("VolumeUUID or InstanceUUID is invalid")
+	}
+
+	_, _, err = parseDetachVolumePayload([]byte("  -"))
+	if err == nil || err.code != payloads.DetachVolumeInvalidPayload {
+		t.Fatalf("AttachVolumeInvalidPayload error expected")
+	}
+
+	_, _, err = parseDetachVolumePayload([]byte(testutil.BadDetachVolumeYaml))
+	if err == nil || err.code != payloads.DetachVolumeInvalidData {
+		t.Fatalf("DetachVolumeInvalidData error expected")
+	}
+}

--- a/ciao-launcher/start_instance.go
+++ b/ciao-launcher/start_instance.go
@@ -17,10 +17,8 @@
 package main
 
 import (
-	"encoding/gob"
 	"fmt"
 	"os"
-	"path"
 	"time"
 
 	"github.com/01org/ciao/networking/libsnnet"
@@ -62,14 +60,10 @@ func createInstance(vm virtualizer, instanceDir string, cfg *vmConfig, bridge st
 		return
 	}
 
-	var cfgFile *os.File
 	defer func() {
 		if r := recover(); r != nil {
 			err = r.(error)
 			_ = os.RemoveAll(instanceDir)
-			if cfgFile != nil {
-				_ = cfgFile.Close()
-			}
 		}
 	}()
 
@@ -79,22 +73,7 @@ func createInstance(vm virtualizer, instanceDir string, cfg *vmConfig, bridge st
 		panic(err)
 	}
 
-	cfgFilePath := path.Join(instanceDir, instanceState)
-	cfgFile, err = os.OpenFile(cfgFilePath, os.O_CREATE|os.O_RDWR, 0600)
-	if err != nil {
-		glog.Errorf("Unable to create state file %v", err)
-		panic(err)
-	}
-
-	enc := gob.NewEncoder(cfgFile)
-	err = enc.Encode(cfg)
-	if err != nil {
-		glog.Errorf("Failed to store state information %v", err)
-		panic(err)
-	}
-
-	err = cfgFile.Close()
-	cfgFile = nil
+	err = cfg.save(instanceDir)
 	if err != nil {
 		glog.Errorf("Failed to store state information %v", err)
 		panic(err)

--- a/ciao-launcher/vmconfig.go
+++ b/ciao-launcher/vmconfig.go
@@ -1,0 +1,88 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/gob"
+	"os"
+	"path"
+
+	"github.com/golang/glog"
+)
+
+type vmConfig struct {
+	Cpus        int
+	Mem         int
+	Disk        int
+	Instance    string
+	Image       string
+	Legacy      bool
+	Container   bool
+	NetworkNode bool
+	VnicMAC     string
+	VnicIP      string
+	ConcIP      string
+	SubnetIP    string
+	TennantUUID string
+	ConcUUID    string
+	VnicUUID    string
+	SSHPort     int
+	Volumes     map[string]struct{}
+}
+
+func loadVMConfig(instanceDir string) (*vmConfig, error) {
+	cfgFilePath := path.Join(instanceDir, instanceState)
+	cfgFile, err := os.Open(cfgFilePath)
+	if err != nil {
+		glog.Errorf("Unable to open instance file %s", cfgFilePath)
+		return nil, err
+	}
+
+	dec := gob.NewDecoder(cfgFile)
+	cfg := &vmConfig{}
+	err = dec.Decode(cfg)
+	_ = cfgFile.Close()
+
+	if err != nil {
+		glog.Error("Unable to retrieve state info")
+		return nil, err
+	}
+
+	if cfg.Volumes == nil {
+		cfg.Volumes = make(map[string]struct{})
+	}
+
+	return cfg, nil
+}
+
+func (cfg *vmConfig) save(instanceDir string) error {
+	cfgFilePath := path.Join(instanceDir, instanceState)
+	cfgFile, err := os.OpenFile(cfgFilePath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		glog.Errorf("Unable to create state file %v", err)
+		panic(err)
+	}
+
+	enc := gob.NewEncoder(cfgFile)
+	if err = enc.Encode(cfg); err != nil {
+		glog.Errorf("Failed to store state information %v", err)
+		_ = cfgFile.Close()
+		return err
+	}
+
+	return cfgFile.Close()
+}

--- a/payloads/attachvolumefailure.go
+++ b/payloads/attachvolumefailure.go
@@ -38,6 +38,19 @@ const (
 	// AttachVolumeAttachFailure indicates that the attempt to attach a
 	// volume to an instance failed.
 	AttachVolumeAttachFailure = "attach_failure"
+
+	// AttachVolumeAlreadyAttached indicates that the volume is already
+	// attached to the instance.
+	AttachVolumeAlreadyAttached = "already_attached"
+
+	// AttachVolumeStateFailure indicates that launcher was unable to
+	// update its internal state to register the new volume.
+	AttachVolumeStateFailure = "state_failure"
+
+	// AttachVolumeInstanceFailure indicates that the volume could not
+	// be attached as the instance has failed to start and is being
+	// deleted
+	AttachVolumeInstanceFailure = "instance_failure"
 )
 
 // ErrorAttachVolumeFailure represents the unmarshalled version of the contents of a
@@ -65,6 +78,12 @@ func (r AttachVolumeFailureReason) String() string {
 		return "Command section of YAML payload is corrupt or missing required information"
 	case AttachVolumeAttachFailure:
 		return "Failed to attach volume to instance"
+	case AttachVolumeAlreadyAttached:
+		return "Volume already attached"
+	case AttachVolumeStateFailure:
+		return "State failure"
+	case AttachVolumeInstanceFailure:
+		return "Instance failure"
 	}
 
 	return ""

--- a/payloads/attachvolumefailure.go
+++ b/payloads/attachvolumefailure.go
@@ -47,6 +47,9 @@ type ErrorAttachVolumeFailure struct {
 	// attached.
 	InstanceUUID string `yaml:"instance_uuid"`
 
+	// VolumeUUID is the UUID of the volume that could not be attached.
+	VolumeUUID string `yaml:"volume_uuid"`
+
 	// Reason provides the reason for the attach failure, e.g.,
 	// AttachVolumehNoInstance.
 	Reason AttachVolumeFailureReason `yaml:"reason"`

--- a/payloads/attachvolumefailure_test.go
+++ b/payloads/attachvolumefailure_test.go
@@ -35,6 +35,10 @@ func TestAttachVolumeFailureUnmarshal(t *testing.T) {
 		t.Error("Wrong UUID field")
 	}
 
+	if error.VolumeUUID != testutil.VolumeUUID {
+		t.Error("Wrong UUID field")
+	}
+
 	if error.Reason != AttachVolumeAttachFailure {
 		t.Error("Wrong Error field")
 	}
@@ -43,6 +47,7 @@ func TestAttachVolumeFailureUnmarshal(t *testing.T) {
 func TestAttachVolumeFailureMarshal(t *testing.T) {
 	error := ErrorAttachVolumeFailure{
 		InstanceUUID: testutil.InstanceUUID,
+		VolumeUUID:   testutil.VolumeUUID,
 		Reason:       AttachVolumeAttachFailure,
 	}
 

--- a/payloads/attachvolumefailure_test.go
+++ b/payloads/attachvolumefailure_test.go
@@ -71,6 +71,9 @@ func TestAttachVolmeFailureString(t *testing.T) {
 		{AttachVolumeInvalidPayload, "YAML payload is corrupt"},
 		{AttachVolumeInvalidData, "Command section of YAML payload is corrupt or missing required information"},
 		{AttachVolumeAttachFailure, "Failed to attach volume to instance"},
+		{AttachVolumeAlreadyAttached, "Volume already attached"},
+		{AttachVolumeStateFailure, "State failure"},
+		{AttachVolumeInstanceFailure, "Instance failure"},
 	}
 	error := ErrorAttachVolumeFailure{
 		InstanceUUID: testutil.InstanceUUID,

--- a/payloads/detachvolumefailure.go
+++ b/payloads/detachvolumefailure.go
@@ -38,6 +38,19 @@ const (
 	// DetachVolumeDetachFailure indicates that the attempt to detach a
 	// volume from an instance failed.
 	DetachVolumeDetachFailure = "detach_failure"
+
+	// DetachVolumeNotAttached indicates that the volume is not
+	// attached to the instance.
+	DetachVolumeNotAttached = "not_attached"
+
+	// DetachVolumeStateFailure indicates that launcher was unable to
+	// update its internal state to remove the volume.
+	DetachVolumeStateFailure = "state_failure"
+
+	// DetachVolumeInstanceFailure indicates that the volume could not
+	// be detached as the instance has failed to start and is being
+	// deleted
+	DetachVolumeInstanceFailure = "instance_failure"
 )
 
 // ErrorDetachVolumeFailure represents the unmarshalled version of the contents of a
@@ -65,6 +78,12 @@ func (r DetachVolumeFailureReason) String() string {
 		return "Command section of YAML payload is corrupt or missing required information"
 	case DetachVolumeDetachFailure:
 		return "Failed to detach volume from instance"
+	case DetachVolumeNotAttached:
+		return "Volume not attached"
+	case DetachVolumeStateFailure:
+		return "State failure"
+	case DetachVolumeInstanceFailure:
+		return "Instance failure"
 	}
 
 	return ""

--- a/payloads/detachvolumefailure.go
+++ b/payloads/detachvolumefailure.go
@@ -47,6 +47,9 @@ type ErrorDetachVolumeFailure struct {
 	// detached.
 	InstanceUUID string `yaml:"instance_uuid"`
 
+	// VolumeUUID is the UUID of the volume that could not be detached.
+	VolumeUUID string `yaml:"volume_uuid"`
+
 	// Reason provides the reason for the detach failure, e.g.,
 	// DetachVolumeNoInstance.
 	Reason DetachVolumeFailureReason `yaml:"reason"`

--- a/payloads/detachvolumefailure_test.go
+++ b/payloads/detachvolumefailure_test.go
@@ -71,6 +71,9 @@ func TestDetachVolmeFailureString(t *testing.T) {
 		{DetachVolumeInvalidPayload, "YAML payload is corrupt"},
 		{DetachVolumeInvalidData, "Command section of YAML payload is corrupt or missing required information"},
 		{DetachVolumeDetachFailure, "Failed to detach volume from instance"},
+		{DetachVolumeNotAttached, "Volume not attached"},
+		{DetachVolumeStateFailure, "State failure"},
+		{DetachVolumeInstanceFailure, "Instance failure"},
 	}
 	error := ErrorDetachVolumeFailure{
 		InstanceUUID: testutil.InstanceUUID,

--- a/payloads/detachvolumefailure_test.go
+++ b/payloads/detachvolumefailure_test.go
@@ -35,6 +35,10 @@ func TestDetachVolumeFailureUnmarshal(t *testing.T) {
 		t.Error("Wrong UUID field")
 	}
 
+	if error.VolumeUUID != testutil.VolumeUUID {
+		t.Error("Wrong UUID field")
+	}
+
 	if error.Reason != DetachVolumeDetachFailure {
 		t.Error("Wrong Error field")
 	}
@@ -43,6 +47,7 @@ func TestDetachVolumeFailureUnmarshal(t *testing.T) {
 func TestDetachVolumeFailureMarshal(t *testing.T) {
 	error := ErrorDetachVolumeFailure{
 		InstanceUUID: testutil.InstanceUUID,
+		VolumeUUID:   testutil.VolumeUUID,
 		Reason:       DetachVolumeDetachFailure,
 	}
 

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -533,18 +533,30 @@ const AttachVolumeYaml = `attach_volume:
   volume_uuid: ` + VolumeUUID + `
 `
 
+// BadAttachVolumeYaml is a corrupt yaml payload for the ssntp Attach Volume command.
+const BadAttachVolumeYaml = `attach_volume:
+  volume_uuid: ` + VolumeUUID + `
+`
+
 // DetachVolumeYaml is a sample yaml payload for the ssntp Detach Volume command.
 const DetachVolumeYaml = `detach_volume:
   instance_uuid: ` + InstanceUUID + `
   volume_uuid: ` + VolumeUUID + `
 `
 
+// BadDetachVolumeYaml is a corrupt yaml payload for the ssntp Detach Volume command.
+const BadDetachVolumeYaml = `detach_volume:
+  instance_uuid: ` + InstanceUUID + `
+`
+
 // AttachVolumeFailureYaml is a sample AttachVolumeFailure ssntp.Error payload for test cases
 const AttachVolumeFailureYaml = `instance_uuid: ` + InstanceUUID + `
+volume_uuid: ` + VolumeUUID + `
 reason: attach_failure
 `
 
 // DetachVolumeFailureYaml is a sample DetachVolumeFailure ssntp.Error payload for test cases
 const DetachVolumeFailureYaml = `instance_uuid: ` + InstanceUUID + `
+volume_uuid: ` + VolumeUUID + `
 reason: detach_failure
 `


### PR DESCRIPTION
The commit updates the original payload structures and errors added for the AttachVolume and DetachVolume commands.  It also adds contains the first storage commit for launcher.  This commit modifies launcher to accept the AttachVolume and DetachVolume commands and to update its internal instance state accordingly. 