### PR TITLE
singlevm : Add networking automation (macvlan and DHCP Server)

### DIFF
--- a/testutil/singlevm/configuration.yaml
+++ b/testutil/singlevm/configuration.yaml
@@ -9,6 +9,9 @@ configure:
   image_service:
     url: http://glance.example.com
   launcher:
+    compute_net: 192.168.12.1/24
+    mgmt_net: 192.168.12.1/24
     disk_limit: false
+    mem_limit: false
   identity_service:
     url: http://keystone.example.com

--- a/testutil/singlevm/configuration.yaml
+++ b/testutil/singlevm/configuration.yaml
@@ -9,8 +9,8 @@ configure:
   image_service:
     url: http://glance.example.com
   launcher:
-    compute_net: 192.168.12.1/24
-    mgmt_net: 192.168.12.1/24
+    compute_net: 198.51.100.1/24
+    mgmt_net: 198.51.100.1/24
     disk_limit: false
     mem_limit: false
   identity_service:

--- a/testutil/singlevm/dnsmasq.conf.macvlan0
+++ b/testutil/singlevm/dnsmasq.conf.macvlan0
@@ -1,0 +1,25 @@
+# Only listen to routers' LAN NIC.  Doing so opens up tcp/udp port 53 to
+# localhost and udp port 67 to world:
+interface=macvlan0
+
+listen-address=198.51.100.1/24
+
+# dnsmasq will open tcp/udp port 53 and udp port 67 to world to help with
+# dynamic interfaces (assigning dynamic ips). Dnsmasq will discard world
+# requests to them, but the paranoid might like to close them and let the
+# kernel handle them:
+bind-interfaces
+
+# Dynamic range of IPs to make available to LAN pc
+dhcp-range=198.51.100.50,198.51.100.100,12h
+
+# If you’d like to have dnsmasq assign static IPs, bind the LAN computer's
+# NIC MAC address:
+
+except-interface=lo
+
+log-queries
+
+log-dhcp
+
+#dhcp-host=aa:bb:cc:dd:ee:ff,198.51.100.50

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -311,7 +311,7 @@ do
 
 	echo "Attempting to ssh to: $ssh_ip"
 
-	if [[ "$ssh_check" == *SSH-2.0-OpenSSH_7.2* ]]
+	if [[ "$ssh_check" == *SSH-2.0-OpenSSH_* ]]
 	then
 		echo "SSH connectivity verified"
 		break


### PR DESCRIPTION
This change adds the following features to Single VM:
- Auto macvlan interface creation with ``ip`` command
- DHCP Server setup with ``dnsmasq``
- When testing ssh connectivity, avoid fixed 7.2 openssh version.

This will help to accomplish #334 