### PR TITLE
Storage cluster config handling

### DIFF
--- a/ciao-launcher/instance.go
+++ b/ciao-launcher/instance.go
@@ -400,7 +400,7 @@ func startInstance(instance string, cfg *vmConfig, wg *sync.WaitGroup, doneCh ch
 	}
 	return startInstanceWithVM(instance, cfg, wg, doneCh, ac, ovsCh, vm,
 		storage.CephDriver{
-			SecretPath: "/etc/ceph/ceph.client.ciao.keyring",
-			ID:         "ciao",
+			SecretPath: secretPath,
+			ID:         cephID,
 		})
 }

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -75,8 +75,8 @@ func init() {
 	flag.BoolVar(&networking, "network", true, "Enable networking")
 	flag.BoolVar(&hardReset, "hard-reset", false, "Kill and delete all instances, reset networking and exit")
 	flag.BoolVar(&simulate, "simulation", false, "Launcher simulation")
-	flag.StringVar(&secretPath, "secret-path", "/etc/ceph/ceph.client.ciao.keyring", "path to ceph client keyring")
-	flag.StringVar(&cephID, "ceph-id", "ciao", "ceph client id")
+	flag.StringVar(&secretPath, "ceph_keyring", "", "path to ceph client keyring")
+	flag.StringVar(&cephID, "ceph_id", "", "ceph client id")
 }
 
 const (
@@ -393,6 +393,12 @@ DONE:
 			mgmtNet = clusterConfig.Configure.Launcher.ManagementNetwork
 			diskLimit = clusterConfig.Configure.Launcher.DiskLimit
 			memLimit = clusterConfig.Configure.Launcher.MemoryLimit
+			if secretPath == "" {
+				secretPath = clusterConfig.Configure.Storage.SecretPath
+			}
+			if cephID == "" {
+				cephID = clusterConfig.Configure.Storage.CephID
+			}
 			printClusterConfig()
 
 			err = startNetwork(doneCh)

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -64,6 +64,8 @@ var networking bool
 var hardReset bool
 var diskLimit bool
 var memLimit bool
+var secretPath string
+var cephID string
 var simulate bool
 var maxInstances = int(math.MaxInt32)
 
@@ -73,6 +75,8 @@ func init() {
 	flag.BoolVar(&networking, "network", true, "Enable networking")
 	flag.BoolVar(&hardReset, "hard-reset", false, "Kill and delete all instances, reset networking and exit")
 	flag.BoolVar(&simulate, "simulation", false, "Launcher simulation")
+	flag.StringVar(&secretPath, "secret-path", "/etc/ceph/ceph.client.ciao.keyring", "path to ceph client keyring")
+	flag.StringVar(&cephID, "ceph-id", "ciao", "ceph client id")
 }
 
 const (
@@ -337,6 +341,8 @@ func printClusterConfig() {
 	glog.Infof("Management Network:   %v", mgmtNet)
 	glog.Infof("Disk Limit:           %v", diskLimit)
 	glog.Infof("Memory Limit:         %v", memLimit)
+	glog.Infof("Secret Path:          %v", secretPath)
+	glog.Infof("Ceph ID:              %v", cephID)
 }
 
 func connectToServer(doneCh chan struct{}, statusCh chan struct{}) {

--- a/ciao-launcher/tests/ciao-launcher-server/server.go
+++ b/ciao-launcher/tests/ciao-launcher-server/server.go
@@ -43,6 +43,8 @@ var computeNet string
 var mgmtNet string
 var diskLimit bool
 var memLimit bool
+var secretPath string
+var cephID string
 
 var ssntpServer = &ssntp.Server{}
 
@@ -55,6 +57,8 @@ func init() {
 	flag.StringVar(&mgmtNet, "mgmt-net", "", "Management Subnet")
 	flag.BoolVar(&diskLimit, "disk-limit", true, "Use disk usage limits")
 	flag.BoolVar(&memLimit, "mem-limit", true, "Use memory usage limits")
+	flag.StringVar(&secretPath, "secret-path", "/etc/ceph/ceph.client.ciao.keyring", "path to ceph client keyring")
+	flag.StringVar(&cephID, "ceph-id", "ciao", "ceph client id")
 }
 
 type client struct {
@@ -491,6 +495,8 @@ func createConfigFile(confPath string) error {
 	conf.Configure.Launcher.MemoryLimit = memLimit
 	conf.Configure.Launcher.ComputeNetwork = []string{computeNet}
 	conf.Configure.Launcher.ManagementNetwork = []string{mgmtNet}
+	conf.Configure.Storage.SecretPath = secretPath
+	conf.Configure.Storage.CephID = cephID
 
 	d, err := yaml.Marshal(&conf)
 	if err != nil {

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -49,6 +49,9 @@ configure:
   scheduler:
     storage_type: string [file, etcd, zookeeper]
     storage_uri: string [The storage URI path]
+  storage:
+    secret_path: string [Path to the keyring file]
+    ceph_id: string [Name used for the Ceph identifier]
   controller:
     compute_port: int
     compute_ca: string [The HTTPS compute endpoint CA]
@@ -99,6 +102,9 @@ configure:
   scheduler:
     storage_type: file
     storage_uri: /etc/ciao/configuration.yaml
+  storage:
+    secret_path: /etc/ceph/ceph.client.ciao.keyring
+    ceph_id: ciao
   controller:
     compute_port: 8774
     compute_ca: /etc/pki/ciao/compute_ca.pem

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -36,6 +36,12 @@ import (
 //
 // TODO: proper validation of values set in yaml setup
 func validMinConf(conf *payloads.Configure) bool {
+	if conf.Configure.Storage.SecretPath == "" {
+		fmt.Printf("Warning, secret_path not set (will become an error soon)")
+	}
+	if conf.Configure.Storage.CephID == "" {
+		fmt.Printf("Warning, ceph_id not set (will become an error soon)")
+	}
 	return (conf.Configure.Scheduler.ConfigStorageURI != "" &&
 		conf.Configure.Controller.HTTPSCACert != "" &&
 		conf.Configure.Controller.HTTPSKey != "" &&

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -40,6 +40,8 @@ const identityUser = "controller"
 const identityPassword = "ciao"
 const httpsKey = "/etc/pki/ciao/compute_key.pem"
 const httpsCACert = "/etc/pki/ciao/compute_ca.pem"
+const secretPath = "/etc/ceph/ceph.client.ciao.keyring"
+const cephID = "ciao"
 
 const minValidConf = `configure:
   scheduler:
@@ -61,6 +63,9 @@ const fullValidConf = `configure:
   scheduler:
     storage_type: file
     storage_uri: /etc/ciao/configuration.yaml
+  storage:
+    secret_path: /etc/ceph/ceph.client.ciao.keyring
+    ceph_id: ciao
   controller:
     compute_port: 8774
     compute_ca: /etc/pki/ciao/compute_ca.pem
@@ -162,6 +167,8 @@ func fillPayload(conf *payloads.Configure) {
 	conf.Configure.Launcher.ManagementNetwork = []string{mgmtNet}
 	conf.Configure.ImageService.URL = glanceURL
 	conf.Configure.IdentityService.URL = keystoneURL
+	conf.Configure.Storage.SecretPath = secretPath
+	conf.Configure.Storage.CephID = cephID
 }
 
 func testPayload(t *testing.T, blob []byte, expectedConf payloads.Configure, positive bool) {

--- a/payloads/configure.go
+++ b/payloads/configure.go
@@ -88,6 +88,13 @@ type ConfigureLauncher struct {
 	MemoryLimit       bool     `yaml:"mem_limit"`
 }
 
+// ConfigureStorage contains the unmarshalled configurations for the
+// Ceph storage driver.
+type ConfigureStorage struct {
+	SecretPath string `yaml:"secret_path"`
+	CephID     string `yaml:"ceph_id"`
+}
+
 // ConfigureService contains the unmarshalled configurations for the resources
 // of the configurations.
 type ConfigureService struct {
@@ -100,6 +107,7 @@ type ConfigureService struct {
 //  imaging and identity.
 type ConfigurePayload struct {
 	Scheduler       ConfigureScheduler  `yaml:"scheduler"`
+	Storage         ConfigureStorage    `yaml:"storage"`
 	Controller      ConfigureController `yaml:"controller"`
 	Launcher        ConfigureLauncher   `yaml:"launcher"`
 	ImageService    ConfigureService    `yaml:"image_service"`

--- a/payloads/configure_test.go
+++ b/payloads/configure_test.go
@@ -50,6 +50,14 @@ func TestConfigureUnmarshal(t *testing.T) {
 		t.Errorf("Wrong launcher compute network %v", cfg.Configure.Launcher.ComputeNetwork)
 	}
 
+	if cfg.Configure.Storage.SecretPath != testutil.KeyPath {
+		t.Errorf("Wrong launcher secret path %v", cfg.Configure.Storage.SecretPath)
+	}
+
+	if cfg.Configure.Storage.CephID != testutil.ManagementID {
+		t.Errorf("Wrong launcher ceph id %v", cfg.Configure.Storage.CephID)
+	}
+
 	if cfg.Configure.Scheduler.ConfigStorageType != Filesystem {
 		t.Errorf("Wrong scheduler storage type [%s]", cfg.Configure.Scheduler.ConfigStorageType)
 	}
@@ -80,6 +88,9 @@ func TestConfigureMarshal(t *testing.T) {
 	cfg.Configure.Controller.HTTPSKey = testutil.HTTPSKey
 	cfg.Configure.Controller.IdentityUser = testutil.IdentityUser
 	cfg.Configure.Controller.IdentityPassword = testutil.IdentityPassword
+
+	cfg.Configure.Storage.SecretPath = testutil.KeyPath
+	cfg.Configure.Storage.CephID = testutil.ManagementID
 
 	cfg.Configure.Scheduler.ConfigStorageType = Filesystem
 	cfg.Configure.Scheduler.ConfigStorageURI = testutil.StorageURI

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -66,6 +66,12 @@ const ComputeNet = "192.168.1.110"
 // MgmtNet is a test management network
 const MgmtNet = "192.168.1.111"
 
+// KeyPath is a test path to a keyring
+const KeyPath = "/etc/ceph/ceph.client.ciao.keyring"
+
+// ManagementID is a test identifier for a Ceph ID
+const ManagementID = "ciao"
+
 // StorageURI is a test storage URI
 const StorageURI = "/etc/ciao/ciao.json"
 
@@ -336,6 +342,9 @@ const ConfigureYaml = `configure:
   scheduler:
     storage_type: file
     storage_uri: ` + StorageURI + `
+  storage:
+    secret_path: ` + KeyPath + `
+    ceph_id: ` + ManagementID + `
   controller:
     compute_port: ` + ComputePort + `
     compute_ca: ` + HTTPSCACert + `


### PR DESCRIPTION
Add storage cluster configuration module that adds CephDriver fields for the storage url and cephx secrets to be passed from the ssntp configuration frame.

This address #462 and partially #388.