### PR TITLE
Prepare

### DIFF
--- a/ciao-controller/deps.go
+++ b/ciao-controller/deps.go
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import "github.com/01org/ciao/osprepare"
+
+var controllerDeps = osprepare.PackageRequirements{
+	/* sqlite3 is not strictly required, but useful for debug */
+	"clearlinux": {
+		{"/usr/bin/sqlite3", "cloud-control"},
+	},
+	"fedora": {
+		{"/usr/bin/sqlite3", "sqlite"},
+	},
+	"ubuntu": {
+		{"/usr/bin/sqlite3", "sqlite3"},
+	},
+}

--- a/ciao-controller/deps.go
+++ b/ciao-controller/deps.go
@@ -21,12 +21,12 @@ import "github.com/01org/ciao/osprepare"
 var controllerDeps = osprepare.PackageRequirements{
 	/* sqlite3 is not strictly required, but useful for debug */
 	"clearlinux": {
-		{"/usr/bin/sqlite3", "cloud-control"},
+		{BinaryName: "/usr/bin/sqlite3", PackageName: "cloud-control"},
 	},
 	"fedora": {
-		{"/usr/bin/sqlite3", "sqlite"},
+		{BinaryName: "/usr/bin/sqlite3", PackageName: "sqlite"},
 	},
 	"ubuntu": {
-		{"/usr/bin/sqlite3", "sqlite3"},
+		{BinaryName: "/usr/bin/sqlite3", PackageName: "sqlite3"},
 	},
 }

