### PR TITLE
bat: Fix tap package import and requirements

### DIFF
--- a/_release/bat/release_test.py
+++ b/_release/bat/release_test.py
@@ -42,7 +42,7 @@ There are 2 configurable parameters that may be set:
 import subprocess32
 import os
 import unittest
-import taprunner
+import tap
 import time
 import sys
 import random
@@ -469,7 +469,7 @@ def main():
     retry_count = args.retry_count
 
     outfile = open("./report.tap", "w")
-    unittest.main(testRunner=taprunner.TAPTestRunner(stream=outfile))
+    unittest.main(testRunner=tap.TAPTestRunner(stream=outfile))
 
 if __name__ == '__main__':
     main()

--- a/_release/bat/requirements.txt
+++ b/_release/bat/requirements.txt
@@ -1,0 +1,6 @@
+linecache2==1.0.0
+six==1.10.0
+subprocess32==3.2.7
+tap.py==2.0
+traceback2==1.4.0
+unittest2==1.1.0


### PR DESCRIPTION
Update BAT testing with proper ``tap`` package import and requirements file was added to easy install with ``pip2``

Dependencies can be easily installed with:
```
     pip2 install -f requirements.txt
```
