### PR TITLE
scheduler: goroutine ssntp Stop() in test case

### DIFF
--- a/ciao-scheduler/scheduler_ssntp_test.go
+++ b/ciao-scheduler/scheduler_ssntp_test.go
@@ -387,7 +387,7 @@ func stopServer() error {
 	netAgentCh := netAgent.AddEventChan(ssntp.NodeDisconnected)
 	agentCh := agent.AddEventChan(ssntp.NodeDisconnected)
 
-	server.ssntp.Stop()
+	go server.ssntp.Stop()
 
 	_, err := controller.GetEventChanResult(controllerCh, ssntp.NodeDisconnected)
 	if err != nil {


### PR DESCRIPTION
The tests propagate event results through channels.  Writers to channels
block until a reader reads.  The reader of a node disconnect event result
doesn't start to read untils the reader code (after the server stop call)
actually runs, which it wont do if the server stop is not a go routine.  If
the stop code is blocked on sending to the channel and the reader only runs
when the stop code is complete (ie: because it is not stopping in a
goroutine) there's going to be a deadlock.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>