### PR TITLE
testutil: race / deadlock hunting

### DIFF
--- a/testutil/agent.go
+++ b/testutil/agent.go
@@ -19,6 +19,7 @@ package testutil
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -510,7 +511,7 @@ func (client *SsntpTestClient) CommandNotify(command ssntp.Command, frame *ssntp
 		result = client.handleAttachVolume(payload)
 
 	default:
-		fmt.Printf("client %s unhandled command %s\n", client.Role.String(), command.String())
+		fmt.Fprintf(os.Stderr, "client %s unhandled command %s\n", client.Role.String(), command.String())
 	}
 
 	client.SendResultAndDelCmdChan(command, result)
@@ -536,7 +537,7 @@ func (client *SsntpTestClient) EventNotify(event ssntp.Event, frame *ssntp.Frame
 			result.Err = err
 		}
 	default:
-		fmt.Printf("client %s unhandled event: %s\n", client.Role.String(), event.String())
+		fmt.Fprintf(os.Stderr, "client %s unhandled event: %s\n", client.Role.String(), event.String())
 	}
 
 	client.SendResultAndDelEventChan(event, result)
@@ -720,7 +721,7 @@ func (client *SsntpTestClient) sendStartFailure(instanceUUID string, reason payl
 
 	_, err = client.Ssntp.SendError(ssntp.StartFailure, y)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 	}
 }
 
@@ -737,7 +738,7 @@ func (client *SsntpTestClient) sendStopFailure(instanceUUID string, reason paylo
 
 	_, err = client.Ssntp.SendError(ssntp.StopFailure, y)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 	}
 }
 
@@ -754,7 +755,7 @@ func (client *SsntpTestClient) sendRestartFailure(instanceUUID string, reason pa
 
 	_, err = client.Ssntp.SendError(ssntp.RestartFailure, y)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 	}
 }
 
@@ -771,7 +772,7 @@ func (client *SsntpTestClient) sendDeleteFailure(instanceUUID string, reason pay
 
 	_, err = client.Ssntp.SendError(ssntp.DeleteFailure, y)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 	}
 }
 
@@ -789,6 +790,6 @@ func (client *SsntpTestClient) sendAttachVolumeFailure(instanceUUID string, volu
 
 	_, err = client.Ssntp.SendError(ssntp.AttachVolumeFailure, y)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 	}
 }

