### PR TITLE
travis: Enable Go 1.7 builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 
 go:
     - 1.6
+    - 1.7
     - tip
 
 env:


### PR DESCRIPTION
This commit will spawn an additional build for each PR and commit to
ensure that ciao can be built with Go 1.7 and that the resulting binaries
pass their unit tests.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>