### PR TITLE
ciao-cnci-agent: minor fixups

### DIFF
--- a/networking/ciao-cnci-agent/scripts/README.md
+++ b/networking/ciao-cnci-agent/scripts/README.md
@@ -26,10 +26,12 @@ the certificates it needs to connect to the ciao-scheduler.
 ```
 	cd $GOPATH/src/github.com/01org/ciao/networking/ciao-cnci-agent
    	go install
+3. Download the appropriate version image and run the modification script:
 ```
-3. Update the image
-```
-./generate_cnci_cloud_image.sh --image <cnci-image>
+	cd scripts
+	curl -O https://download.clearlinux.org/demos/ciao/clear-${VERSION}-ciao-networking.img.xz
+	xz --decompress clear-${VERSION}-ciao-networking.img.xz
+	./generate_cnci_cloud_image.sh --image clear-${VERSION}-ciao-networking.img
 ```
 
 This will yield a provisioned image. This can be used as a CNCI VM.

--- a/networking/ciao-cnci-agent/scripts/generate_cnci_cloud_image.sh
+++ b/networking/ciao-cnci-agent/scripts/generate_cnci_cloud_image.sh
@@ -62,6 +62,7 @@ retry=0
 until [ $retry -ge 3 ]
 do
 	sudo udevadm settle
+	sudo partprobe /dev/nbd0
 	sudo mount /dev/nbd0p$partition "$tmpdir" && break
 	let retry=retry+1
 	echo "Mount failed, retrying $retry"


### PR DESCRIPTION
Attempting to follow the README and run the script, I bumped into a couple
minor issues:

The image is downloaded by default, so describe how to download the image
and to where.  (Alternatively, could simplify the README by using the
"--download" option.)

Depending on OS specifics, the /dev/nbd0p* might not be created.  Running
'partprobe' is a fairly linux-OS-agnostic way to get them.  Given the
script currently only deals with raw format images, we could also simply do
a loopback mount and not deal with nbd and qemu-nbd, but I'm guessing
qemu-nbd is used to be better ready in the futue to handle qcow format
images in addition to raw?

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>