### PR TITLE
testutil: connect/disconnect make 1 result on event channel

### DIFF
--- a/testutil/server.go
+++ b/testutil/server.go
@@ -404,8 +404,12 @@ func (server *SsntpTestServer) EventNotify(uuid string, event ssntp.Event, frame
 	payload := frame.Payload
 
 	switch event {
-	// case ssntp.NodeConnected:	handled by ConnectNotify()
-	// case ssntp.NodeDisconnected:	handled by DisconnectNotify()
+	case ssntp.NodeConnected:
+		//handled by ConnectNotify()
+		return
+	case ssntp.NodeDisconnected:
+		//handled by DisconnectNotify()
+		return
 	case ssntp.TraceReport:
 		var traceEvent payloads.Trace
 


### PR DESCRIPTION
There's an event result write to the events channel in both the
EventNotify() and in the ConnectNotify()/DisconnectNotify() code paths,
but there will only be one read.  These writers will block and leak
goroutines.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>