--- a/testutil/agent.go
+++ b/testutil/agent.go
@@ -62,8 +62,8 @@ type SsntpTestClient struct {
 
 // Shutdown shuts down the testutil.SsntpTestClient and cleans up state
 func (client *SsntpTestClient) Shutdown() {
-	client.Ssntp.Close()
 	closeClientChans(client)
+	client.Ssntp.Close()
 }
 
 // NewSsntpTestClientConnection creates an SsntpTestClient and dials the server.

--- a/testutil/client_server_test.go
+++ b/testutil/client_server_test.go
@@ -116,7 +116,7 @@ func TestStartFailure(t *testing.T) {
 
 	serverErrorCh := server.AddErrorChan(ssntp.StartFailure)
 	controllerErrorCh := controller.AddErrorChan(ssntp.StartFailure)
-	fmt.Printf("Expecting server and controller to note: \"%s\"\n", ssntp.StartFailure)
+	fmt.Fprintf(os.Stderr, "Expecting server and controller to note: \"%s\"\n", ssntp.StartFailure)
 
 	agent.StartFail = true
 	agent.StartFailReason = payloads.FullCloud
@@ -252,7 +252,7 @@ func TestStopFailure(t *testing.T) {
 
 	serverErrorCh := server.AddErrorChan(ssntp.StopFailure)
 	controllerErrorCh := controller.AddErrorChan(ssntp.StopFailure)
-	fmt.Printf("Expecting server and controller to note: \"%s\"\n", ssntp.StopFailure)
+	fmt.Fprintf(os.Stderr, "Expecting server and controller to note: \"%s\"\n", ssntp.StopFailure)
 
 	agent.StopFail = true
 	agent.StopFailReason = payloads.StopNoInstance
@@ -307,7 +307,7 @@ func TestRestartFailure(t *testing.T) {
 
 	serverErrorCh := server.AddErrorChan(ssntp.RestartFailure)
 	controllerErrorCh := controller.AddErrorChan(ssntp.RestartFailure)
-	fmt.Printf("Expecting server and controller to note: \"%s\"\n", ssntp.RestartFailure)
+	fmt.Fprintf(os.Stderr, "Expecting server and controller to note: \"%s\"\n", ssntp.RestartFailure)
 
 	agent.RestartFail = true
 	agent.RestartFailReason = payloads.RestartNoInstance
@@ -347,7 +347,7 @@ func doDelete(fail bool) error {
 	if fail == true {
 		serverErrorCh = server.AddErrorChan(ssntp.DeleteFailure)
 		controllerErrorCh = controller.AddErrorChan(ssntp.DeleteFailure)
-		fmt.Printf("Expecting server and controller to note: \"%s\"\n", ssntp.DeleteFailure)
+		fmt.Fprintf(os.Stderr, "Expecting server and controller to note: \"%s\"\n", ssntp.DeleteFailure)
 
 		agent.DeleteFail = true
 		agent.DeleteFailReason = payloads.DeleteNoInstance
@@ -441,7 +441,7 @@ func doAttachVolume(fail bool) error {
 	if fail == true {
 		serverErrorCh = server.AddErrorChan(ssntp.AttachVolumeFailure)
 		controllerErrorCh = controller.AddErrorChan(ssntp.AttachVolumeFailure)
-		fmt.Printf("Expecting server and controller to note: \"%s\"\n", ssntp.AttachVolumeFailure)
+		fmt.Fprintf(os.Stderr, "Expecting server and controller to note: \"%s\"\n", ssntp.AttachVolumeFailure)
 
 		agent.AttachFail = true
 		agent.AttachVolumeFailReason = payloads.AttachVolumeAlreadyAttached
@@ -579,7 +579,7 @@ func restartServer() error {
 }
 
 func TestReconnects(t *testing.T) {
-	fmt.Println("stopping server")
+	fmt.Fprintln(os.Stderr, "stopping server")
 	err := stopServer()
 	if err != nil {
 		t.Fatal(err)
@@ -587,7 +587,7 @@ func TestReconnects(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	fmt.Println("restarting server")
+	fmt.Fprintln(os.Stderr, "restarting server")
 	err = restartServer()
 	if err != nil {
 		t.Fatal(err)

--- a/testutil/controller.go
+++ b/testutil/controller.go
@@ -42,8 +42,8 @@ type SsntpTestController struct {
 
 // Shutdown shuts down the testutil.SsntpTestClient and cleans up state
 func (ctl *SsntpTestController) Shutdown() {
-	ctl.Ssntp.Close()
 	closeControllerChans(ctl)
+	ctl.Ssntp.Close()
 }
 
 // NewSsntpTestControllerConnection creates an SsntpTestController and dials the server.

--- a/testutil/controller.go
+++ b/testutil/controller.go
@@ -18,6 +18,7 @@ package testutil
 import (
 	"errors"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -275,7 +276,7 @@ func (ctl *SsntpTestController) CommandNotify(command ssntp.Command, frame *ssnt
 		}
 
 	default:
-		fmt.Printf("controller unhandled command: %s\n", command.String())
+		fmt.Fprintf(os.Stderr, "controller unhandled command: %s\n", command.String())
 	}
 
 	ctl.SendResultAndDelCmdChan(command, result)
@@ -319,7 +320,7 @@ func (ctl *SsntpTestController) EventNotify(event ssntp.Event, frame *ssntp.Fram
 			result.Err = err
 		}
 	default:
-		fmt.Printf("controller unhandled event: %s\n", event.String())
+		fmt.Fprintf(os.Stderr, "controller unhandled event: %s\n", event.String())
 	}
 
 	ctl.SendResultAndDelEventChan(event, result)
@@ -343,7 +344,7 @@ func (ctl *SsntpTestController) ErrorNotify(error ssntp.Error, frame *ssntp.Fram
 	case ssntp.InvalidConfiguration:
 	*/
 	default:
-		fmt.Printf("controller unhandled error %s\n", error.String())
+		fmt.Fprintf(os.Stderr, "controller unhandled error %s\n", error.String())
 	}
 
 	ctl.SendResultAndDelErrorChan(error, result)

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -622,8 +622,8 @@ func (server *SsntpTestServer) CommandForward(uuid string, command ssntp.Command
 
 // Shutdown shuts down the testutil.SsntpTestServer and cleans up state
 func (server *SsntpTestServer) Shutdown() {
-	server.Ssntp.Stop()
 	closeServerChans(server)
+	server.Ssntp.Stop()
 }
 
 // StartTestServer starts a go routine for based on a

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -19,6 +19,7 @@ package testutil
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"sync"
 	"time"
 
@@ -304,9 +305,9 @@ func (server *SsntpTestServer) StatusNotify(uuid string, status ssntp.Status, fr
 
 	switch status {
 	case ssntp.READY:
-		fmt.Printf("server received READY from node %s\n", uuid)
+		fmt.Fprintf(os.Stderr, "server received READY from node %s\n", uuid)
 	default:
-		fmt.Printf("server unhandled status frame from node %s\n", uuid)
+		fmt.Fprintf(os.Stderr, "server unhandled status frame from node %s\n", uuid)
 	}
 
 	server.SendResultAndDelStatusChan(status, result)
@@ -410,7 +411,7 @@ func (server *SsntpTestServer) CommandNotify(uuid string, command ssntp.Command,
 		getAttachVolumeResult(payload, &result)
 
 	default:
-		fmt.Printf("server unhandled command %s\n", command.String())
+		fmt.Fprintf(os.Stderr, "server unhandled command %s\n", command.String())
 	}
 
 	server.SendResultAndDelCmdChan(command, result)
@@ -442,7 +443,7 @@ func (server *SsntpTestServer) EventNotify(uuid string, event ssntp.Event, frame
 	case ssntp.PublicIPAssigned:
 		// forwards from CNCI Controller(s) via server.EventForward()
 	default:
-		fmt.Printf("server unhandled event %s\n", event.String())
+		fmt.Fprintf(os.Stderr, "server unhandled event %s\n", event.String())
 	}
 
 	server.SendResultAndDelEventChan(event, result)
@@ -489,7 +490,7 @@ func (server *SsntpTestServer) EventForward(uuid string, event ssntp.Event, fram
 	}
 
 	if err != nil {
-		fmt.Println("server error parsing event yaml for forwarding")
+		fmt.Fprintf(os.Stderr, "server error parsing event yaml for forwarding")
 		result.Err = err
 	}
 
@@ -530,7 +531,7 @@ func (server *SsntpTestServer) ErrorNotify(uuid string, error ssntp.Error, frame
 		fallthrough
 
 	default:
-		fmt.Printf("server unhandled error %s\n", error.String())
+		fmt.Fprintf(os.Stderr, "server unhandled error %s\n", error.String())
 	}
 
 	server.SendResultAndDelErrorChan(error, result)


### PR DESCRIPTION
This PR has some more verbose output to aide debugging and a prospective deadlock fix in testutil agent/server shutdown.