### PR TITLE
testutil: add Shutdown() to clients and server

### DIFF
--- a/ciao-controller/compute_test.go
+++ b/ciao-controller/compute_test.go
@@ -286,7 +286,7 @@ func testDeleteServer(t *testing.T, httpExpectedStatus int, httpExpectedErrorSta
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 
 	tURL := testutil.ComputeURL + "/v2.1/" + tenant.ID + "/servers/"
 
@@ -337,7 +337,7 @@ func testServersActionStart(t *testing.T, httpExpectedStatus int, validToken boo
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 
 	servers := testCreateServer(t, 1)
 	if servers.TotalServers != 1 {
@@ -397,7 +397,7 @@ func testServersActionStop(t *testing.T, httpExpectedStatus int, action string) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 
 	servers := testCreateServer(t, 1)
 	if servers.TotalServers != 1 {
@@ -446,7 +446,7 @@ func testServerActionStop(t *testing.T, httpExpectedStatus int, validToken bool)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 
 	servers := testCreateServer(t, 1)
 	if servers.TotalServers != 1 {
@@ -483,7 +483,7 @@ func TestServerActionStart(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 
 	servers := testCreateServer(t, 1)
 	if servers.TotalServers != 1 {
@@ -1124,7 +1124,7 @@ func testListTraces(t *testing.T, httpExpectedStatus int, validToken bool) {
 	var expected payloads.CiaoTracesSummary
 
 	client := testStartTracedWorkload(t)
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 
 	sendTraceReportEvent(client, t)
 
@@ -1246,7 +1246,7 @@ func TestClearEventsInvalidToken(t *testing.T) {
 
 func testTraceData(t *testing.T, httpExpectedStatus int, validToken bool) {
 	client := testStartTracedWorkload(t)
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 
 	sendTraceReportEvent(client, t)
 

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -233,17 +233,17 @@ func TestStartWorkload(t *testing.T) {
 	var reason payloads.StartFailureReason
 
 	client, _ := testStartWorkload(t, 1, false, reason)
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 }
 
 func TestStartTracedWorkload(t *testing.T) {
 	client := testStartTracedWorkload(t)
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 }
 
 func TestStartWorkloadLaunchCNCI(t *testing.T) {
 	netClient, instances := testStartWorkloadLaunchCNCI(t, 1)
-	defer netClient.Ssntp.Close()
+	defer netClient.Shutdown()
 
 	id := instances[0].TenantID
 
@@ -293,7 +293,7 @@ func TestDeleteInstance(t *testing.T) {
 	var reason payloads.StartFailureReason
 
 	client, instances := testStartWorkload(t, 1, false, reason)
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 
 	sendStatsCmd(client, t)
 
@@ -319,7 +319,7 @@ func TestStopInstance(t *testing.T) {
 	var reason payloads.StartFailureReason
 
 	client, instances := testStartWorkload(t, 1, false, reason)
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 
 	sendStatsCmd(client, t)
 
@@ -345,7 +345,7 @@ func TestRestartInstance(t *testing.T) {
 	var reason payloads.StartFailureReason
 
 	client, instances := testStartWorkload(t, 1, false, reason)
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 
 	time.Sleep(1 * time.Second)
 
@@ -400,7 +400,7 @@ func TestEvacuateNode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 
 	serverCh := server.AddCmdChan(ssntp.EVACUATE)
 
@@ -424,7 +424,7 @@ func TestInstanceDeletedEvent(t *testing.T) {
 	var reason payloads.StartFailureReason
 
 	client, instances := testStartWorkload(t, 1, false, reason)
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 
 	sendStatsCmd(client, t)
 
@@ -467,7 +467,7 @@ func TestStartFailure(t *testing.T) {
 	reason := payloads.FullCloud
 
 	client, _ := testStartWorkload(t, 1, true, reason)
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 
 	// since we had a start failure, we should confirm that the
 	// instance is no longer pending in the database
@@ -479,7 +479,7 @@ func TestStopFailure(t *testing.T) {
 	var reason payloads.StartFailureReason
 
 	client, instances := testStartWorkload(t, 1, false, reason)
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 
 	client.StopFail = true
 	client.StopFailReason = payloads.StopNoInstance
@@ -527,7 +527,7 @@ func TestRestartFailure(t *testing.T) {
 	var reason payloads.StartFailureReason
 
 	client, instances := testStartWorkload(t, 1, false, reason)
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 
 	client.RestartFail = true
 	client.RestartFailReason = payloads.RestartLaunchFailure
@@ -601,10 +601,10 @@ func TestNoNetwork(t *testing.T) {
 	var reason payloads.StartFailureReason
 
 	client, _ := testStartWorkload(t, 1, false, reason)
-	defer client.Ssntp.Close()
+	defer client.Shutdown()
 }
 
-// NOTE: the caller is responsible for calling Ssntp.Close() on the *SsntpTestClient
+// NOTE: the caller is responsible for calling Shutdown() on the *SsntpTestClient
 func testStartTracedWorkload(t *testing.T) *testutil.SsntpTestClient {
 	tenant, err := addTestTenant()
 	if err != nil {
@@ -616,7 +616,7 @@ func testStartTracedWorkload(t *testing.T) *testutil.SsntpTestClient {
 		t.Fatal(err)
 	}
 	// caller of TestStartTracedWorkload() owns doing the close
-	//defer client.Ssntp.Close()
+	//defer client.Shutdown()
 
 	wls, err := context.ds.GetWorkloads()
 	if err != nil {
@@ -652,7 +652,7 @@ func testStartTracedWorkload(t *testing.T) *testutil.SsntpTestClient {
 	return client
 }
 
-// NOTE: the caller is responsible for calling Ssntp.Close() on the *SsntpTestClient
+// NOTE: the caller is responsible for calling Shutdown() on the *SsntpTestClient
 func testStartWorkload(t *testing.T, num int, fail bool, reason payloads.StartFailureReason) (*testutil.SsntpTestClient, []*types.Instance) {
 	tenant, err := addTestTenant()
 	if err != nil {
@@ -664,7 +664,7 @@ func testStartWorkload(t *testing.T, num int, fail bool, reason payloads.StartFa
 		t.Fatal(err)
 	}
 	// caller of TestStartWorkload() owns doing the close
-	//defer client.Ssntp.Close()
+	//defer client.Shutdown()
 
 	wls, err := context.ds.GetWorkloads()
 	if err != nil {
@@ -708,14 +708,14 @@ func testStartWorkload(t *testing.T, num int, fail bool, reason payloads.StartFa
 	return client, instances
 }
 
-// NOTE: the caller is responsible for calling Ssntp.Close() on the *SsntpTestClient
+// NOTE: the caller is responsible for calling Shutdown() on the *SsntpTestClient
 func testStartWorkloadLaunchCNCI(t *testing.T, num int) (*testutil.SsntpTestClient, []*types.Instance) {
 	netClient, err := testutil.NewSsntpTestClientConnection("StartWorkloadLaunchCNCI", ssntp.NETAGENT, testutil.NetAgentUUID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// caller of testStartWorkloadLaunchCNCI() owns doing the close
-	//defer netClient.Ssntp.Close()
+	//defer netClient.Shutdown()
 
 	wls, err := context.ds.GetWorkloads()
 	if err != nil {
@@ -784,7 +784,7 @@ func testStartWorkloadLaunchCNCI(t *testing.T, num int) (*testutil.SsntpTestClie
 	}
 
 	// shutdown the test CNCI client
-	cnciClient.Ssntp.Close()
+	cnciClient.Shutdown()
 
 	if result.InstanceUUID != tenantCNCI[0].InstanceID {
 		t.Fatalf("Did not get correct Instance ID, got %s, expected %s", result.InstanceUUID, tenantCNCI[0].InstanceID)
@@ -863,7 +863,7 @@ func TestMain(m *testing.M) {
 	context.client.Disconnect()
 	context.ds.Exit()
 	id.Close()
-	server.Ssntp.Stop()
+	server.Shutdown()
 
 	os.Remove("./ciao-controller-test.db")
 	os.Remove("./ciao-controller-test.db-shm")

--- a/testutil/agent.go
+++ b/testutil/agent.go
@@ -60,7 +60,7 @@ type SsntpTestClient struct {
 // Shutdown shuts down the testutil.SsntpTestClient and cleans up state
 func (client *SsntpTestClient) Shutdown() {
 	client.Ssntp.Close()
-	client.CloseChans()
+	closeClientChans(client)
 }
 
 // NewSsntpTestClientConnection creates an SsntpTestClient and dials the server.
@@ -80,14 +80,7 @@ func NewSsntpTestClientConnection(name string, role ssntp.Role, uuid string) (*S
 	client.UUID = uuid
 	client.Role = role
 	client.StartFail = false
-	client.CmdChans = make(map[ssntp.Command]chan Result)
-	client.CmdChansLock = &sync.Mutex{}
-	client.EventChans = make(map[ssntp.Event]chan Result)
-	client.EventChansLock = &sync.Mutex{}
-	client.ErrorChans = make(map[ssntp.Error]chan Result)
-	client.ErrorChansLock = &sync.Mutex{}
-	client.StatusChans = make(map[ssntp.Status]chan Result)
-	client.StatusChansLock = &sync.Mutex{}
+	openClientChans(client)
 	client.instancesLock = &sync.Mutex{}
 	client.tracesLock = &sync.Mutex{}
 
@@ -252,8 +245,18 @@ func (client *SsntpTestClient) SendResultAndDelStatusChan(status ssntp.Status, r
 	}
 }
 
-// CloseChans closes all the test results channels for the test client
-func (client *SsntpTestClient) CloseChans() {
+func openClientChans(client *SsntpTestClient) {
+	client.CmdChans = make(map[ssntp.Command]chan Result)
+	client.CmdChansLock = &sync.Mutex{}
+	client.EventChans = make(map[ssntp.Event]chan Result)
+	client.EventChansLock = &sync.Mutex{}
+	client.ErrorChans = make(map[ssntp.Error]chan Result)
+	client.ErrorChansLock = &sync.Mutex{}
+	client.StatusChans = make(map[ssntp.Status]chan Result)
+	client.StatusChansLock = &sync.Mutex{}
+}
+
+func closeClientChans(client *SsntpTestClient) {
 	client.CmdChansLock.Lock()
 	for _, ch := range client.CmdChans {
 		close(ch)

--- a/testutil/agent.go
+++ b/testutil/agent.go
@@ -57,6 +57,12 @@ type SsntpTestClient struct {
 	StatusChansLock *sync.Mutex
 }
 
+// Shutdown shuts down the testutil.SsntpTestClient and cleans up state
+func (client *SsntpTestClient) Shutdown() {
+	client.Ssntp.Close()
+	client.CloseChans()
+}
+
 // NewSsntpTestClientConnection creates an SsntpTestClient and dials the server.
 // Calling with a unique name parameter string for inclusion in the SsntpTestClient.Name
 // field aides in debugging.  The role parameter is mandatory.  The uuid string
@@ -244,6 +250,33 @@ func (client *SsntpTestClient) SendResultAndDelStatusChan(status ssntp.Status, r
 		c <- result
 		close(c)
 	}
+}
+
+// CloseChans closes all the test results channels for the test client
+func (client *SsntpTestClient) CloseChans() {
+	client.CmdChansLock.Lock()
+	for _, ch := range client.CmdChans {
+		close(ch)
+	}
+	client.CmdChansLock.Unlock()
+
+	client.EventChansLock.Lock()
+	for _, ch := range client.EventChans {
+		close(ch)
+	}
+	client.EventChansLock.Unlock()
+
+	client.ErrorChansLock.Lock()
+	for _, ch := range client.ErrorChans {
+		close(ch)
+	}
+	client.ErrorChansLock.Unlock()
+
+	client.StatusChansLock.Lock()
+	for _, ch := range client.StatusChans {
+		close(ch)
+	}
+	client.StatusChansLock.Unlock()
 }
 
 // ConnectNotify implements the SSNTP client ConnectNotify callback for SsntpTestClient

--- a/testutil/agent.go
+++ b/testutil/agent.go
@@ -258,26 +258,30 @@ func openClientChans(client *SsntpTestClient) {
 
 func closeClientChans(client *SsntpTestClient) {
 	client.CmdChansLock.Lock()
-	for _, ch := range client.CmdChans {
-		close(ch)
+	for k := range client.CmdChans {
+		close(client.CmdChans[k])
+		delete(client.CmdChans, k)
 	}
 	client.CmdChansLock.Unlock()
 
 	client.EventChansLock.Lock()
-	for _, ch := range client.EventChans {
-		close(ch)
+	for k := range client.EventChans {
+		close(client.EventChans[k])
+		delete(client.EventChans, k)
 	}
 	client.EventChansLock.Unlock()
 
 	client.ErrorChansLock.Lock()
-	for _, ch := range client.ErrorChans {
-		close(ch)
+	for k := range client.ErrorChans {
+		close(client.ErrorChans[k])
+		delete(client.ErrorChans, k)
 	}
 	client.ErrorChansLock.Unlock()
 
 	client.StatusChansLock.Lock()
-	for _, ch := range client.StatusChans {
-		close(ch)
+	for k := range client.StatusChans {
+		close(client.StatusChans[k])
+		delete(client.StatusChans, k)
 	}
 	client.StatusChansLock.Unlock()
 }

--- a/testutil/agent_test.go
+++ b/testutil/agent_test.go
@@ -151,3 +151,22 @@ func TestAgentCmdChanTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestAgentCloseChans(t *testing.T) {
+	var result Result
+
+	_ = agent.AddCmdChan(ssntp.START)
+	go agent.SendResultAndDelCmdChan(ssntp.START, result)
+
+	_ = agent.AddEventChan(ssntp.TraceReport)
+	go agent.SendResultAndDelEventChan(ssntp.TraceReport, result)
+
+	_ = agent.AddErrorChan(ssntp.StopFailure)
+	go agent.SendResultAndDelErrorChan(ssntp.StopFailure, result)
+
+	_ = agent.AddStatusChan(ssntp.READY)
+	go agent.SendResultAndDelStatusChan(ssntp.READY, result)
+
+	CloseClientChans(agent)
+	OpenClientChans(agent)
+}

--- a/testutil/client_server_test.go
+++ b/testutil/client_server_test.go
@@ -451,7 +451,7 @@ func stopServer() error {
 	netAgentCh := netAgent.AddEventChan(ssntp.NodeDisconnected)
 	agentCh := agent.AddEventChan(ssntp.NodeDisconnected)
 
-	server.Ssntp.Stop()
+	server.Shutdown()
 
 	_, err := controller.GetEventChanResult(controllerCh, ssntp.NodeDisconnected)
 	if err != nil {
@@ -589,16 +589,16 @@ func TestMain(m *testing.M) {
 
 	// stop everybody
 	time.Sleep(1 * time.Second)
-	controller.Ssntp.Close()
+	controller.Shutdown()
 
 	time.Sleep(1 * time.Second)
-	netAgent.Ssntp.Close()
+	netAgent.Shutdown()
 
 	time.Sleep(1 * time.Second)
-	agent.Ssntp.Close()
+	agent.Shutdown()
 
 	time.Sleep(1 * time.Second)
-	server.Ssntp.Stop()
+	server.Shutdown()
 
 	os.Exit(status)
 }

--- a/testutil/controller.go
+++ b/testutil/controller.go
@@ -198,20 +198,23 @@ func openControllerChans(ctl *SsntpTestController) {
 
 func closeControllerChans(ctl *SsntpTestController) {
 	ctl.CmdChansLock.Lock()
-	for _, ch := range ctl.CmdChans {
-		close(ch)
+	for k := range ctl.CmdChans {
+		close(ctl.CmdChans[k])
+		delete(ctl.CmdChans, k)
 	}
 	ctl.CmdChansLock.Unlock()
 
 	ctl.EventChansLock.Lock()
-	for _, ch := range ctl.EventChans {
-		close(ch)
+	for k := range ctl.EventChans {
+		close(ctl.EventChans[k])
+		delete(ctl.EventChans, k)
 	}
 	ctl.EventChansLock.Unlock()
 
 	ctl.ErrorChansLock.Lock()
-	for _, ch := range ctl.ErrorChans {
-		close(ch)
+	for k := range ctl.ErrorChans {
+		close(ctl.ErrorChans[k])
+		delete(ctl.ErrorChans, k)
 	}
 	ctl.ErrorChansLock.Unlock()
 }

--- a/testutil/controller.go
+++ b/testutil/controller.go
@@ -42,7 +42,7 @@ type SsntpTestController struct {
 // Shutdown shuts down the testutil.SsntpTestClient and cleans up state
 func (ctl *SsntpTestController) Shutdown() {
 	ctl.Ssntp.Close()
-	ctl.CloseChans()
+	closeControllerChans(ctl)
 }
 
 // NewSsntpTestControllerConnection creates an SsntpTestController and dials the server.
@@ -60,12 +60,7 @@ func NewSsntpTestControllerConnection(name string, uuid string) (*SsntpTestContr
 		UUID: uuid,
 	}
 
-	ctl.CmdChans = make(map[ssntp.Command]chan Result)
-	ctl.CmdChansLock = &sync.Mutex{}
-	ctl.EventChans = make(map[ssntp.Event]chan Result)
-	ctl.EventChansLock = &sync.Mutex{}
-	ctl.ErrorChans = make(map[ssntp.Error]chan Result)
-	ctl.ErrorChansLock = &sync.Mutex{}
+	openControllerChans(ctl)
 
 	config := &ssntp.Config{
 		URI:    "",
@@ -192,8 +187,16 @@ func (ctl *SsntpTestController) SendResultAndDelErrorChan(error ssntp.Error, res
 	}
 }
 
-// CloseChans closes all the test results channels for the test controller
-func (ctl *SsntpTestController) CloseChans() {
+func openControllerChans(ctl *SsntpTestController) {
+	ctl.CmdChans = make(map[ssntp.Command]chan Result)
+	ctl.CmdChansLock = &sync.Mutex{}
+	ctl.EventChans = make(map[ssntp.Event]chan Result)
+	ctl.EventChansLock = &sync.Mutex{}
+	ctl.ErrorChans = make(map[ssntp.Error]chan Result)
+	ctl.ErrorChansLock = &sync.Mutex{}
+}
+
+func closeControllerChans(ctl *SsntpTestController) {
 	ctl.CmdChansLock.Lock()
 	for _, ch := range ctl.CmdChans {
 		close(ch)

--- a/testutil/controller.go
+++ b/testutil/controller.go
@@ -39,6 +39,12 @@ type SsntpTestController struct {
 	ErrorChansLock *sync.Mutex
 }
 
+// Shutdown shuts down the testutil.SsntpTestClient and cleans up state
+func (ctl *SsntpTestController) Shutdown() {
+	ctl.Ssntp.Close()
+	ctl.CloseChans()
+}
+
 // NewSsntpTestControllerConnection creates an SsntpTestController and dials the server.
 // Calling with a unique name parameter string for inclusion in the
 // SsntpTestClient.Name field aides in debugging.  The uuid string
@@ -184,6 +190,27 @@ func (ctl *SsntpTestController) SendResultAndDelErrorChan(error ssntp.Error, res
 		c <- result
 		close(c)
 	}
+}
+
+// CloseChans closes all the test results channels for the test controller
+func (ctl *SsntpTestController) CloseChans() {
+	ctl.CmdChansLock.Lock()
+	for _, ch := range ctl.CmdChans {
+		close(ch)
+	}
+	ctl.CmdChansLock.Unlock()
+
+	ctl.EventChansLock.Lock()
+	for _, ch := range ctl.EventChans {
+		close(ch)
+	}
+	ctl.EventChansLock.Unlock()
+
+	ctl.ErrorChansLock.Lock()
+	for _, ch := range ctl.ErrorChans {
+		close(ch)
+	}
+	ctl.ErrorChansLock.Unlock()
 }
 
 // ConnectNotify implements the SSNTP client ConnectNotify callback for SsntpTestController

--- a/testutil/controller_test.go
+++ b/testutil/controller_test.go
@@ -117,3 +117,19 @@ func TestControllerCmdChanTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestControllerCloseChans(t *testing.T) {
+	var result Result
+
+	_ = controller.AddCmdChan(ssntp.START)
+	go controller.SendResultAndDelCmdChan(ssntp.START, result)
+
+	_ = controller.AddEventChan(ssntp.TraceReport)
+	go controller.SendResultAndDelEventChan(ssntp.TraceReport, result)
+
+	_ = controller.AddErrorChan(ssntp.StopFailure)
+	go controller.SendResultAndDelErrorChan(ssntp.StopFailure, result)
+
+	CloseControllerChans(controller)
+	OpenControllerChans(controller)
+}

--- a/testutil/export_test.go
+++ b/testutil/export_test.go
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package testutil
+
+var OpenControllerChans = openControllerChans
+var OpenServerChans = openServerChans
+var OpenClientChans = openClientChans
+
+var CloseControllerChans = closeControllerChans
+var CloseServerChans = closeServerChans
+var CloseClientChans = closeClientChans

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -210,26 +210,30 @@ func openServerChans(server *SsntpTestServer) {
 
 func closeServerChans(server *SsntpTestServer) {
 	server.CmdChansLock.Lock()
-	for _, ch := range server.CmdChans {
-		close(ch)
+	for k := range server.CmdChans {
+		close(server.CmdChans[k])
+		delete(server.CmdChans, k)
 	}
 	server.CmdChansLock.Unlock()
 
 	server.EventChansLock.Lock()
-	for _, ch := range server.EventChans {
-		close(ch)
+	for k := range server.EventChans {
+		close(server.EventChans[k])
+		delete(server.EventChans, k)
 	}
 	server.EventChansLock.Unlock()
 
 	server.ErrorChansLock.Lock()
-	for _, ch := range server.ErrorChans {
-		close(ch)
+	for k := range server.ErrorChans {
+		close(server.ErrorChans[k])
+		delete(server.ErrorChans, k)
 	}
 	server.ErrorChansLock.Unlock()
 
 	server.StatusChansLock.Lock()
-	for _, ch := range server.StatusChans {
-		close(ch)
+	for k := range server.StatusChans {
+		close(server.StatusChans[k])
+		delete(server.StatusChans, k)
 	}
 	server.StatusChansLock.Unlock()
 }

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -194,6 +194,33 @@ func (server *SsntpTestServer) SendResultAndDelStatusChan(error ssntp.Status, re
 	}
 }
 
+// CloseChans closes all the test results channels for the test server
+func (server *SsntpTestServer) CloseChans() {
+	server.CmdChansLock.Lock()
+	for _, ch := range server.CmdChans {
+		close(ch)
+	}
+	server.CmdChansLock.Unlock()
+
+	server.EventChansLock.Lock()
+	for _, ch := range server.EventChans {
+		close(ch)
+	}
+	server.EventChansLock.Unlock()
+
+	server.ErrorChansLock.Lock()
+	for _, ch := range server.ErrorChans {
+		close(ch)
+	}
+	server.ErrorChansLock.Unlock()
+
+	server.StatusChansLock.Lock()
+	for _, ch := range server.StatusChans {
+		close(ch)
+	}
+	server.StatusChansLock.Unlock()
+}
+
 // ConnectNotify implements an SSNTP ConnectNotify callback for SsntpTestServer
 func (server *SsntpTestServer) ConnectNotify(uuid string, role ssntp.Role) {
 	var result Result
@@ -519,6 +546,12 @@ func (server *SsntpTestServer) CommandForward(uuid string, command ssntp.Command
 	}
 
 	return dest
+}
+
+// Shutdown shuts down the testutil.SsntpTestServer and cleans up state
+func (server *SsntpTestServer) Shutdown() {
+	server.Ssntp.Stop()
+	server.CloseChans()
 }
 
 // StartTestServer starts a go routine for based on a

--- a/testutil/server_test.go
+++ b/testutil/server_test.go
@@ -139,3 +139,22 @@ func TestServerCmdChanTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestServerCloseChans(t *testing.T) {
+	var result Result
+
+	_ = server.AddCmdChan(ssntp.START)
+	go server.SendResultAndDelCmdChan(ssntp.START, result)
+
+	_ = server.AddEventChan(ssntp.TraceReport)
+	go server.SendResultAndDelEventChan(ssntp.TraceReport, result)
+
+	_ = server.AddErrorChan(ssntp.StopFailure)
+	go server.SendResultAndDelErrorChan(ssntp.StopFailure, result)
+
+	_ = server.AddStatusChan(ssntp.READY)
+	go server.SendResultAndDelStatusChan(ssntp.READY, result)
+
+	CloseServerChans(&server)
+	OpenServerChans(&server)
+}


### PR DESCRIPTION
A Shutdown() helper is added to the testutil clients and server in order to
handle teardown of the SSNTP session and closing the testutil results
channels.

This should prevent channel writers that are blocked from causing
goroutine leaks across test cases.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>