### PR TITLE
travis: Remove test-cases --race parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,9 @@ script:
    - sudo mkdir -p /var/lib/ciao/instances
    - sudo chmod 0777 /var/lib/ciao/instances
    - test-cases -v -timeout 9 -text -coverprofile /tmp/cover.out -short github.com/01org/ciao/ciao-controller/...
-   - test-cases -v -timeout 9 -text -coverprofile /tmp/cover.out -append-profile -short -race github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/payloads github.com/01org/ciao/configuration github.com/01org/ciao/testutil github.com/01org/ciao/ssntp/uuid
-   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -text -coverprofile /tmp/cover.out -append-profile -race github.com/01org/ciao/ssntp
-   - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -text -short -tags travis -coverprofile /tmp/cover.out -append-profile -race github.com/01org/ciao/networking/libsnnet
+   - test-cases -v -timeout 9 -text -coverprofile /tmp/cover.out -append-profile -short github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/payloads github.com/01org/ciao/configuration github.com/01org/ciao/testutil github.com/01org/ciao/ssntp/uuid
+   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -text -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/ssntp
+   - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -text -short -tags travis -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/networking/libsnnet
 
 after_success:
    - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=/tmp/cover.out


### PR DESCRIPTION
We suspect that the addition of this parameter has led to the instability
of our Travis builds over the last week or so.  Our code is simply not
yet ready to have race detection enabled on all tests.  Enabling race
detection also seems to mess up the line numbers in the stack traces,
 making it difficult to pinpoint where code is panicing and hanging.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>