--- a/ciao-controller/deps_debug.go
+++ b/ciao-controller/deps_debug.go
@@ -13,21 +13,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// +build !debug
+// +build debug
 
 package main
 
 import "github.com/01org/ciao/osprepare"
 
 var controllerDeps = osprepare.PackageRequirements{
-	// no known dependencies
+	/* sqlite3 is not strictly required, but useful for debug */
 	"clearlinux": {
-		{BinaryName: "", PackageName: ""},
+		{BinaryName: "/usr/bin/sqlite3", PackageName: "cloud-control"},
 	},
 	"fedora": {
-		{BinaryName: "", PackageName: ""},
+		{BinaryName: "/usr/bin/sqlite3", PackageName: "sqlite"},
 	},
 	"ubuntu": {
-		{BinaryName: "", PackageName: ""},
+		{BinaryName: "/usr/bin/sqlite3", PackageName: "sqlite3"},
 	},
 }

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -25,6 +25,7 @@ import (
 	datastore "github.com/01org/ciao/ciao-controller/internal/datastore"
 	image "github.com/01org/ciao/ciao-image/client"
 	storage "github.com/01org/ciao/ciao-storage"
+	"github.com/01org/ciao/osprepare"
 	"github.com/01org/ciao/ssntp"
 	"github.com/01org/ciao/testutil"
 	"github.com/golang/glog"
@@ -134,6 +135,8 @@ func main() {
 	if *cephID == "" {
 		*cephID = clusterConfig.Configure.Storage.CephID
 	}
+
+	osprepare.InstallDeps(controllerDeps)
 
 	if *singleMachine {
 		hostname, _ := os.Hostname()

--- a/ciao-launcher/deps.go
+++ b/ciao-launcher/deps.go
@@ -25,21 +25,21 @@ import "github.com/01org/ciao/osprepare"
 // fuser for qemu instance pid
 
 var launcherClearLinuxCommonDeps = []osprepare.PackageRequirement{
-	{"/usr/bin/qemu-system-x86_64", "cloud-control"},
-	{"/usr/bin/xorriso", "cloud-control"},
-	{"/usr/sbin/fuser", "cloud-control"},
+	{BinaryName: "/usr/bin/qemu-system-x86_64", PackageName: "cloud-control"},
+	{BinaryName: "/usr/bin/xorriso", PackageName: "cloud-control"},
+	{BinaryName: "/usr/sbin/fuser", PackageName: "cloud-control"},
 }
 
 var launcherFedoraCommonDeps = []osprepare.PackageRequirement{
-	{"/usr/bin/qemu-system-x86_64", "qemu-system-x86"},
-	{"/usr/bin/xorriso", "xorriso"},
-	{"/usr/sbin/fuser", "psmisc"},
+	{BinaryName: "/usr/bin/qemu-system-x86_64", PackageName: "qemu-system-x86"},
+	{BinaryName: "/usr/bin/xorriso", PackageName: "xorriso"},
+	{BinaryName: "/usr/sbin/fuser", PackageName: "psmisc"},
 }
 
 var launcherUbuntuCommonDeps = []osprepare.PackageRequirement{
-	{"/usr/bin/qemu-system-x86_64", "qemu-system-x86"},
-	{"/usr/bin/xorriso", "xorriso"},
-	{"/bin/fuser", "psmisc"},
+	{BinaryName: "/usr/bin/qemu-system-x86_64", PackageName: "qemu-system-x86"},
+	{BinaryName: "/usr/bin/xorriso", PackageName: "xorriso"},
+	{BinaryName: "/bin/fuser", PackageName: "psmisc"},
 }
 
 var launcherNetNodeDeps = map[string][]osprepare.PackageRequirement{

--- a/ciao-launcher/deps.go
+++ b/ciao-launcher/deps.go
@@ -18,24 +18,49 @@ package main
 
 import "github.com/01org/ciao/osprepare"
 
-var launcherDeps = osprepare.PackageRequirements{
-	// docker for containers
-	// qemu/kvm for VM's
-	// xorriso for cloud init config drive
+// common launcher node needs are:
+//
+// qemu/kvm for VM's
+// xorriso for cloud init config drive
+// fuser for qemu instance pid
 
-	"clearlinux": {
-		{"/usr/bin/docker", "cloud-control"},
-		{"/usr/bin/qemu-system-x86_64", "cloud-control"},
-		{"/usr/bin/xorriso", "cloud-control"},
-	},
-	"fedora": {
-		{"/usr/bin/docker", "docker-engine"},
-		{"/usr/bin/qemu-system-x86_64", "qemu-system-x86"},
-		{"/usr/bin/xorriso", "xorriso"},
-	},
-	"ubuntu": {
-		{"/usr/bin/docker", "docker"},
-		{"/usr/bin/qemu-system-x86_64", "qemu-system-x86"},
-		{"/usr/bin/xorriso", "xorriso"},
-	},
+var launcherClearLinuxCommonDeps = []osprepare.PackageRequirement{
+	{"/usr/bin/qemu-system-x86_64", "cloud-control"},
+	{"/usr/bin/xorriso", "cloud-control"},
+	{"/usr/sbin/fuser", "cloud-control"},
+}
+
+var launcherFedoraCommonDeps = []osprepare.PackageRequirement{
+	{"/usr/bin/qemu-system-x86_64", "qemu-system-x86"},
+	{"/usr/bin/xorriso", "xorriso"},
+	{"/usr/sbin/fuser", "psmisc"},
+}
+
+var launcherUbuntuCommonDeps = []osprepare.PackageRequirement{
+	{"/usr/bin/qemu-system-x86_64", "qemu-system-x86"},
+	{"/usr/bin/xorriso", "xorriso"},
+	{"/bin/fuser", "psmisc"},
+}
+
+var launcherNetNodeDeps = map[string][]osprepare.PackageRequirement{
+	// network nodes have a unique additional need for:
+	//
+	// 	none currently
+
+	"clearlinux": launcherClearLinuxCommonDeps,
+	"fedora":     launcherFedoraCommonDeps,
+	"ubuntu":     launcherUbuntuCommonDeps,
+}
+
+var launcherComputeNodeDeps = map[string][]osprepare.PackageRequirement{
+	// compute nodes have a unique additional need for:
+	//
+	// docker for containers
+
+	"clearlinux": append(launcherClearLinuxCommonDeps,
+		osprepare.PackageRequirement{BinaryName: "/usr/bin/docker", PackageName: "cloud-control"}),
+	"fedora": append(launcherFedoraCommonDeps,
+		osprepare.PackageRequirement{BinaryName: "/usr/bin/docker", PackageName: "docker-engine"}),
+	"ubuntu": append(launcherUbuntuCommonDeps,
+		osprepare.PackageRequirement{BinaryName: "/usr/bin/docker", PackageName: "docker"}),
 }

--- a/ciao-launcher/deps.go
+++ b/ciao-launcher/deps.go
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import "github.com/01org/ciao/osprepare"
+
+var launcherDeps = osprepare.PackageRequirements{
+	// docker for containers
+	// qemu/kvm for VM's
+	// xorriso for cloud init config drive
+
+	"clearlinux": {
+		{"/usr/bin/docker", "cloud-control"},
+		{"/usr/bin/qemu-system-x86_64", "cloud-control"},
+		{"/usr/bin/xorriso", "cloud-control"},
+	},
+	"fedora": {
+		{"/usr/bin/docker", "docker-engine"},
+		{"/usr/bin/qemu-system-x86_64", "qemu-system-x86"},
+		{"/usr/bin/xorriso", "xorriso"},
+	},
+	"ubuntu": {
+		{"/usr/bin/docker", "docker"},
+		{"/usr/bin/qemu-system-x86_64", "qemu-system-x86"},
+		{"/usr/bin/xorriso", "xorriso"},
+	},
+}

--- a/ciao-launcher/instance_test.go
+++ b/ciao-launcher/instance_test.go
@@ -177,6 +177,10 @@ func (v *instanceTestState) SendCommand(cmd ssntp.Command, payload []byte) (int,
 	return 0, nil
 }
 
+func (v *instanceTestState) Role() ssntp.Role {
+	return ssntp.AGENT | ssntp.NETAGENT
+}
+
 func (v *instanceTestState) UUID() string {
 	return ""
 }

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -236,6 +236,16 @@ func (client *agentClient) ErrorNotify(err ssntp.Error, frame *ssntp.Frame) {
 	glog.Infof("ERROR %d", err)
 }
 
+func (client *agentClient) installLauncherDeps() {
+	role := client.conn.Role()
+	if role.IsNetAgent() {
+		osprepare.InstallDeps(launcherNetNodeDeps)
+	}
+	if role.IsAgent() {
+		osprepare.InstallDeps(launcherComputeNodeDeps)
+	}
+}
+
 func insCmdChannel(instance string, ovsCh chan<- interface{}) chan<- interface{} {
 	targetCh := make(chan ovsGetResult)
 	ovsCh <- &ovsGetCmd{instance, targetCh}
@@ -403,13 +413,7 @@ DONE:
 			}
 			printClusterConfig()
 
-			role := client.conn.Role()
-			if role.IsNetAgent() {
-				osprepare.InstallDeps(launcherNetNodeDeps)
-			}
-			if role.IsAgent() {
-				osprepare.InstallDeps(launcherComputeNodeDeps)
-			}
+			client.installLauncherDeps()
 
 			err = startNetwork(doneCh)
 			if err != nil {

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -102,6 +102,7 @@ type serverConn interface {
 	Dial(config *ssntp.Config, ntf ssntp.ClientNotifier) error
 	SendStatus(status ssntp.Status, payload []byte) (int, error)
 	SendCommand(cmd ssntp.Command, payload []byte) (int, error)
+	Role() ssntp.Role
 	UUID() string
 	Close()
 	isConnected() bool
@@ -402,7 +403,13 @@ DONE:
 			}
 			printClusterConfig()
 
-			osprepare.InstallDeps(launcherDeps)
+			role := client.conn.Role()
+			if role.IsNetAgent() {
+				osprepare.InstallDeps(launcherNetNodeDeps)
+			}
+			if role.IsAgent() {
+				osprepare.InstallDeps(launcherComputeNodeDeps)
+			}
 
 			err = startNetwork(doneCh)
 			if err != nil {

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -28,6 +28,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/01org/ciao/osprepare"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp"
 	"github.com/golang/glog"
@@ -400,6 +401,8 @@ DONE:
 				cephID = clusterConfig.Configure.Storage.CephID
 			}
 			printClusterConfig()
+
+			osprepare.InstallDeps(launcherDeps)
 
 			err = startNetwork(doneCh)
 			if err != nil {

--- a/ciao-launcher/overseer_test.go
+++ b/ciao-launcher/overseer_test.go
@@ -149,6 +149,10 @@ func (v *overseerTestState) SendCommand(cmd ssntp.Command, payload []byte) (int,
 	return 0, nil
 }
 
+func (v *overseerTestState) Role() ssntp.Role {
+	return ssntp.AGENT | ssntp.NETAGENT
+}
+
 func (v *overseerTestState) UUID() string {
 	return "test-uuid"
 }

--- a/ciao-scheduler/deps.go
+++ b/ciao-scheduler/deps.go
@@ -19,13 +19,14 @@ package main
 import "github.com/01org/ciao/osprepare"
 
 var schedDeps = osprepare.PackageRequirements{
+	// no known dependencies
 	"clearlinux": {
-		{"", ""},
+		{BinaryName: "", PackageName: ""},
 	},
 	"fedora": {
-		{"", ""},
+		{BinaryName: "", PackageName: ""},
 	},
 	"ubuntu": {
-		{"", ""},
+		{BinaryName: "", PackageName: ""},
 	},
 }

--- a/ciao-scheduler/deps.go
+++ b/ciao-scheduler/deps.go
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import "github.com/01org/ciao/osprepare"
+
+var schedDeps = osprepare.PackageRequirements{
+	"clearlinux": {
+		{"", ""},
+	},
+	"fedora": {
+		{"", ""},
+	},
+	"ubuntu": {
+		{"", ""},
+	},
+}

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -26,6 +26,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/01org/ciao/osprepare"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp"
 	"github.com/golang/glog"
@@ -1041,6 +1042,7 @@ func configSchedulerServer() (sched *ssntpSchedulerServer) {
 
 func main() {
 	flag.Parse()
+	osprepare.PrepareOsDeps(nil)
 
 	sched := configSchedulerServer()
 	if sched == nil {

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -1042,7 +1042,7 @@ func configSchedulerServer() (sched *ssntpSchedulerServer) {
 
 func main() {
 	flag.Parse()
-	osprepare.PrepareOsDeps(nil)
+	osprepare.PrepareOsDeps(schedDeps)
 
 	sched := configSchedulerServer()
 	if sched == nil {

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -1042,7 +1042,7 @@ func configSchedulerServer() (sched *ssntpSchedulerServer) {
 
 func main() {
 	flag.Parse()
-	osprepare.PrepareOsDeps(schedDeps)
+	osprepare.InstallDeps(schedDeps)
 
 	sched := configSchedulerServer()
 	if sched == nil {

--- a/osprepare/README.md
+++ b/osprepare/README.md
@@ -1,0 +1,15 @@
+# osprepare
+
+osprepare is the Operating System Preparation facility of Ciao, enabling
+very simple automated configuration of dependencies between various
+Linux distributions in a sane fashion.
+
+It provides a simple mechanism for expressing system dependencies and then
+handles the OS-specific plumbing transparently.  In this way a ciao
+component can in one place articulate its dependencies and with a single
+call out get runtime confirmation that the system has the needed code,
+without having to care about the details of whether that happens via a call
+to apt or rpm or any other package/update manager software.
+
+For more detailed technical information see the [osprepare package godoc
+page](https://godoc.org/github.com/01org/ciao/osprepare).

--- a/osprepare/distro.go
+++ b/osprepare/distro.go
@@ -184,7 +184,7 @@ type distro interface {
 // getDistro will return a distro based on what
 // is read from GetOsRelease
 func getDistro() distro {
-	osRelease := GetOsRelease()
+	osRelease := getOSRelease()
 
 	if osRelease == nil {
 		return nil

--- a/osprepare/distro.go
+++ b/osprepare/distro.go
@@ -1,0 +1,268 @@
+//
+// Copyright © 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package osprepare
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+const (
+	aptSourcesList  = "/etc/apt/sources.list"
+	aptSourcesListD = "/etc/apt/sources.list.d"
+)
+
+// aptSourcesFile abstracts a source.list file into
+// a list of aptSource structs and the file where
+// those definitions are located.
+// Each apt source list may have multiple sources
+type aptSourcesFile struct {
+	Sources []*aptSource
+	Path    string
+}
+
+// aptSource struct contains all the fields
+// in an apt line in /etc/apt/sources.list
+// e.g:
+// deb|deb-src $origin $distribution $component1 $component2
+type aptSource struct {
+	DebType      string
+	Origin       string
+	Distribution string
+	Components   []string
+}
+
+// readAptSourcesFile reads a sources.list style file
+// and return an aptSourcesFile
+func readAptSourcesFile(path string) *aptSourcesFile {
+	fi, err := os.Open(path)
+
+	if err != nil {
+		return nil
+	}
+
+	ret := aptSourcesFile{Path: path}
+
+	defer fi.Close()
+	sc := bufio.NewScanner(fi)
+	for sc.Scan() {
+		line := sc.Text()
+
+		line = strings.TrimSpace(line)
+
+		// Skip blanks..
+		if len(line) < 1 {
+			continue
+		}
+
+		// Skip comment lines
+		if line[0] == '#' {
+			continue
+		}
+
+		if rs := newAptSource(line); rs != nil {
+			ret.Sources = append(ret.Sources, rs)
+		}
+		// Could warn here, but that's overkill.
+	}
+	return &ret
+}
+
+// loadAptSources reads the apt source files
+// defined by aptSourcesList and aptSourcesListD
+// returning a list of aptSourcesFile containing
+// all sources defined in the distro
+func loadAptSources() []*aptSourcesFile {
+	var sources []*aptSourcesFile
+
+	// Closure is only relevant to this function
+	addAptSources := func(path string) {
+		if r := readAptSourcesFile(path); r != nil {
+			sources = append(sources, r)
+		}
+	}
+
+	if pathExists(aptSourcesList) {
+		addAptSources(aptSourcesList)
+	}
+
+	// Glob the *.list files now
+	if pathExists(aptSourcesListD) {
+		tpath := fmt.Sprintf("%s/*.list", aptSourcesListD)
+		if files, err := filepath.Glob(tpath); err == nil {
+			for _, file := range files {
+				addAptSources(file)
+			}
+		}
+	}
+
+	return sources
+}
+
+// newAptSource constructs a new apt source from
+// the given deb style line
+func newAptSource(debLine string) *aptSource {
+	fields := strings.Fields(debLine)
+	var asource aptSource
+
+	if len(fields) < 3 {
+		return nil
+	}
+
+	dtype := fields[0]
+	if dtype != "deb" && dtype != "deb-src" {
+		return nil
+	}
+
+	asource.DebType = dtype
+	asource.Origin = fields[1]
+	asource.Distribution = fields[2]
+	if len(fields) > 3 {
+		asource.Components = fields[3:]
+	}
+
+	return &asource
+}
+
+// isUbuntuDockerRepoEnabled iterates through the sources
+// to find out if the docker repo is enabled or not.
+func isUbuntuDockerRepoEnabled() bool {
+	sources := loadAptSources()
+	if sources == nil {
+		return false
+	}
+	for _, sourceFile := range sources {
+		for _, source := range sourceFile.Sources {
+			if strings.Contains(source.Origin, "apt.dockerproject.org") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// pathExists is a helper function which handles the
+// error and simply return true or false if the given
+// path exists
+func pathExists(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	return true
+}
+
+type distro interface {
+	// InstallPackages should implement the installation
+	// of packages using distro specific methods for
+	// the given target list of items to install
+	InstallPackages(packages []string) bool
+
+	// getID should return a string specifying
+	// the distribution ID (e.g: "clearlinux")
+	getID() string
+}
+
+// getDistro will return a distro based on what
+// is read from GetOsRelease
+func getDistro() distro {
+	osRelease := GetOsRelease()
+
+	if osRelease == nil {
+		return nil
+	}
+
+	if strings.HasPrefix(osRelease.ID, "clear-linux") {
+		return &clearLinuxDistro{}
+	} else if strings.Contains(osRelease.ID, "ubuntu") {
+		// Store the Ubuntu codename, i.e. "xenial'
+		return &ubuntuDistro{CodeName: osRelease.GetValue("UBUNTU_CODENAME")}
+	} else if strings.Contains(osRelease.ID, "fedora") {
+		return &fedoraDistro{}
+	}
+	return nil
+}
+
+// os-release clear-linux*
+type clearLinuxDistro struct {
+}
+
+func (d *clearLinuxDistro) getID() string {
+	return "clearlinux"
+}
+
+// Correctly split and format the command, using sudo if appropriate, as a
+// common mechanism for the various package install functions.
+func sudoFormatCommand(command string, packages []string) bool {
+	toInstall := strings.Join(packages[0:], " ")
+
+	var executable string
+	var args string
+	splits := strings.Split(command, " ")
+
+	if syscall.Geteuid() == 0 {
+		executable = splits[0]
+		args = fmt.Sprintf(strings.Join(splits[1:], " "), toInstall)
+	} else {
+		executable = "sudo"
+		args = fmt.Sprintf(command, toInstall)
+	}
+
+	c := exec.Command(executable, strings.Split(args, " ")...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+
+	if err := c.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to run command: %s", err)
+		return false
+	}
+	return true
+}
+
+func (d *clearLinuxDistro) InstallPackages(packages []string) bool {
+	return sudoFormatCommand("swupd bundle-add %s", packages)
+}
+
+// os-release *ubuntu*
+type ubuntuDistro struct {
+	CodeName string
+}
+
+func (d *ubuntuDistro) getID() string {
+	return "ubuntu"
+}
+
+func (d *ubuntuDistro) InstallPackages(packages []string) bool {
+	return sudoFormatCommand("apt-get --yes --force-yes install %s", packages)
+}
+
+// Fedora
+type fedoraDistro struct {
+}
+
+func (d *fedoraDistro) getID() string {
+	return "fedora"
+}
+
+// Use dnf to install on Fedora
+func (d *fedoraDistro) InstallPackages(packages []string) bool {
+	return sudoFormatCommand("dnf install -y %s", packages)
+}

--- a/osprepare/distro_test.go
+++ b/osprepare/distro_test.go
@@ -1,0 +1,34 @@
+//
+// Copyright © 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package osprepare
+
+import (
+	"testing"
+)
+
+func TestGetDistro(t *testing.T) {
+	if pathExists("/usr/share/clear/bundles") == false {
+		t.Skip("Unsupported test distro")
+	}
+	d := getDistro()
+	if d == nil {
+		t.Fatal("Cannot get known distro object")
+	}
+	if d.getID() == "" {
+		t.Fatal("Invalid ID for distro")
+	}
+}

--- a/osprepare/doc.go
+++ b/osprepare/doc.go
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*
+
+osprepare is the Operating System Preparation facility of Ciao, enabling very
+simple automated configuration of dependencies between various Linux distributions
+in a sane fashion.
+
+
+Expressing Dependencies
+
+InstallDeps is used to ensure the presence of mandatory dependencies during
+the early initialization of Ciao components, and install them via the native
+package deployment system when they are absent.
+InstallDeps should be invoked with a PackageRequirements map, which is simply
+a mapping of operating system IDs to path/package pairs.
+The function may not yet support all systems, so it is expected that it should
+perform its function without any outside interference, and should never cause
+failures or require checking of returns.
+
+The PackageRequirements map (deps.go)
+
+Below is an example of a valid PackageRequirements structure.
+
+	var deps = osprepare.PackageRequirements{
+		"ubuntu": {
+			{"/usr/bin/docker", "docker"},
+		},
+		"clearlinux": {
+			{"/usr/bin/docker", "containers-basic"},
+		},
+	}
+
+As we can see, full paths to the expected locations on the filesystem are given
+for each OS, and the name of the native package or bundle to install should those
+files be missing. That is to say, if /usr/bin/docker is missing, on a system that
+has been identified as Ubuntu, then the 'docker' package would be installed.
+
+The dependencies for each component should be placed into a `deps.go` file, which
+then facilitates easier maintainence and discoverability of the dependencies for
+every component.
+
+Verified lack of dependencies
+
+Note that it is also valid to state you have *no* dependencies at all, and that
+you have verified that each distro requires no additional dependencies to be
+installed during startup. Just pass an empty pair to the distro ID:
+
+	var schedDeps = osprepare.PackageRequirements{
+		"clearlinux": {
+			{"", ""},
+		},
+		"fedora": {
+			{"", ""},
+		},
+		"ubuntu": {
+			{"", ""},
+		},
+	}
+
+Operating System Identification
+
+Operating Systems are identified via their `os-release` file, a standardized
+mechanism for identifying Linux distributions. Currently, detection is performed
+by comparison the lower-case value of the `ID` field to our known implementations,
+which are:
+
+ * clearlinux
+ * ubuntu
+ * fedora 
+
+*/
+package osprepare

--- a/osprepare/doc.go
+++ b/osprepare/doc.go
@@ -16,9 +16,9 @@
 
 /*
 
-osprepare is the Operating System Preparation facility of Ciao, enabling very
-simple automated configuration of dependencies between various Linux distributions
-in a sane fashion.
+Package osprepare is the Operating System Preparation facility of Ciao,
+enabling very simple automated configuration of dependencies between
+various Linux distributions in a sane fashion.
 
 
 Expressing Dependencies
@@ -51,7 +51,7 @@ files be missing. That is to say, if /usr/bin/docker is missing, on a system tha
 has been identified as Ubuntu, then the 'docker' package would be installed.
 
 The dependencies for each component should be placed into a `deps.go` file, which
-then facilitates easier maintainence and discoverability of the dependencies for
+then facilitates easier maintenance and discoverability of the dependencies for
 every component.
 
 Verified lack of dependencies
@@ -81,7 +81,7 @@ which are:
 
  * clearlinux
  * ubuntu
- * fedora 
+ * fedora
 
 */
 package osprepare

--- a/osprepare/main.go
+++ b/osprepare/main.go
@@ -50,7 +50,8 @@ type PackageRequirement struct {
 // )
 type PackageRequirements map[string][]*PackageRequirement
 
-// Required for absolutely core functionality across all Ciao components
+// BootstrapRequirements lists required dependencies for absolutely core
+// functionality across all Ciao components
 var BootstrapRequirements = PackageRequirements{
 	"ubuntu": {
 		{"/usr/bin/cephfs", "ceph-fs-common"},
@@ -92,7 +93,7 @@ func PrepareOsDeps(reqs PackageRequirements) {
 
 	if distro == nil {
 		fmt.Fprintf(os.Stderr, "Running on an unsupported distro\n")
-		if rel := GetOsRelease(); rel != nil {
+		if rel := getOSRelease(); rel != nil {
 			fmt.Fprintf(os.Stderr, "Unsupported distro: %s %s\n", rel.Name, rel.Version)
 		} else {
 			fmt.Fprintln(os.Stderr, "No os-release found on this host")

--- a/osprepare/main.go
+++ b/osprepare/main.go
@@ -63,7 +63,7 @@ var BootstrapRequirements = PackageRequirements{
 
 // CollectPackages returns a list of non-installed packages from
 // the PackageRequirements received
-func collectPackages(dist distro, reqs *PackageRequirements) []string {
+func collectPackages(dist distro, reqs PackageRequirements) []string {
 	// For now just support keys like "ubuntu" vs "ubuntu:16.04"
 	var pkgsMissing []string
 	if reqs == nil {
@@ -71,7 +71,7 @@ func collectPackages(dist distro, reqs *PackageRequirements) []string {
 	}
 
 	id := dist.getID()
-	if pkgs, success := (*reqs)[id]; success {
+	if pkgs, success := reqs[id]; success {
 		for _, pkg := range pkgs {
 			// Have the path existing, skip.
 			if pathExists(pkg.BinaryName) {
@@ -85,9 +85,9 @@ func collectPackages(dist distro, reqs *PackageRequirements) []string {
 	return nil
 }
 
-// PrepareOsDeps installs all the dependencies defined in
-// PackageRequirements in order to run the ciao component
-func PrepareOsDeps(reqs *PackageRequirements) {
+// PrepareOsDeps installs all the dependencies defined in a component
+// specific PackageRequirements in order to enable running the component
+func PrepareOsDeps(reqs PackageRequirements) {
 	distro := getDistro()
 
 	if distro == nil {
@@ -113,5 +113,5 @@ func PrepareOsDeps(reqs *PackageRequirements) {
 // Bootstrap installs all the core dependencies required to bootstrap the core
 // configuration of all Ciao components
 func Bootstrap() {
-	PrepareOsDeps(&BootstrapRequirements)
+	PrepareOsDeps(BootstrapRequirements)
 }

--- a/osprepare/main.go
+++ b/osprepare/main.go
@@ -74,6 +74,11 @@ func collectPackages(dist distro, reqs PackageRequirements) []string {
 	id := dist.getID()
 	if pkgs, success := reqs[id]; success {
 		for _, pkg := range pkgs {
+			// skip empties
+			if pkg.BinaryName == "" || pkg.PackageName == "" {
+				continue
+			}
+
 			// Have the path existing, skip.
 			if pathExists(pkg.BinaryName) {
 				continue

--- a/osprepare/main.go
+++ b/osprepare/main.go
@@ -57,6 +57,10 @@ var BootstrapRequirements = PackageRequirements{
 		{"/usr/bin/cephfs", "ceph-fs-common"},
 		{"/usr/bin/ceph", "ceph-common"},
 	},
+	"fedora": {
+		{"/usr/bin/cephfs", "ceph"},
+		{"/usr/bin/ceph", "ceph-common"},
+	},
 	"clearlinux": {
 		{"/usr/bin/ceph", "storage-cluster"},
 	},

--- a/osprepare/main.go
+++ b/osprepare/main.go
@@ -86,9 +86,9 @@ func collectPackages(dist distro, reqs PackageRequirements) []string {
 	return nil
 }
 
-// PrepareOsDeps installs all the dependencies defined in a component
+// InstallDeps installs all the dependencies defined in a component
 // specific PackageRequirements in order to enable running the component
-func PrepareOsDeps(reqs PackageRequirements) {
+func InstallDeps(reqs PackageRequirements) {
 	distro := getDistro()
 
 	if distro == nil {
@@ -114,5 +114,5 @@ func PrepareOsDeps(reqs PackageRequirements) {
 // Bootstrap installs all the core dependencies required to bootstrap the core
 // configuration of all Ciao components
 func Bootstrap() {
-	PrepareOsDeps(BootstrapRequirements)
+	InstallDeps(BootstrapRequirements)
 }

--- a/osprepare/main.go
+++ b/osprepare/main.go
@@ -1,0 +1,99 @@
+//
+// Copyright © 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package osprepare
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Minimal versions supported by ciao
+const (
+	MinDockerVersion = "1.11.0"
+	MinQemuVersion   = "2.5.0"
+)
+
+// PackageRequirement contains the BinaryName expected to
+// exist on the filesystem once PackageName is installed
+// (e.g: { '/usr/bin/qemu-system-x86_64', 'qemu'})
+type PackageRequirement struct {
+	BinaryName  string
+	PackageName string
+}
+
+// PackageRequirements type allows to create complex
+// mapping to group a set of PackageRequirement to a single
+// key.
+// (e.g:
+//
+//	"ubuntu": {
+//		{"/usr/bin/docker", "docker"},
+//	},
+//	"clearlinux": {
+//		{"/usr/bin/docker", "containers-basic"},
+//	},
+// )
+type PackageRequirements map[string][]*PackageRequirement
+
+// CollectPackages returns a list of non-installed packages from
+// the PackageRequirements received
+func collectPackages(dist distro, reqs *PackageRequirements) []string {
+	// For now just support keys like "ubuntu" vs "ubuntu:16.04"
+	var pkgsMissing []string
+	if reqs == nil {
+		return nil
+	}
+
+	id := dist.getID()
+	if pkgs, success := (*reqs)[id]; success {
+		for _, pkg := range pkgs {
+			// Have the path existing, skip.
+			if pathExists(pkg.BinaryName) {
+				continue
+			}
+			// Mark the package for installation
+			pkgsMissing = append(pkgsMissing, pkg.PackageName)
+		}
+		return pkgsMissing
+	}
+	return nil
+}
+
+// PrepareCIAO installs all the dependencies defined in
+// PackageRequirements in order to run the ciao component
+func PrepareCIAO(reqs *PackageRequirements) bool {
+	distro := getDistro()
+
+	if distro == nil {
+		fmt.Fprintf(os.Stderr, "Running on an unsupported distro\n")
+		if rel := GetOsRelease(); rel != nil {
+			fmt.Fprintf(os.Stderr, "Unsupported distro: %s %s\n", rel.Name, rel.Version)
+		} else {
+			fmt.Fprintln(os.Stderr, "No os-release found on this host")
+		}
+		return false
+	}
+	fmt.Println(distro.getID())
+	if reqPkgs := collectPackages(distro, reqs); reqPkgs != nil {
+		if distro.InstallPackages(reqPkgs) == false {
+			fmt.Fprintf(os.Stderr, "Failed to install: %s\n", strings.Join(reqPkgs, ", "))
+			return false
+		}
+	}
+	return true
+}

--- a/osprepare/main.go
+++ b/osprepare/main.go
@@ -74,9 +74,9 @@ func collectPackages(dist distro, reqs *PackageRequirements) []string {
 	return nil
 }
 
-// PrepareCIAO installs all the dependencies defined in
+// PrepareOsDeps installs all the dependencies defined in
 // PackageRequirements in order to run the ciao component
-func PrepareCIAO(reqs *PackageRequirements) bool {
+func PrepareOsDeps(reqs *PackageRequirements) {
 	distro := getDistro()
 
 	if distro == nil {
@@ -86,14 +86,15 @@ func PrepareCIAO(reqs *PackageRequirements) bool {
 		} else {
 			fmt.Fprintln(os.Stderr, "No os-release found on this host")
 		}
-		return false
+		return
 	}
-	fmt.Println(distro.getID())
+	// Nothing requested to install
+	if reqs == nil {
+		return
+	}
 	if reqPkgs := collectPackages(distro, reqs); reqPkgs != nil {
 		if distro.InstallPackages(reqPkgs) == false {
 			fmt.Fprintf(os.Stderr, "Failed to install: %s\n", strings.Join(reqPkgs, ", "))
-			return false
 		}
 	}
-	return true
 }

--- a/osprepare/main.go
+++ b/osprepare/main.go
@@ -48,7 +48,7 @@ type PackageRequirement struct {
 //		{"/usr/bin/docker", "containers-basic"},
 //	},
 // )
-type PackageRequirements map[string][]*PackageRequirement
+type PackageRequirements map[string][]PackageRequirement
 
 // BootstrapRequirements lists required dependencies for absolutely core
 // functionality across all Ciao components

--- a/osprepare/main.go
+++ b/osprepare/main.go
@@ -50,6 +50,17 @@ type PackageRequirement struct {
 // )
 type PackageRequirements map[string][]*PackageRequirement
 
+// Required for absolutely core functionality across all Ciao components
+var BootstrapRequirements = PackageRequirements{
+	"ubuntu": {
+		{"/usr/bin/cephfs", "ceph-fs-common"},
+		{"/usr/bin/ceph", "ceph-common"},
+	},
+	"clearlinux": {
+		{"/usr/bin/ceph", "storage-cluster"},
+	},
+}
+
 // CollectPackages returns a list of non-installed packages from
 // the PackageRequirements received
 func collectPackages(dist distro, reqs *PackageRequirements) []string {
@@ -97,4 +108,10 @@ func PrepareOsDeps(reqs *PackageRequirements) {
 			fmt.Fprintf(os.Stderr, "Failed to install: %s\n", strings.Join(reqPkgs, ", "))
 		}
 	}
+}
+
+// Bootstrap installs all the core dependencies required to bootstrap the core
+// configuration of all Ciao components
+func Bootstrap() {
+	PrepareOsDeps(&BootstrapRequirements)
 }

--- a/osprepare/os_release.go
+++ b/osprepare/os_release.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 )
 
-type OsRelease struct {
+type osRelease struct {
 	Name       string
 	ID         string
 	PrettyName string
@@ -33,10 +33,10 @@ type OsRelease struct {
 
 // Parse the given path and attempt to return a valid
 // OsRelease for it
-func ParseReleaseFile(path string) *OsRelease {
+func parseReleaseFile(path string) *osRelease {
 	fi, err := os.Open(path)
-	var os_rel OsRelease
-	os_rel.mapping = make(map[string]string)
+	var r osRelease
+	r.mapping = make(map[string]string)
 
 	if err != nil {
 		return nil
@@ -57,25 +57,25 @@ func ParseReleaseFile(path string) *OsRelease {
 		value = strings.Replace(value, "'", "", -1)
 
 		if key == "name" {
-			os_rel.Name = value
+			r.Name = value
 		} else if key == "id" {
-			os_rel.ID = value
+			r.ID = value
 		} else if key == "pretty_name" {
-			os_rel.PrettyName = value
+			r.PrettyName = value
 		} else if key == "version" {
-			os_rel.Version = value
+			r.Version = value
 		} else if key == "version_id" {
-			os_rel.VersionID = value
+			r.VersionID = value
 		}
 
 		// Store it for use by Distro
-		os_rel.mapping[key] = value
+		r.mapping[key] = value
 	}
-	return &os_rel
+	return &r
 }
 
 // Try all known paths to get the right OsRelease instance
-func GetOsRelease() *OsRelease {
+func getOSRelease() *osRelease {
 	paths := []string{
 		"/etc/os-release",
 		"/usr/lib/os-release",
@@ -83,14 +83,14 @@ func GetOsRelease() *OsRelease {
 	}
 
 	for _, item := range paths {
-		if os_rel := ParseReleaseFile(item); os_rel != nil {
-			return os_rel
+		if r := parseReleaseFile(item); r != nil {
+			return r
 		}
 	}
 	return nil
 }
 
-func (o *OsRelease) GetValue(key string) string {
+func (o *osRelease) GetValue(key string) string {
 	if val, succ := o.mapping[strings.ToLower(key)]; succ {
 		return val
 	}

--- a/osprepare/os_release.go
+++ b/osprepare/os_release.go
@@ -1,0 +1,98 @@
+//
+// Copyright © 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package osprepare
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+type OsRelease struct {
+	Name       string
+	ID         string
+	PrettyName string
+	Version    string
+	VersionID  string
+	mapping    map[string]string
+}
+
+// Parse the given path and attempt to return a valid
+// OsRelease for it
+func ParseReleaseFile(path string) *OsRelease {
+	fi, err := os.Open(path)
+	var os_rel OsRelease
+	os_rel.mapping = make(map[string]string)
+
+	if err != nil {
+		return nil
+	}
+	defer fi.Close()
+	sc := bufio.NewScanner(fi)
+	for sc.Scan() {
+		line := sc.Text()
+
+		spl := strings.Split(line, "=")
+		if len(spl) < 2 {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(spl[0]))
+		value := strings.TrimSpace(strings.Join(spl[1:], "="))
+
+		value = strings.Replace(value, "\"", "", -1)
+		value = strings.Replace(value, "'", "", -1)
+
+		if key == "name" {
+			os_rel.Name = value
+		} else if key == "id" {
+			os_rel.ID = value
+		} else if key == "pretty_name" {
+			os_rel.PrettyName = value
+		} else if key == "version" {
+			os_rel.Version = value
+		} else if key == "version_id" {
+			os_rel.VersionID = value
+		}
+
+		// Store it for use by Distro
+		os_rel.mapping[key] = value
+	}
+	return &os_rel
+}
+
+// Try all known paths to get the right OsRelease instance
+func GetOsRelease() *OsRelease {
+	paths := []string{
+		"/etc/os-release",
+		"/usr/lib/os-release",
+		"/usr/lib64/os-release",
+	}
+
+	for _, item := range paths {
+		if os_rel := ParseReleaseFile(item); os_rel != nil {
+			return os_rel
+		}
+	}
+	return nil
+}
+
+func (o *OsRelease) GetValue(key string) string {
+	if val, succ := o.mapping[strings.ToLower(key)]; succ {
+		return val
+	}
+	return ""
+}

--- a/osprepare/os_release_test.go
+++ b/osprepare/os_release_test.go
@@ -1,0 +1,50 @@
+//
+// Copyright © 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package osprepare
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	NON_EXISTENT_FILE = "/nonexistentpath/this/file/doesnt/exists"
+)
+
+func TestGetOsRelease(t *testing.T) {
+	d := getDistro()
+	if d == nil {
+		t.Skip("Unknown distro, cannot test")
+	}
+	os_rel := GetOsRelease()
+	if os_rel == nil {
+		t.Fatal("Could not get os-release file for known distro")
+	}
+	if d.getID() == "clearlinux" && !strings.Contains(os_rel.ID, "clear") {
+		t.Fatal("Invalid os-release for clearlinux")
+	} else if d.getID() == "ubuntu" && !strings.Contains(os_rel.ID, "ubuntu") {
+		t.Fatal("Invalid os-release for Ubuntu")
+	} else if d.getID() == "fedora" && !strings.Contains(os_rel.ID, "fedora") {
+		t.Fatal("Invalid os-release for Fedora")
+	}
+}
+
+func TestParseReleaseFileNonExistent(t *testing.T) {
+	if res := ParseReleaseFile(NON_EXISTENT_FILE); res != nil {
+		t.Fatal("Expected nil, got %v\n", res)
+	}
+}

--- a/osprepare/os_release_test.go
+++ b/osprepare/os_release_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	nonExistentFile = "/nonexistentpath/this/file/doesnt/exists"
+	nonExistentFile = "/nonexistentpath/this/file/doesnot/exists"
 )
 
 func TestGetOsRelease(t *testing.T) {

--- a/osprepare/os_release_test.go
+++ b/osprepare/os_release_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	NON_EXISTENT_FILE = "/nonexistentpath/this/file/doesnt/exists"
+	nonExistentFile = "/nonexistentpath/this/file/doesnt/exists"
 )
 
 func TestGetOsRelease(t *testing.T) {
@@ -30,21 +30,21 @@ func TestGetOsRelease(t *testing.T) {
 	if d == nil {
 		t.Skip("Unknown distro, cannot test")
 	}
-	os_rel := GetOsRelease()
-	if os_rel == nil {
+	r := getOSRelease()
+	if r == nil {
 		t.Fatal("Could not get os-release file for known distro")
 	}
-	if d.getID() == "clearlinux" && !strings.Contains(os_rel.ID, "clear") {
+	if d.getID() == "clearlinux" && !strings.Contains(r.ID, "clear") {
 		t.Fatal("Invalid os-release for clearlinux")
-	} else if d.getID() == "ubuntu" && !strings.Contains(os_rel.ID, "ubuntu") {
+	} else if d.getID() == "ubuntu" && !strings.Contains(r.ID, "ubuntu") {
 		t.Fatal("Invalid os-release for Ubuntu")
-	} else if d.getID() == "fedora" && !strings.Contains(os_rel.ID, "fedora") {
+	} else if d.getID() == "fedora" && !strings.Contains(r.ID, "fedora") {
 		t.Fatal("Invalid os-release for Fedora")
 	}
 }
 
 func TestParseReleaseFileNonExistent(t *testing.T) {
-	if res := ParseReleaseFile(NON_EXISTENT_FILE); res != nil {
+	if res := parseReleaseFile(nonExistentFile); res != nil {
 		t.Fatalf("Expected nil, got %v\n", res)
 	}
 }

--- a/osprepare/os_release_test.go
+++ b/osprepare/os_release_test.go
@@ -45,6 +45,6 @@ func TestGetOsRelease(t *testing.T) {
 
 func TestParseReleaseFileNonExistent(t *testing.T) {
 	if res := ParseReleaseFile(NON_EXISTENT_FILE); res != nil {
-		t.Fatal("Expected nil, got %v\n", res)
+		t.Fatalf("Expected nil, got %v\n", res)
 	}
 }

--- a/osprepare/versions.go
+++ b/osprepare/versions.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 )
 
-func get_command_output(command string) string {
+func getCommandOutput(command string) string {
 	splits := strings.Split(command, " ")
 	c := exec.Command(splits[0], splits[1:]...)
 	c.Env = os.Environ()
@@ -33,73 +33,77 @@ func get_command_output(command string) string {
 	c.Env = append(c.Env, "LANG=C")
 	c.Stderr = os.Stderr
 
-	if out, err := c.Output(); err != nil {
+	out, err := c.Output()
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to run %s: %s\n", splits[0], err)
 		return ""
-	} else {
-		return string(out)
 	}
+
+	return string(out)
 }
 
-func GetDockerVersion() string {
-	ret := get_command_output("docker --version")
+func getDockerVersion() string {
+	ret := getCommandOutput("docker --version")
 	var version string
+
 	if n, _ := fmt.Sscanf(ret, "Docker version %s, build", &version); n != 1 {
 		return ""
-	} else {
-		if strings.HasSuffix(version, ",") {
-			return string(version[0 : len(version)-1])
-		}
-		return version
 	}
+
+	if strings.HasSuffix(version, ",") {
+		return string(version[0 : len(version)-1])
+	}
+	return version
 }
 
-func GetQemuVersion() string {
-	ret := get_command_output("qemu-system-x86_64 --version")
+func getQemuVersion() string {
+	ret := getCommandOutput("qemu-system-x86_64 --version")
 	var version string
+
 	if n, _ := fmt.Sscanf(ret, "QEMU emulator version %s, Copyright (c)", &version); n != 1 {
 		return ""
-	} else {
-		if strings.HasSuffix(version, ",") {
-			return string(version[0 : len(version)-1])
-		}
-		return version
 	}
+
+	if strings.HasSuffix(version, ",") {
+		return string(version[0 : len(version)-1])
+	}
+	return version
 }
 
 // Determine if the given current version is less than the test version
 // Note: Can only compare equal version schemas (i.e. same level of dots)
-func VersionLessThan(current_version string, test_version string) bool {
-	cur_splits := strings.Split(current_version, ".")
-	test_splits := strings.Split(test_version, ".")
+func versionLessThan(currentVer string, testVer string) bool {
+	curSplits := strings.Split(currentVer, ".")
+	testSplits := strings.Split(testVer, ".")
 
-	max_range := len(cur_splits)
-	if l2 := len(test_splits); l2 < max_range {
-		max_range = l2
+	max := len(curSplits)
+
+	if l2 := len(testSplits); l2 < max {
+		max = l2
 	}
 
-	cur_isplits := make([]int, max_range)
-	cur_tsplits := make([]int, max_range)
+	iSplits := make([]int, max)
+	tSplits := make([]int, max)
 
-	for i := 0; i < max_range; i++ {
-		cur_isplits[i], _ = strconv.Atoi(cur_splits[i])
-		cur_tsplits[i], _ = strconv.Atoi(test_splits[i])
+	for i := 0; i < max; i++ {
+		iSplits[i], _ = strconv.Atoi(curSplits[i])
+		tSplits[i], _ = strconv.Atoi(testSplits[i])
 	}
 
-	for i := 0; i < max_range; i++ {
+	for i := 0; i < max; i++ {
 		if i == 0 {
-			if cur_isplits[i] < cur_tsplits[i] {
+			if iSplits[i] < tSplits[i] {
 				return true
 			}
 		} else {
 			match := true
 			for j := 0; j < i; j++ {
-				if cur_isplits[j] != cur_tsplits[j] {
+				if iSplits[j] != tSplits[j] {
 					match = false
 					break
 				}
 			}
-			if match && cur_isplits[i] < cur_tsplits[i] {
+			if match && iSplits[i] < tSplits[i] {
 				return true
 			}
 		}

--- a/osprepare/versions.go
+++ b/osprepare/versions.go
@@ -1,0 +1,108 @@
+//
+// Copyright © 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package osprepare
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func get_command_output(command string) string {
+	splits := strings.Split(command, " ")
+	c := exec.Command(splits[0], splits[1:]...)
+	c.Env = os.Environ()
+	// Force C locale
+	c.Env = append(c.Env, "LC_ALL=C")
+	c.Env = append(c.Env, "LANG=C")
+	c.Stderr = os.Stderr
+
+	if out, err := c.Output(); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to run %s: %s\n", splits[0], err)
+		return ""
+	} else {
+		return string(out)
+	}
+}
+
+func GetDockerVersion() string {
+	ret := get_command_output("docker --version")
+	var version string
+	if n, _ := fmt.Sscanf(ret, "Docker version %s, build", &version); n != 1 {
+		return ""
+	} else {
+		if strings.HasSuffix(version, ",") {
+			return string(version[0 : len(version)-1])
+		}
+		return version
+	}
+}
+
+func GetQemuVersion() string {
+	ret := get_command_output("qemu-system-x86_64 --version")
+	var version string
+	if n, _ := fmt.Sscanf(ret, "QEMU emulator version %s, Copyright (c)", &version); n != 1 {
+		return ""
+	} else {
+		if strings.HasSuffix(version, ",") {
+			return string(version[0 : len(version)-1])
+		}
+		return version
+	}
+}
+
+// Determine if the given current version is less than the test version
+// Note: Can only compare equal version schemas (i.e. same level of dots)
+func VersionLessThan(current_version string, test_version string) bool {
+	cur_splits := strings.Split(current_version, ".")
+	test_splits := strings.Split(test_version, ".")
+
+	max_range := len(cur_splits)
+	if l2 := len(test_splits); l2 < max_range {
+		max_range = l2
+	}
+
+	cur_isplits := make([]int, max_range)
+	cur_tsplits := make([]int, max_range)
+
+	for i := 0; i < max_range; i++ {
+		cur_isplits[i], _ = strconv.Atoi(cur_splits[i])
+		cur_tsplits[i], _ = strconv.Atoi(test_splits[i])
+	}
+
+	for i := 0; i < max_range; i++ {
+		if i == 0 {
+			if cur_isplits[i] < cur_tsplits[i] {
+				return true
+			}
+		} else {
+			match := true
+			for j := 0; j < i; j++ {
+				if cur_isplits[j] != cur_tsplits[j] {
+					match = false
+					break
+				}
+			}
+			if match && cur_isplits[i] < cur_tsplits[i] {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/osprepare/versions_test.go
+++ b/osprepare/versions_test.go
@@ -1,0 +1,66 @@
+//
+// Copyright © 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package osprepare
+
+import (
+	"testing"
+)
+
+func TestGetDocker(t *testing.T) {
+	if pathExists("/usr/bin/docker") == false {
+		t.Skip("Docker not installed, cannot validate version get")
+	}
+	if vers := GetDockerVersion(); vers == "" {
+		t.Fatal("Cannot determine docker version")
+	}
+}
+
+func TestGetQemu(t *testing.T) {
+	if pathExists("/usr/bin/qemu-system-x86_64") == false {
+		t.Skip("Qemu not installed, cannot validate version get")
+	}
+	if vers := GetQemuVersion(); vers == "" {
+		t.Fatal("Cannot determine qemu version")
+	}
+}
+
+// TestVersionLessThanEqualVersion tests than VersionLessThan returns
+// false when given same version to tests. e.g: VersionLessThan("1.11.0", "1.11.0")
+// this tests is expected to pass
+func TestVersionLessThanEqualVersion(t *testing.T) {
+	if res := VersionLessThan(MinQemuVersion, MinQemuVersion); res != false {
+		t.Fatal("expected false, got %v\n", res)
+	}
+}
+
+// TestVersionLessThanGreaterVersion tests than VersionLessThan returns
+// false when given greater version. e.g: VersionLessThan("1.11.0", "0.0.1")
+// this tests is expected to pass
+func TestVersionLessThanGreaterVersion(t *testing.T) {
+	if res := VersionLessThan(MinQemuVersion, "0.0.1"); res != false {
+		t.Fatal("expected false, got %v\n", res)
+	}
+}
+
+// TestVersionLessThanLowerVersion tests than VersionLessThan returns
+// true when given lower version. e.g: VersionLessThan("0.0.1", "99.9.9")
+// this tests is expected to pass
+func TestVersionLessThanLowerVersion(t *testing.T) {
+	if res := VersionLessThan("0.0.1", MinQemuVersion); res != true {
+		t.Fatal("expected true, got %v\n", res)
+	}
+}

--- a/osprepare/versions_test.go
+++ b/osprepare/versions_test.go
@@ -43,7 +43,7 @@ func TestGetQemu(t *testing.T) {
 // this tests is expected to pass
 func TestVersionLessThanEqualVersion(t *testing.T) {
 	if res := VersionLessThan(MinQemuVersion, MinQemuVersion); res != false {
-		t.Fatal("expected false, got %v\n", res)
+		t.Fatalf("expected false, got %v\n", res)
 	}
 }
 
@@ -52,7 +52,7 @@ func TestVersionLessThanEqualVersion(t *testing.T) {
 // this tests is expected to pass
 func TestVersionLessThanGreaterVersion(t *testing.T) {
 	if res := VersionLessThan(MinQemuVersion, "0.0.1"); res != false {
-		t.Fatal("expected false, got %v\n", res)
+		t.Fatalf("expected false, got %v\n", res)
 	}
 }
 
@@ -61,6 +61,6 @@ func TestVersionLessThanGreaterVersion(t *testing.T) {
 // this tests is expected to pass
 func TestVersionLessThanLowerVersion(t *testing.T) {
 	if res := VersionLessThan("0.0.1", MinQemuVersion); res != true {
-		t.Fatal("expected true, got %v\n", res)
+		t.Fatalf("expected true, got %v\n", res)
 	}
 }

--- a/osprepare/versions_test.go
+++ b/osprepare/versions_test.go
@@ -24,7 +24,7 @@ func TestGetDocker(t *testing.T) {
 	if pathExists("/usr/bin/docker") == false {
 		t.Skip("Docker not installed, cannot validate version get")
 	}
-	if vers := GetDockerVersion(); vers == "" {
+	if vers := getDockerVersion(); vers == "" {
 		t.Fatal("Cannot determine docker version")
 	}
 }
@@ -33,7 +33,7 @@ func TestGetQemu(t *testing.T) {
 	if pathExists("/usr/bin/qemu-system-x86_64") == false {
 		t.Skip("Qemu not installed, cannot validate version get")
 	}
-	if vers := GetQemuVersion(); vers == "" {
+	if vers := getQemuVersion(); vers == "" {
 		t.Fatal("Cannot determine qemu version")
 	}
 }
@@ -42,7 +42,7 @@ func TestGetQemu(t *testing.T) {
 // false when given same version to tests. e.g: VersionLessThan("1.11.0", "1.11.0")
 // this tests is expected to pass
 func TestVersionLessThanEqualVersion(t *testing.T) {
-	if res := VersionLessThan(MinQemuVersion, MinQemuVersion); res != false {
+	if res := versionLessThan(MinQemuVersion, MinQemuVersion); res != false {
 		t.Fatalf("expected false, got %v\n", res)
 	}
 }
@@ -51,7 +51,7 @@ func TestVersionLessThanEqualVersion(t *testing.T) {
 // false when given greater version. e.g: VersionLessThan("1.11.0", "0.0.1")
 // this tests is expected to pass
 func TestVersionLessThanGreaterVersion(t *testing.T) {
-	if res := VersionLessThan(MinQemuVersion, "0.0.1"); res != false {
+	if res := versionLessThan(MinQemuVersion, "0.0.1"); res != false {
 		t.Fatalf("expected false, got %v\n", res)
 	}
 }
@@ -60,7 +60,7 @@ func TestVersionLessThanGreaterVersion(t *testing.T) {
 // true when given lower version. e.g: VersionLessThan("0.0.1", "99.9.9")
 // this tests is expected to pass
 func TestVersionLessThanLowerVersion(t *testing.T) {
-	if res := VersionLessThan("0.0.1", MinQemuVersion); res != true {
+	if res := versionLessThan("0.0.1", MinQemuVersion); res != true {
 		t.Fatalf("expected true, got %v\n", res)
 	}
 }

--- a/ssntp/client.go
+++ b/ssntp/client.go
@@ -482,6 +482,11 @@ func (client *Client) SendTracedError(error Error, payload []byte, trace *TraceC
 	return client.sendError(error, payload, trace)
 }
 
+// Role exports the SSNTP client role.
+func (client *Client) Role() Role {
+	return client.role
+}
+
 // UUID exports the SSNTP client Universally Unique ID.
 func (client *Client) UUID() string {
 	return client.uuid.String()


### PR DESCRIPTION
@ikeydoherty started hacking up some code to make our documentation, deployment and ansible scripting easier.  The idea is that our components' binaries articulate their system dependencies, instead of the documentation and scripting.  Then at runtime the osprepare package's helper code detects the running OS and automatically installs the dependencies if they're not present.  This PR includes the ciao osprepare package, some cleanup to make our CI happy, and initial usage in controller, launcher and scheduler.

Still to do is adding plumbing to check that a particular version is present (eg: docker >= 1.12).  Also I wonder if we need to condition the call to osprepare.InstallDeps() in launcher to allow a network node to check for and install additional dependencies and am hoping @markdryan and @mcastelino can offer guidance there.