### PR TITLE
ciao-cli: Handle the case where a user does not belong to a tenant.

### DIFF
--- a/ciao-cli/identity.go
+++ b/ciao-cli/identity.go
@@ -252,6 +252,10 @@ func getTenant(username string, password string, tenantID string) (string, strin
 		return "", "", err
 	}
 
+	if len(projects) == 0 {
+		return "", tenantID, fmt.Errorf("No tenant name for %s", username)
+	}
+
 	if len(projects) > 1 {
 		if tenantID == "" {
 			fmt.Printf("Available projects for %s:\n", *identityUser)


### PR DESCRIPTION
When a tenant is not specified in the cli or environment variables,
ciao-cli uses getTenant function to fetch the tenantName and
tenantID the user belongs to.

getTenant was not handling the case where a user exists but does not
belong to any tenant resulting in an index out of range panic.

This commits handles this scenario and fails properly.

Fixes: #433

Signed-off-by: Alberto Murillo <alberto.murillo.silva@intel.com>