### PR TITLE
ciao-launcher: Ensure qmp ids are valid ids

### DIFF
--- a/ciao-launcher/qemu.go
+++ b/ciao-launcher/qemu.go
@@ -53,7 +53,7 @@ const attachVolumeDriveTemplateString = `
                 "driver": "file",
                 "filename": "{{.Device}}"
             },
-            "id": "{{.VolumeUUID}}_drive"
+            "id": "drive_{{.VolumeUUID}}"
         }
     }
 }
@@ -63,9 +63,9 @@ const attachVolumeDeviceTemplateString = `
 {
     "execute": "device_add",
     "arguments": {
-        "drive": "{{.VolumeUUID}}_drive",
+        "drive": "drive_{{.VolumeUUID}}",
         "driver": "virtio-blk-pci",
-        "id": "{{.VolumeUUID}}_device"
+        "id": "device_{{.VolumeUUID}}"
     }
 }
 `
@@ -74,7 +74,7 @@ const detachVolumeDriveTemplateString = `
 {
     "execute": "x-blockdev-del",
     "arguments": {
-        "id": "{{.VolumeUUID}}_drive"
+        "id": "drive_{{.VolumeUUID}}"
     }
 }
 `
@@ -83,7 +83,7 @@ const detachVolumeDeviceTemplateString = `
 {
     "execute": "device_del",
     "arguments": {
-        "id": "{{.VolumeUUID}}_device"
+        "id": "device_{{.VolumeUUID}}"
     }
 }
 `


### PR DESCRIPTION
The commands to attach and detach a volume currently fail if the
UUID of that volume does not begin with a letter.  The UUIDs are
used in QMP device and drive names and the QMP commands to which
these names are passed can fail, if the UUIDs start with a number.
This patch fixes the issue by prepending, rather than appending,
drive_ or device_ to the volume UUIDs before that are used in QMP
ids.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>