### PR TITLE
storage: image server needs trailing '/' on its keystone url

### DIFF
--- a/ciao-image/main.go
+++ b/ciao-image/main.go
@@ -27,7 +27,7 @@ var httpsCAcert = "/etc/pki/ciao/ciao-image-cacert.pem"
 var httpsKey = "/etc/pki/ciao/ciao-image-key.pem"
 var port = image.APIPort
 var logDir = "/var/lib/ciao/logs/ciao-image"
-var identity = "https://localhost:35357"
+var identity = "https://localhost:35357/"
 var userName = "ciao"
 var password = "hello"
 


### PR DESCRIPTION
Without the '/' ciao-image tries to GET https://localhost:35357v3/
which is obviously wrong.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>