### PR TITLE
testutil: call flag.Parse in TestMain

### DIFF
--- a/testutil/client_server_test.go
+++ b/testutil/client_server_test.go
@@ -17,6 +17,7 @@
 package testutil_test
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"testing"
@@ -557,6 +558,10 @@ func TestPublicIPAssigned(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	var err error
+
+	// anything that uses ssntp must call flag.Parse first
+	// due to glog.
+	flag.Parse()
 
 	// start server
 	StartTestServer(&server)


### PR DESCRIPTION
Because this test code is using ssntp, which uses glog, you
must call flag.Parse prior to using ssntp.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>