### PR TITLE
ciao-launcher: Add ceph credentials to the storage driver.

### DIFF
--- a/ciao-launcher/instance.go
+++ b/ciao-launcher/instance.go
@@ -398,5 +398,9 @@ func startInstance(instance string, cfg *vmConfig, wg *sync.WaitGroup, doneCh ch
 	} else {
 		vm = &qemu{}
 	}
-	return startInstanceWithVM(instance, cfg, wg, doneCh, ac, ovsCh, vm, storage.CephDriver{})
+	return startInstanceWithVM(instance, cfg, wg, doneCh, ac, ovsCh, vm,
+		storage.CephDriver{
+			SecretPath: "/etc/ceph/ceph.client.ciao.keyring",
+			ID:         "ciao",
+		})
 }


### PR DESCRIPTION
This is just a temporary work around for testing the end to
end attach and detach commands.  The credentials need to be
retrieved in a different way going forward.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>