### PR TITLE
Fix misspell errors in ciao-launcher and networking.

### DIFF
--- a/ciao-launcher/overseer.go
+++ b/ciao-launcher/overseer.go
@@ -568,7 +568,7 @@ func (ovs *overseer) processRemoveCommand(cmd *ovsRemoveCmd) {
 }
 
 func (ovs *overseer) processStatusCommand(cmd *ovsStatusCmd) {
-	glog.Info("Overseer: Recieved Status Command")
+	glog.Info("Overseer: Received Status Command")
 	if !ovs.ac.conn.isConnected() {
 		return
 	}
@@ -578,7 +578,7 @@ func (ovs *overseer) processStatusCommand(cmd *ovsStatusCmd) {
 }
 
 func (ovs *overseer) processStatsStatusCommand(cmd *ovsStatsStatusCmd) {
-	glog.Info("Overseer: Recieved StatsStatus Command")
+	glog.Info("Overseer: Received StatsStatus Command")
 	if !ovs.ac.conn.isConnected() {
 		return
 	}
@@ -590,7 +590,7 @@ func (ovs *overseer) processStatsStatusCommand(cmd *ovsStatsStatusCmd) {
 }
 
 func (ovs *overseer) processStateChangeCommand(cmd *ovsStateChange) {
-	glog.Infof("Overseer: Recieved State Change %v", *cmd)
+	glog.Infof("Overseer: Received State Change %v", *cmd)
 	target := ovs.instances[cmd.instance]
 	if target != nil {
 		target.running = cmd.state

--- a/networking/libsnnet/cn_test.go
+++ b/networking/libsnnet/cn_test.go
@@ -559,7 +559,7 @@ func TestNN_Base(t *testing.T) {
 	assert.Nil(cn.DestroyCnciVnic(cnciVnicCfg2))
 	assert.Nil(cn.DestroyCnciVnic(cnciVnicCfg))
 
-	//Destory again, it should work
+	//Destroy again, it should work
 	assert.Nil(cn.DestroyCnciVnic(cnciVnicCfg))
 }
 


### PR DESCRIPTION
The misspell tool in travis has detected misspellings in the
ciao-launcher and networking code. Correct the spelling so that
travis will pass.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>