### PR TITLE
openstack block: don't cast nil

### DIFF
--- a/openstack/block/api.go
+++ b/openstack/block/api.go
@@ -602,8 +602,11 @@ func volumeActionDetach(bc *Context, m map[string]interface{}, tenant string, vo
 	m = val.(map[string]interface{})
 
 	// attachment-id is optional
+	var attachment string
 	val = m["attachment-id"]
-	attachment := val.(string)
+	if val != nil {
+		attachment = val.(string)
+	}
 
 	err := bc.DetachVolume(tenant, volume, attachment)
 	if err != nil {


### PR DESCRIPTION
The attachment var is probably frequently (especially today) empty so I
can't var.(string) in that case.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>