### PR TITLE
travis: make logdir for scheduler in non-stupid location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 # We need to create and install SSNTP certs for the SSNTP and controller tests
 before_script:
    - sudo mkdir -p /etc/pki/ciao/
-   - sudo mkdir -p /etc/pki/ciao/logs/scheduler
+   - sudo mkdir -p /var/lib/ciao/logs/scheduler
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server -role scheduler
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role agent
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role agent,netagent


### PR DESCRIPTION
In commit 33f421fa357563eecc6b3641cec7949caacdc008 I added a mkdir
in the travis yaml file for the scheduler logs.  It looks like I copy
pasted the line above and appended the log directory.  I should have
also changed /etc/pki to /var/lib.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>