### PR TITLE
ciao-controller: add support for detach

### DIFF
--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -302,6 +302,28 @@ func (client *ssntpClient) attachVolume(volID string, instanceID string, nodeID 
 	return err
 }
 
+func (client *ssntpClient) detachVolume(volID string, instanceID string, nodeID string) error {
+	payload := payloads.DetachVolume{
+		Detach: payloads.VolumeCmd{
+			InstanceUUID:      instanceID,
+			VolumeUUID:        volID,
+			WorkloadAgentUUID: nodeID,
+		},
+	}
+
+	y, err := yaml.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	glog.Infof("DetachVolume %s to %s\n", volID, instanceID)
+	glog.V(1).Info(string(y))
+
+	_, err = client.ssntp.SendCommand(ssntp.DetachVolume, y)
+
+	return err
+}
+
 func (client *ssntpClient) Disconnect() {
 	client.ssntp.Close()
 }

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -1593,3 +1593,21 @@ func (ds *Datastore) deleteStorageAttachment(ID string) error {
 
 	return ds.db.deleteStorageAttachment(ID)
 }
+
+// GetVolumeAttachments will return a list of attachments associated with
+// this volume ID.
+func (ds *Datastore) GetVolumeAttachments(volume string) ([]types.StorageAttachment, error) {
+	var attachments []types.StorageAttachment
+
+	ds.attachLock.RLock()
+
+	for _, a := range ds.attachments {
+		if a.BlockID == volume {
+			attachments = append(attachments, a)
+		}
+	}
+
+	ds.attachLock.RUnlock()
+
+	return attachments, nil
+}

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -217,6 +217,10 @@ const (
 	// InUse means that the volume has been successfully
 	// attached to an instance.
 	InUse BlockState = BlockState(block.InUse)
+
+	// Detaching means that the volume is in process
+	// of detaching.
+	Detaching BlockState = "detaching"
 )
 
 // BlockData respresents the attributes of this block device.

--- a/openstack/block/api.go
+++ b/openstack/block/api.go
@@ -301,6 +301,7 @@ var (
 	ErrVolumeOwner          = errors.New("You are not volume owner")
 	ErrInstanceOwner        = errors.New("You are not instance owner")
 	ErrInstanceNotAvailable = errors.New("Instance not available")
+	ErrVolumeNotAttached    = errors.New("Volume not attached")
 )
 
 // errorResponse maps service error responses to http responses.
@@ -316,15 +317,12 @@ func errorResponse(err error) APIResponse {
 		return APIResponse{http.StatusNotFound, nil}
 	case ErrInstanceNotFound:
 		return APIResponse{http.StatusNotFound, nil}
-	case ErrVolumeNotAvailable:
-		return APIResponse{http.StatusForbidden, nil}
-	case ErrVolumeNotAvailable:
-		return APIResponse{http.StatusForbidden, nil}
-	case ErrVolumeOwner:
-		return APIResponse{http.StatusForbidden, nil}
-	case ErrInstanceOwner:
-		return APIResponse{http.StatusForbidden, nil}
-	case ErrInstanceNotAvailable:
+	case ErrVolumeNotAvailable,
+		ErrVolumeNotAvailable,
+		ErrVolumeOwner,
+		ErrInstanceOwner,
+		ErrInstanceNotAvailable,
+		ErrVolumeNotAttached:
 		return APIResponse{http.StatusForbidden, nil}
 	default:
 		return APIResponse{http.StatusInternalServerError, nil}


### PR DESCRIPTION
Implement the block api interface for detaching a volume from
a running instance.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>