### PR TITLE
scheduler: more test code locking bugfixes

### DIFF
--- a/ciao-scheduler/scheduler_ssntp_test.go
+++ b/ciao-scheduler/scheduler_ssntp_test.go
@@ -63,6 +63,8 @@ func TestSendAgentStatus(t *testing.T) {
 
 	server.cnMutex.Lock()
 	cn = server.cnMap[testutil.AgentUUID]
+	cn.mutex.Lock()
+	defer cn.mutex.Unlock()
 	if cn != nil && cn.status != tgtStatus {
 		t.Fatalf("agent node incorrect status: expected %s, got %s", tgtStatus.String(), cn.status.String())
 	}
@@ -90,6 +92,8 @@ func TestSendNetAgentStatus(t *testing.T) {
 
 	server.nnMutex.Lock()
 	nn = server.nnMap[testutil.NetAgentUUID]
+	nn.mutex.Lock()
+	defer nn.mutex.Unlock()
 	if nn != nil && nn.status != tgtStatus {
 		t.Fatalf("netagent node incorrect status: expected %s, got %s", tgtStatus.String(), nn.status.String())
 	}
@@ -505,6 +509,7 @@ func waitForAgent(uuid string, status *ssntp.Status) {
 	for {
 		server.cnMutex.Lock()
 		cn := server.cnMap[uuid]
+		cn.mutex.Lock()
 		server.cnMutex.Unlock()
 
 		if cn == nil {
@@ -514,14 +519,17 @@ func waitForAgent(uuid string, status *ssntp.Status) {
 			fmt.Printf("awaiting agent %s in state %s\n", uuid, status.String())
 			time.Sleep(50 * time.Millisecond)
 		} else {
+			cn.mutex.Unlock()
 			return
 		}
+		cn.mutex.Unlock()
 	}
 }
 func waitForNetAgent(uuid string, status *ssntp.Status) {
 	for {
 		server.nnMutex.Lock()
 		nn := server.nnMap[uuid]
+		nn.mutex.Lock()
 		server.nnMutex.Unlock()
 
 		if nn == nil {
@@ -531,8 +539,10 @@ func waitForNetAgent(uuid string, status *ssntp.Status) {
 			fmt.Printf("awaiting netagent %s in state %s\n", uuid, status.String())
 			time.Sleep(50 * time.Millisecond)
 		} else {
+			nn.mutex.Unlock()
 			return
 		}
+		nn.mutex.Unlock()
 	}
 }
 

--- a/ciao-scheduler/scheduler_ssntp_test.go
+++ b/ciao-scheduler/scheduler_ssntp_test.go
@@ -580,17 +580,17 @@ func ssntpTestsTeardown() {
 	wg.Add(3)
 
 	go func() {
-		controller.Ssntp.Close()
+		controller.Shutdown()
 		wg.Done()
 	}()
 
 	go func() {
-		netAgent.Ssntp.Close()
+		netAgent.Shutdown()
 		wg.Done()
 	}()
 
 	go func() {
-		agent.Ssntp.Close()
+		agent.Shutdown()
 		wg.Done()
 	}()
 


### PR DESCRIPTION
The data race Kristen caught in https://travis-ci.org/kaccardi/ciao/jobs/151574113 is addressed here.

I've also got a patch for what is likely the test deadlock which appears very regularly these days "in" ciao-launcher.  The stack traces there show it's not really launcher's test, but really is due to the same old races in the testutil/ results channels that I've been chasing for a while.  A scheduler test was failing to fully shutdown a test instance of the ssntp server, which later caused issues when launcher's test tried to restart.