### PR TITLE
testutil: close result channels before ending ssntp session

### DIFF
--- a/testutil/agent.go
+++ b/testutil/agent.go
@@ -59,8 +59,8 @@ type SsntpTestClient struct {
 
 // Shutdown shuts down the testutil.SsntpTestClient and cleans up state
 func (client *SsntpTestClient) Shutdown() {
-	client.Ssntp.Close()
 	closeClientChans(client)
+	client.Ssntp.Close()
 }
 
 // NewSsntpTestClientConnection creates an SsntpTestClient and dials the server.

--- a/testutil/controller.go
+++ b/testutil/controller.go
@@ -41,8 +41,8 @@ type SsntpTestController struct {
 
 // Shutdown shuts down the testutil.SsntpTestClient and cleans up state
 func (ctl *SsntpTestController) Shutdown() {
-	ctl.Ssntp.Close()
 	closeControllerChans(ctl)
+	ctl.Ssntp.Close()
 }
 
 // NewSsntpTestControllerConnection creates an SsntpTestController and dials the server.

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -579,8 +579,8 @@ func (server *SsntpTestServer) CommandForward(uuid string, command ssntp.Command
 
 // Shutdown shuts down the testutil.SsntpTestServer and cleans up state
 func (server *SsntpTestServer) Shutdown() {
-	server.Ssntp.Stop()
 	closeServerChans(server)
+	server.Ssntp.Stop()
 }
 
 // StartTestServer starts a go routine for based on a


### PR DESCRIPTION
Some of our hangs look like they're in ssntp.Stop().  I stop the server
after disconnecting clients in tests, but I wonder if they still have
threads hanging around because the channel closing hasn't yet finished
because it wasn't actually started.  If the channel close happens before
the ssntp sessions are Close()/Stop()'d, then if the ssntp Close()/Stop()
were waiting for something to finish then that something has at least
been unblocked to finish.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>