### PR TITLE
ciao-controller: fix trivial go vet warning

### DIFF
--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -166,7 +166,7 @@ func (c *controller) ShowVolumeDetails(tenant string, volume string) (block.Volu
 // then wrap them in keystone validation. It will then start the https
 // service.
 func (c *controller) startVolumeService() error {
-	config := block.APIConfig{block.APIPort, c}
+	config := block.APIConfig{Port: block.APIPort, VolService: c}
 
 	r := block.Routes(config)
 	if r == nil {


### PR DESCRIPTION
Go vet was complaining about "composite literal uses unkeyed fields", so I
keyed the fields.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>