### PR TITLE
configuration: fix configure scheme

### DIFF
--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -58,8 +58,8 @@ func (f *uiFlag) Enabled() bool {
 
 var serverCertPath string
 var clientCertPath string
-var computeNet string
-var mgmtNet string
+var computeNet []string
+var mgmtNet []string
 var networking bool
 var hardReset bool
 var diskLimit bool

--- a/ciao-launcher/network.go
+++ b/ciao-launcher/network.go
@@ -37,23 +37,23 @@ var dockerNet *libsnnet.DockerPlugin
 func initNetworkPhase1() error {
 
 	cn := &libsnnet.ComputeNode{}
-	var mnetList []net.IPNet
-	var cnetList []net.IPNet
 
-	if computeNet != "" {
-		_, cnet, _ := net.ParseCIDR(computeNet)
+	cnetList := make([]net.IPNet, len(computeNet))
+	for i, netStr := range computeNet {
+		_, cnet, _ := net.ParseCIDR(netStr)
 		if cnet == nil {
-			return fmt.Errorf("Unable to Parse CIDR :" + computeNet)
+			return fmt.Errorf("Unable to Parse CIDR :" + netStr)
 		}
-		cnetList = []net.IPNet{*cnet}
+		cnetList[i] = *cnet
 	}
 
-	if mgmtNet != "" {
-		_, mnet, _ := net.ParseCIDR(mgmtNet)
+	mnetList := make([]net.IPNet, len(mgmtNet))
+	for i, netStr := range mgmtNet {
+		_, mnet, _ := net.ParseCIDR(netStr)
 		if mnet == nil {
-			return fmt.Errorf("Unable to Parse CIDR :" + mgmtNet)
+			return fmt.Errorf("Unable to Parse CIDR :" + netStr)
 		}
-		mnetList = []net.IPNet{*mnet}
+		mnetList[i] = *mnet
 	}
 
 	cn.NetworkConfig = &libsnnet.NetworkConfig{

--- a/ciao-launcher/tests/ciao-launcher-server/server.go
+++ b/ciao-launcher/tests/ciao-launcher-server/server.go
@@ -481,8 +481,8 @@ func createConfigFile(confPath string) error {
 
 	conf.Configure.Launcher.DiskLimit = diskLimit
 	conf.Configure.Launcher.MemoryLimit = memLimit
-	conf.Configure.Launcher.ComputeNetwork = computeNet
-	conf.Configure.Launcher.ManagementNetwork = mgmtNet
+	conf.Configure.Launcher.ComputeNetwork = []string{computeNet}
+	conf.Configure.Launcher.ManagementNetwork = []string{mgmtNet}
 
 	d, err := yaml.Marshal(&conf)
 	if err != nil {

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -56,8 +56,8 @@ configure:
     identity_user: string [The identity (e.g. Keystone) user]
     identity_password: string [The identity (e.g. Keystone) password]
   launcher:
-    compute_net: string [The launcher compute network]
-    mgmt_net: string [The launcher management network]
+    compute_net: list [The launcher compute network(s)]
+    mgmt_net: list [The launcher management network(s)]
     disk_limit: bool
     mem_limit: bool
   image_service:
@@ -82,8 +82,10 @@ configure:
     identity_user: controller
     identity_password: ciao
   launcher:
-    compute_net: 192.168.0.0/16
-    mgmt_net: 192.168.0.0/16
+    compute_net:
+    - 192.168.0.0/16
+    mgmt_net:
+    - 192.168.0.0/16
   image_service:
     url: http://glance.example.com:9292
   identity_service:
@@ -104,8 +106,10 @@ configure:
     identity_user: controller
     identity_password: ciao
   launcher:
-    compute_net: 192.168.0.0/16
-    mgmt_net: 192.168.0.0/16
+    compute_net:
+    - 192.168.0.0/16
+    mgmt_net:
+    - 192.168.0.0/16
     disk_limit: true
     mem_limit: true
   image_service:

--- a/networking/libsnnet/utils.go
+++ b/networking/libsnnet/utils.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -41,6 +43,25 @@ var (
 	ifaceRseed rand.Source
 	ifaceRsrc  *rand.Rand
 )
+
+// EqualNetSlice compare 2 network slices
+func EqualNetSlice(slice1, slice2 []string) bool {
+	// if a slice is nil and other isn't then are not equal
+	// if length of slices are not the same, are not equal
+	if (slice1 == nil && slice2 != nil) ||
+		(slice2 == nil && slice1 != nil) ||
+		(len(slice1) != len(slice2)) {
+		return false
+	}
+	sortedSlice1 := make(sort.StringSlice, len(slice1))
+	sortedSlice2 := make(sort.StringSlice, len(slice2))
+	copy(sortedSlice1, slice1)
+	copy(sortedSlice2, slice2)
+	sortedSlice1.Sort()
+	sortedSlice2.Sort()
+	return reflect.DeepEqual(sortedSlice1, sortedSlice2)
+
+}
 
 func init() {
 	ifaceRseed = rand.NewSource(time.Now().UnixNano())

--- a/networking/libsnnet/utils_test.go
+++ b/networking/libsnnet/utils_test.go
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package libsnnet
+
+import (
+	"testing"
+)
+
+func TestEqualNetSlice(t *testing.T) {
+	netSlice1 := []string{"192.168.0.0/24", "192.168.5.0/24", "192.168.42.0/24"}
+	netSlice2 := []string{"192.168.0.0/24", "192.168.5.0/24", "192.168.42.0/24"}
+
+	equalSlices := EqualNetSlice(netSlice1, netSlice2)
+	if equalSlices == false {
+		t.Fatalf("Expected true, got %v", equalSlices)
+	}
+}

--- a/payloads/configure.go
+++ b/payloads/configure.go
@@ -82,10 +82,10 @@ type ConfigureController struct {
 // ConfigureLauncher contains the unmarshalled configurations for the
 // launcher service.
 type ConfigureLauncher struct {
-	ComputeNetwork    string `yaml:"compute_net"`
-	ManagementNetwork string `yaml:"mgmt_net"`
-	DiskLimit         bool   `yaml:"disk_limit"`
-	MemoryLimit       bool   `yaml:"mem_limit"`
+	ComputeNetwork    []string `yaml:"compute_net"`
+	ManagementNetwork []string `yaml:"mgmt_net"`
+	DiskLimit         bool     `yaml:"disk_limit"`
+	MemoryLimit       bool     `yaml:"mem_limit"`
 }
 
 // ConfigureService contains the unmarshalled configurations for the resources

--- a/payloads/configure_test.go
+++ b/payloads/configure_test.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/01org/ciao/networking/libsnnet"
 	. "github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/testutil"
 	"gopkg.in/yaml.v2"
@@ -41,12 +42,12 @@ func TestConfigureUnmarshal(t *testing.T) {
 		t.Errorf("Wrong identity service type [%s]", cfg.Configure.IdentityService.Type)
 	}
 
-	if cfg.Configure.Launcher.ManagementNetwork != testutil.MgmtNet {
-		t.Errorf("Wrong launcher management network [%s]", cfg.Configure.Launcher.ManagementNetwork)
+	if libsnnet.EqualNetSlice(cfg.Configure.Launcher.ManagementNetwork, []string{testutil.MgmtNet}) == false {
+		t.Errorf("Wrong launcher management network %v", cfg.Configure.Launcher.ManagementNetwork)
 	}
 
-	if cfg.Configure.Launcher.ComputeNetwork != testutil.ComputeNet {
-		t.Errorf("Wrong launcher compute network [%s]", cfg.Configure.Launcher.ComputeNetwork)
+	if libsnnet.EqualNetSlice(cfg.Configure.Launcher.ComputeNetwork, []string{testutil.ComputeNet}) == false {
+		t.Errorf("Wrong launcher compute network %v", cfg.Configure.Launcher.ComputeNetwork)
 	}
 
 	if cfg.Configure.Scheduler.ConfigStorageType != Filesystem {
@@ -68,8 +69,8 @@ func TestConfigureMarshal(t *testing.T) {
 	cfg.Configure.IdentityService.Type = Keystone
 	cfg.Configure.IdentityService.URL = testutil.KeystoneURL
 
-	cfg.Configure.Launcher.ComputeNetwork = testutil.ComputeNet
-	cfg.Configure.Launcher.ManagementNetwork = testutil.MgmtNet
+	cfg.Configure.Launcher.ComputeNetwork = []string{testutil.ComputeNet}
+	cfg.Configure.Launcher.ManagementNetwork = []string{testutil.MgmtNet}
 	cfg.Configure.Launcher.DiskLimit = false
 	cfg.Configure.Launcher.MemoryLimit = false
 

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -340,8 +340,10 @@ const ConfigureYaml = `configure:
     identity_user: ` + IdentityUser + `
     identity_password: ` + IdentityPassword + `
   launcher:
-    compute_net: ` + ComputeNet + `
-    mgmt_net: ` + MgmtNet + `
+    compute_net:
+    - ` + ComputeNet + `
+    mgmt_net:
+    - ` + MgmtNet + `
     disk_limit: false
     mem_limit: false
   image_service:


### PR DESCRIPTION
Both `compute_net` and `mgmt_net` can only represent one
subnet. This commit changes the configure scheme for
`compute_net` and `mgmt_net` to accept a list of subnets.

both values should be now a YAML list of subnets like:
```
  launcher:
    compute_net: [192.168.1.110]
    mgmt_net: [192.168.1.0/24, 192.168.2.0/24]
```
or
```
  launcher:
    compute_net:
      - 192.168.1.110
    mgmt_net:
      - 192.168.1.0/24
      - 192.168.2.0/24
```
Fixes #232

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>