### PR TITLE
travis: Fix build by restricting docker version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
 script:
    - go env
    - docker --version
-   - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine
+   - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-engine=1.11.2-0~trusty
    - docker --version
    - sudo docker pull debian
    - sudo ip link add testdummy type dummy


### PR DESCRIPTION
This commit forces the docker version used in travis to be 1.11.2-0~trusty.
It seems that some of the network unit tests are not working with the
latest version of docker.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>