### PR TITLE
Kaccardi/topic/storage

### DIFF
--- a/ciao-launcher/image.go
+++ b/ciao-launcher/image.go
@@ -44,7 +44,7 @@ func init() {
 // qemu parameter.  In the future we might add imageInfo back to the virtualiser
 // interface.
 
-func getMinImageSize(vm *qemu, imagePath string) (minSizeMB int, err error) {
+func getMinImageSize(vm *qemuV, imagePath string) (minSizeMB int, err error) {
 	imagesMap.Lock()
 	info := imagesMap.images[imagePath]
 	if info == nil {

--- a/ciao-launcher/instance.go
+++ b/ciao-launcher/instance.go
@@ -396,7 +396,7 @@ func startInstance(instance string, cfg *vmConfig, wg *sync.WaitGroup, doneCh ch
 	} else if cfg.Container {
 		vm = &docker{}
 	} else {
-		vm = &qemu{}
+		vm = &qemuV{}
 	}
 	return startInstanceWithVM(instance, cfg, wg, doneCh, ac, ovsCh, vm,
 		storage.CephDriver{

--- a/ciao-launcher/qemu.go
+++ b/ciao-launcher/qemu.go
@@ -20,10 +20,8 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"html/template"
 	"io"
 	"io/ioutil"
-	"net"
 	"os"
 	"os/exec"
 	"path"
@@ -33,6 +31,9 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/net/context"
+
+	"github.com/01org/ciao/qemu"
 	"github.com/golang/glog"
 )
 
@@ -43,81 +44,33 @@ const (
 	vcTries    = 10
 )
 
-const attachVolumeDriveTemplateString = `
-{
-    "execute": "blockdev-add",
-    "arguments": {
-        "options": {
-            "driver": "raw",
-            "file": {
-                "driver": "file",
-                "filename": "{{.Device}}"
-            },
-            "id": "drive_{{.VolumeUUID}}"
-        }
-    }
-}
-`
+type qmpGlogLogger struct{}
 
-const attachVolumeDeviceTemplateString = `
-{
-    "execute": "device_add",
-    "arguments": {
-        "drive": "drive_{{.VolumeUUID}}",
-        "driver": "virtio-blk-pci",
-        "id": "device_{{.VolumeUUID}}"
-    }
+func (l qmpGlogLogger) V(level int32) bool {
+	return bool(glog.V(glog.Level(level)))
 }
-`
 
-const detachVolumeDriveTemplateString = `
-{
-    "execute": "x-blockdev-del",
-    "arguments": {
-        "id": "drive_{{.VolumeUUID}}"
-    }
+func (l qmpGlogLogger) Infof(format string, v ...interface{}) {
+	glog.InfoDepth(2, fmt.Sprintf(format, v...))
 }
-`
 
-const detachVolumeDeviceTemplateString = `
-{
-    "execute": "device_del",
-    "arguments": {
-        "id": "device_{{.VolumeUUID}}"
-    }
+func (l qmpGlogLogger) Warningf(format string, v ...interface{}) {
+	glog.WarningDepth(2, fmt.Sprintf(format, v...))
 }
-`
+
+func (l qmpGlogLogger) Errorf(format string, v ...interface{}) {
+	glog.ErrorDepth(2, fmt.Sprintf(format, v...))
+}
 
 var virtualSizeRegexp *regexp.Regexp
 var pssRegexp *regexp.Regexp
-var attachVolumeDriveTemplate *template.Template
-var attachVolumeDeviceTemplate *template.Template
-var detachVolumeDriveTemplate *template.Template
-var detachVolumeDeviceTemplate *template.Template
 
 func init() {
 	virtualSizeRegexp = regexp.MustCompile(`virtual size:.*\(([0-9]+) bytes\)`)
 	pssRegexp = regexp.MustCompile(`^Pss:\s*([0-9]+)`)
-	var err error
-	attachVolumeDriveTemplate, err = template.New("attachVolumeDriveTemplate").Parse(attachVolumeDriveTemplateString)
-	if err != nil {
-		panic(err)
-	}
-	attachVolumeDeviceTemplate, err = template.New("attachVolumeDeviceTemplate").Parse(attachVolumeDeviceTemplateString)
-	if err != nil {
-		panic(err)
-	}
-	detachVolumeDriveTemplate, err = template.New("detachVolumeDriveTemplate").Parse(detachVolumeDriveTemplateString)
-	if err != nil {
-		panic(err)
-	}
-	detachVolumeDeviceTemplate, err = template.New("detachVolumeDeviceTemplate").Parse(detachVolumeDeviceTemplateString)
-	if err != nil {
-		panic(err)
-	}
 }
 
-type qemu struct {
+type qemuV struct {
 	cfg            *vmConfig
 	instanceDir    string
 	vcPort         int
@@ -127,7 +80,7 @@ type qemu struct {
 	isoPath        string
 }
 
-func (q *qemu) init(cfg *vmConfig, instanceDir string) {
+func (q *qemuV) init(cfg *vmConfig, instanceDir string) {
 	q.cfg = cfg
 	q.instanceDir = instanceDir
 	q.isoPath = path.Join(instanceDir, seedImage)
@@ -172,7 +125,7 @@ func extractImageInfo(r io.Reader) int {
 	return imageSizeMB
 }
 
-func (q *qemu) imageInfo(imagePath string) (int, error) {
+func (q *qemuV) imageInfo(imagePath string) (int, error) {
 	params := make([]string, 0, 8)
 	params = append(params, "info")
 	params = append(params, imagePath)
@@ -252,7 +205,7 @@ func createCloudInitISO(instanceDir, isoPath string, cfg *vmConfig, userData, me
 	return nil
 }
 
-func (q *qemu) createRootfs() error {
+func (q *qemuV) createRootfs() error {
 	vmImage := path.Join(q.instanceDir, "image.qcow2")
 	backingImage := path.Join(imagesPath, q.cfg.Image)
 	glog.Infof("Creating qcow image from %s backing %s", vmImage, backingImage)
@@ -269,7 +222,7 @@ func (q *qemu) createRootfs() error {
 	return cmd.Run()
 }
 
-func (q *qemu) checkBackingImage() error {
+func (q *qemuV) checkBackingImage() error {
 	backingImage := path.Join(imagesPath, q.cfg.Image)
 	_, err := os.Stat(backingImage)
 	if err != nil {
@@ -291,11 +244,11 @@ func (q *qemu) checkBackingImage() error {
 	return nil
 }
 
-func (q *qemu) downloadBackingImage() error {
+func (q *qemuV) downloadBackingImage() error {
 	return fmt.Errorf("Not supported yet!")
 }
 
-func (q *qemu) createImage(bridge string, userData, metaData []byte) error {
+func (q *qemuV) createImage(bridge string, userData, metaData []byte) error {
 	err := createCloudInitISO(q.instanceDir, q.isoPath, q.cfg, userData, metaData)
 	if err != nil {
 		glog.Errorf("Unable to create iso image %v", err)
@@ -305,7 +258,7 @@ func (q *qemu) createImage(bridge string, userData, metaData []byte) error {
 	return q.createRootfs()
 }
 
-func (q *qemu) deleteImage() error {
+func (q *qemuV) deleteImage() error {
 	return nil
 }
 
@@ -518,7 +471,7 @@ func generateQEMULaunchParams(cfg *vmConfig, isoPath, instanceDir string, networ
 	return params
 }
 
-func (q *qemu) startVM(vnicName, ipAddress string) error {
+func (q *qemuV) startVM(vnicName, ipAddress string) error {
 
 	var fds []*os.File
 
@@ -580,7 +533,7 @@ func (q *qemu) startVM(vnicName, ipAddress string) error {
 	return nil
 }
 
-func (q *qemu) lostVM() {
+func (q *qemuV) lostVM() {
 	if launchWithUI.Enabled() {
 		glog.Infof("Releasing VC Port %d", q.vcPort)
 		uiPortGrabber.releasePort(q.vcPort)
@@ -590,186 +543,89 @@ func (q *qemu) lostVM() {
 	q.prevCPUTime = -1
 }
 
-func readLoop(instance string, eventCh chan string, scanner *bufio.Scanner) {
-	for scanner.Scan() {
-		text := scanner.Text()
-		if glog.V(1) {
-			glog.Info(text)
+func qmpAttach(cmd virtualizerAttachCmd, q *qemu.QMP) {
+	glog.Info("Attach command received")
+	blockdevID := fmt.Sprintf("drive_%s", cmd.volumeUUID)
+	err := q.ExecuteBlockdevAdd(context.Background(), cmd.device, blockdevID)
+	if err != nil {
+		glog.Errorf("Failed to execute blockdev-add: %v", err)
+	} else {
+		devID := fmt.Sprintf("device_%s", cmd.volumeUUID)
+		err := q.ExecuteDeviceAdd(context.Background(), blockdevID,
+			devID, "virtio-blk-pci", "")
+		if err != nil {
+			glog.Errorf("Failed to execute device_add: %v", err)
 		}
-		eventCh <- scanner.Text()
 	}
-	glog.Infof("Quitting %s read Loop", instance)
-	close(eventCh)
-}
-
-func connectToVM(instance, instanceDir string, eventCh chan string, connectedCh chan struct{}) (net.Conn, error) {
-	qmpSocket := path.Join(instanceDir, "socket")
-	conn, err := net.DialTimeout("unix", qmpSocket, time.Second*30)
-	if err != nil {
-		glog.Errorf("Unable to open qmp socket for instance %s: %v", instance, err)
-		return nil, err
-	}
-
-	defer func() {
-		if conn != nil {
-			_ = conn.Close()
-		}
-	}()
-
-	scanner := bufio.NewScanner(conn)
-	_, err = fmt.Fprintln(conn, "{ \"execute\": \"qmp_capabilities\" }")
-	if err != nil {
-		glog.Errorf("Unable to send qmp_capabilities to instance %s: %v", instance, err)
-		return nil, err
-	}
-
-	/* TODO check return value and implement timeout */
-
-	if !scanner.Scan() {
-		err := fmt.Errorf("qmp_capabilities failed on instance %s", instance)
-		glog.Errorf("%v", err)
-		return nil, err
-	}
-
-	close(connectedCh)
-
-	go readLoop(instance, eventCh, scanner)
-	retval := conn
-	conn = nil
-	return retval, nil
-}
-
-func qmpAttach(cmd virtualizerAttachCmd, conn net.Conn) {
-	volInfo := &struct {
-		Device     string
-		VolumeUUID string
-	}{
-		cmd.device,
-		cmd.volumeUUID,
-	}
-	err := attachVolumeDriveTemplate.Execute(conn, &volInfo)
-	if err != nil {
-		cmd.responseCh <- err
-	}
-
-	// TODO,this code is no good.  We need to wait for the first command to
-	// exit first.
-
-	err = attachVolumeDeviceTemplate.Execute(conn, &volInfo)
-
-	// TODO try to delete block device if this fails.
-
 	cmd.responseCh <- err
 }
 
-func qmpDetach(cmd virtualizerDetachCmd, conn net.Conn) {
+func qmpDetach(cmd virtualizerDetachCmd, q *qemu.QMP) {
 	glog.Info("Detach command received")
-	volInfo := &struct {
-		VolumeUUID string
-	}{
-		cmd.volumeUUID,
-	}
-
-	err := detachVolumeDeviceTemplate.Execute(conn, &volInfo)
+	devID := fmt.Sprintf("device_%s", cmd.volumeUUID)
+	err := q.ExecuteDeviceDel(context.Background(), devID)
 	if err != nil {
-		cmd.responseCh <- err
-	}
-
-	// TODO,this code is no good.  We need to wait for the first command to
-	// exit first.
-
-	err = detachVolumeDriveTemplate.Execute(conn, &volInfo)
-
-	cmd.responseCh <- err
-}
-
-func qmpLoop(instance string, conn net.Conn, qmpChannel chan interface{}, eventCh chan string, closedCh chan struct{}) (chan string, chan struct{}) {
-	waitForShutdown := false
-	quitting := false
-
-DONE:
-	for {
-		select {
-		case cmd, ok := <-qmpChannel:
-			if !ok {
-				qmpChannel = nil
-				if !waitForShutdown {
-					break DONE
-				} else {
-					quitting = true
-				}
-			}
-			switch cmd := cmd.(type) {
-			case virtualizerStopCmd:
-				glog.Info("Sending STOP")
-				_, err := fmt.Fprintln(conn, "{ \"execute\": \"quit\" }")
-				if err != nil {
-					glog.Errorf("Unable to send power down command to %s: %v\n", instance, err)
-				} else {
-					waitForShutdown = true
-				}
-			case virtualizerAttachCmd:
-				qmpAttach(cmd, conn)
-			case virtualizerDetachCmd:
-				qmpDetach(cmd, conn)
-			}
-		case event, ok := <-eventCh:
-			if !ok {
-				close(closedCh)
-				closedCh = nil
-				eventCh = nil
-				waitForShutdown = false
-				if quitting {
-					glog.Info("Lost connection to qemu domain socket")
-					break DONE
-				} else {
-					glog.Warning("Lost connection to qemu domain socket")
-				}
-				continue
-			}
-			if waitForShutdown == true && strings.Contains(event, "return") {
-				waitForShutdown = false
-				if quitting {
-					break DONE
-				}
-			}
+		glog.Errorf("Failed to execute device_del: %v", err)
+	} else {
+		blockdevID := fmt.Sprintf("drive_%s", cmd.volumeUUID)
+		err := q.ExecuteXBlockdevDel(context.Background(), blockdevID)
+		if err != nil {
+			glog.Errorf("Failed to execute x-blockdev-del: %v", err)
 		}
 	}
-
-	return eventCh, closedCh
+	cmd.responseCh <- err
 }
 
 func qmpConnect(qmpChannel chan interface{}, instance, instanceDir string, closedCh chan struct{},
 	connectedCh chan struct{}, wg *sync.WaitGroup, boot bool) {
-	var conn net.Conn
 
+	var q *qemu.QMP
 	defer func() {
-		if closedCh != nil {
-			close(closedCh)
+		if q != nil {
+			q.Shutdown()
 		}
 		glog.Infof("Monitor function for %s exitting", instance)
 		wg.Done()
 	}()
 
-	eventCh := make(chan string)
-	conn, err := connectToVM(instance, instanceDir, eventCh, connectedCh)
+	socket := path.Join(instanceDir, "socket")
+	cfg := qemu.QMPConfig{Logger: qmpGlogLogger{}}
+	q, ver, err := qemu.QMPStart(context.Background(), socket, cfg, closedCh)
 	if err != nil {
-		glog.Infof("Monitor function for %s exitting with err: %v", instance, err)
+		glog.Warningf("Failed to connect to QEMU instance %s: %v", instance, err)
 		return
 	}
 
-	eventCh, closedCh = qmpLoop(instance, conn, qmpChannel, eventCh, closedCh)
+	glog.Infof("Connected to %s.", instance)
+	glog.Infof("QMP version %d.%d.%d", ver.Major, ver.Minor, ver.Micro)
+	glog.Infof("QMP capabilities %s", ver.Capabilities)
 
-	_ = conn.Close()
-
-	/* Readloop could be blocking on a send */
-
-	if eventCh != nil {
-		for range eventCh {
-		}
+	err = q.ExecuteQMPCapabilities(context.Background())
+	if err != nil {
+		glog.Errorf("Unable to send qmp_capabilities command: %v", err)
+		return
 	}
 
-	glog.Infof("Quitting Monitor Loop for %s\n", instance)
+	close(connectedCh)
+
+DONE:
+	for {
+		cmd, ok := <-qmpChannel
+		if !ok {
+			break DONE
+		}
+		switch cmd := cmd.(type) {
+		case virtualizerStopCmd:
+			err = q.ExecuteQuit(context.Background())
+			if err != nil {
+				glog.Warningf("Failed to execute stop command: %v", err)
+			}
+		case virtualizerAttachCmd:
+			qmpAttach(cmd, q)
+		case virtualizerDetachCmd:
+			qmpDetach(cmd, q)
+		}
+	}
 }
 
 /* closedCh is closed by the monitor go routine when it loses connection to the domain socket, basically,
@@ -780,7 +636,7 @@ func qmpConnect(qmpChannel chan interface{}, instance, instanceDir string, close
    VM instance is running.
 */
 
-func (q *qemu) monitorVM(closedCh chan struct{}, connectedCh chan struct{},
+func (q *qemuV) monitorVM(closedCh chan struct{}, connectedCh chan struct{},
 	wg *sync.WaitGroup, boot bool) chan interface{} {
 	qmpChannel := make(chan interface{})
 	wg.Add(1)
@@ -797,7 +653,7 @@ func computeInstanceDiskspace(instanceDir string) int {
 	return int(fi.Size() / 1000000)
 }
 
-func (q *qemu) stats() (disk, memory, cpu int) {
+func (q *qemuV) stats() (disk, memory, cpu int) {
 	disk = computeInstanceDiskspace(q.instanceDir)
 	memory = -1
 	cpu = -1
@@ -829,7 +685,7 @@ func (q *qemu) stats() (disk, memory, cpu int) {
 	return
 }
 
-func (q *qemu) connected() {
+func (q *qemuV) connected() {
 	qmpSocket := path.Join(q.instanceDir, "socket")
 	var buf bytes.Buffer
 	cmd := exec.Command("fuser", qmpSocket)

--- a/ciao-launcher/qemu_test.go
+++ b/ciao-launcher/qemu_test.go
@@ -253,13 +253,20 @@ func setupQmpSocket(t *testing.T, runTest func(net.Conn, *bufio.Scanner, chan in
 	}
 
 	fd.SetDeadline(time.Now().Add(5. * time.Second))
+	const qmpHello = `{ "QMP": { "version": { "qemu": { "micro": 0, "minor": 5, "major": 2}, "package": ""}, "capabilities": []}}`
+	_, err = fmt.Fprintln(fd, qmpHello)
+	if err != nil {
+		fd.Close()
+		t.Fatalf("Unable to write to qmpChannel %v", err)
+	}
+
 	sc := bufio.NewScanner(fd)
 	if !sc.Scan() {
 		fd.Close()
 		t.Fatalf("query capabilities not received")
 	}
 
-	_, err = fmt.Fprintln(fd, "{}")
+	_, err = fmt.Fprintln(fd, `{ "return": {}}`)
 	if err != nil {
 		fd.Close()
 		t.Fatalf("Unable to write to qmpChannel %v", err)

--- a/qemu/examples_test.go
+++ b/qemu/examples_test.go
@@ -1,0 +1,84 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package qemu_test
+
+import (
+	"time"
+
+	"github.com/01org/ciao/qemu"
+	"golang.org/x/net/context"
+)
+
+func Example() {
+	params := make([]string, 0, 32)
+
+	// Rootfs
+	params = append(params, "-drive", "file=/tmp/image.qcow2,if=virtio,aio=threads,format=qcow2")
+	// Network
+	params = append(params, "-net", "nic,model=virtio", "-net", "user")
+	// kvm
+	params = append(params, "-enable-kvm", "-cpu", "host")
+	// qmp socket
+	params = append(params, "-daemonize", "-qmp", "unix:/tmp/qmp-socket,server,nowait")
+	// resources
+	params = append(params, "-m", "370", "-smp", "cpus=2")
+
+	// LaunchQemu should return as soon as the instance has launched as we
+	// are using the --daemonize flag.  It will set up a unix domain socket
+	// called /tmp/qmp-socket that we can use to manage the instance.
+	_, err := qemu.LaunchQemu(context.Background(), params, nil, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// This channel will be closed when the instance dies.
+	disconnectedCh := make(chan struct{})
+
+	// Set up our options.  We don't want any logging or to receive any events.
+	cfg := qemu.QMPConfig{}
+
+	// Start monitoring the qemu instance.  This functon will block until we have
+	// connect to the QMP socket and received the welcome message.
+	q, _, err := qemu.QMPStart(context.Background(), "/tmp/qmp-socket", cfg, disconnectedCh)
+	if err != nil {
+		panic(err)
+	}
+
+	// This has to be the first command executed in a QMP session.
+	err = q.ExecuteQMPCapabilities(context.Background())
+	if err != nil {
+		panic(err)
+	}
+
+	// Let's try to shutdown the VM.  If it hasn't shutdown in 10 seconds we'll
+	// send a quit message.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	err = q.ExecuteSystemPowerdown(ctx)
+	cancel()
+	if err != nil {
+		err = q.ExecuteQuit(context.Background())
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	q.Shutdown()
+
+	// disconnectedCh is closed when the VM exits. This line blocks until this
+	// event occurs.
+	<-disconnectedCh
+}

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -14,6 +14,14 @@
 // limitations under the License.
 */
 
+// Package qemu provides methods and types for launching and managing QEMU
+// instances.  Instances can be launched with the LaunchQemu function and
+// managed thereafter via QMPStart and the QMP object that this function
+// returns.  To manage a qemu instance after it has been launched you need
+// to pass the -qmp option during launch requesting the qemu instance to create
+// a QMP unix domain manageent socket, e.g.,
+// -qmp unix:/tmp/qmp-socket,server,nowait.  For more information see the
+// example below.
 package qemu
 
 import (

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -51,7 +51,7 @@ import (
 func LaunchQemu(ctx context.Context, params []string, fds []*os.File, logger QMPLog) (string, error) {
 	errStr := ""
 	cmd := exec.Command("qemu-system-x86_64", params...)
-	if fds != nil {
+	if len(fds) > 0 {
 		logger.Infof("Adding extra file %v", fds)
 		cmd.ExtraFiles = fds
 	}

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -1,0 +1,62 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package qemu
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+
+	"golang.org/x/net/context"
+)
+
+// LaunchQemu can be used to launch a new qemu instance by invoking the
+// qemu-system-x86_64 binary.
+//
+// The ctx parameter is not currently used but has been added so that the
+// signature of this function will not need to change when launch cancellation
+// is implemented.
+//
+// params is a slice of options to pass to qemu-system-x86_64 and fds is a
+// list of open file descriptors that are to be passed to the spawned qemu
+// process.
+//
+// This function writes its log output via logger parameter.
+//
+// The function will block until the launched qemu process exits.  "", nil
+// will be returned if the launch succeeds.  Otherwise a string containing
+// the contents of stderr + a Go error object will be returned.
+func LaunchQemu(ctx context.Context, params []string, fds []*os.File, logger QMPLog) (string, error) {
+	errStr := ""
+	cmd := exec.Command("qemu-system-x86_64", params...)
+	if fds != nil {
+		logger.Infof("Adding extra file %v", fds)
+		cmd.ExtraFiles = fds
+	}
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	logger.Infof("launching qemu with: %v", params)
+
+	err := cmd.Run()
+	if err != nil {
+		logger.Errorf("Unable to launch qemu: %v", err)
+		errStr = stderr.String()
+		logger.Errorf("%s", errStr)
+	}
+	return errStr, err
+}

--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -1,0 +1,600 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package qemu
+
+import (
+	"bufio"
+	"container/list"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+// Code to launch qemu
+// move to package and document
+
+// QMPLog is a logging interface used by the qemu package to log various
+// interesting pieces of information.  Rather than introduce a dependency
+// on a given logging package, qemu presents this interface that allows
+// clients to provide their own logging type which they can use to
+// seamlessly integrate qemu's logs into their own logs.  A QMPLog
+// implementation can be specified in the QMPConfig structure.
+type QMPLog interface {
+	// V returns true if the given argument is less than or equal
+	// to the implementation's defined verbosity level.
+	V(int32) bool
+
+	// Infof writes informational output to the log.  A newline will be
+	// added to the output if one is not provided.
+	Infof(string, ...interface{})
+
+	// Warningf writes warning output to the log.  A newline will be
+	// added to the output if one is not provided.
+	Warningf(string, ...interface{})
+
+	// Errorf writes error output to the log.  A newline will be
+	// added to the output if one is not provided.
+	Errorf(string, ...interface{})
+}
+
+type qmpNullLogger struct{}
+
+func (l qmpNullLogger) V(level int32) bool {
+	return false
+}
+
+func (l qmpNullLogger) Infof(format string, v ...interface{}) {
+}
+
+func (l qmpNullLogger) Warningf(format string, v ...interface{}) {
+}
+
+func (l qmpNullLogger) Errorf(format string, v ...interface{}) {
+}
+
+// QMPConfig is a configuration structure that can be used to specify a
+// logger and a channel to which logs and  QMP events are to be sent.  If
+// neither of these fields are specified, or are set to nil, no logs will be
+// written and no QMP events will be reported to the client.
+type QMPConfig struct {
+	// eventCh can be specified by clients who wish to receive QMP
+	// events.
+	EventCh chan<- QMPEvent
+
+	// logger is used by the qmpStart function and all the go routines
+	// it spawns to log information.
+	Logger QMPLog
+}
+
+type qmpEventFilter struct {
+	eventName string
+	dataKey   string
+	dataValue string
+}
+
+// QMPEvent contains a single QMP event, sent on the QMPConfig.EventCh channel.
+type QMPEvent struct {
+	// The name of the event, e.g., DEVICE_DELETED
+	Name string
+
+	// The data associated with the event.  The contents of this map are
+	// unprocessed by the qemu package.  It is simply the result of
+	// unmarshalling the QMP json event.  Here's an example map
+	// map[string]interface{}{
+	//	"driver": "virtio-blk-pci",
+	//	"drive":  "drive_3437843748734873483",
+	// }
+	Data map[string]interface{}
+
+	// The event's timestamp converted to a time.Time object.
+	Timestamp time.Time
+}
+
+type qmpResult struct {
+	err  error
+	data map[string]interface{}
+}
+
+type qmpCommand struct {
+	ctx            context.Context
+	res            chan qmpResult
+	name           string
+	args           map[string]interface{}
+	filter         *qmpEventFilter
+	resultReceived bool
+}
+
+// QMP is a structure that contains the internal state used by startQMPLoop and
+// the go routines it spwans.  All the contents of this structure are private.
+type QMP struct {
+	cmdCh          chan qmpCommand
+	conn           io.ReadWriteCloser
+	cfg            QMPConfig
+	connectedCh    chan<- *QMPVersion
+	disconnectedCh chan struct{}
+}
+
+// QMPVersion contains the version number and the capabailities of a QEMU
+// instance, as reported in the QMP greeting message.
+type QMPVersion struct {
+	Major        int
+	Minor        int
+	Micro        int
+	Capabilities []string
+}
+
+func (q *QMP) readLoop(fromVMCh chan<- []byte) {
+	scanner := bufio.NewScanner(q.conn)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if q.cfg.Logger.V(1) {
+			q.cfg.Logger.Infof("%s", string(line))
+		}
+		fromVMCh <- line
+	}
+	close(fromVMCh)
+}
+
+func (q *QMP) processQMPEvent(cmdQueue *list.List, name interface{}, data interface{},
+	timestamp interface{}) {
+
+	strname, ok := name.(string)
+	if !ok {
+		return
+	}
+
+	var eventData map[string]interface{}
+	if data != nil {
+		eventData, _ = data.(map[string]interface{})
+	}
+
+	cmdEl := cmdQueue.Front()
+	if cmdEl != nil {
+		cmd := cmdEl.Value.(*qmpCommand)
+		filter := cmd.filter
+		if filter != nil {
+			if filter.eventName == strname {
+				match := filter.dataKey == ""
+				if !match && eventData != nil {
+					match = eventData[filter.dataKey] == filter.dataValue
+				}
+				if match {
+					if cmd.resultReceived {
+						q.finaliseCommand(cmdEl, cmdQueue, true)
+					} else {
+						cmd.filter = nil
+					}
+				}
+			}
+		}
+	}
+
+	if q.cfg.EventCh != nil {
+		ev := QMPEvent{
+			Name: strname,
+			Data: eventData,
+		}
+		if timestamp != nil {
+			timestamp, ok := timestamp.(map[string]interface{})
+			if ok {
+				seconds, _ := timestamp["seconds"].(float64)
+				microseconds, _ := timestamp["microseconds"].(float64)
+				ev.Timestamp = time.Unix(int64(seconds), int64(microseconds))
+			}
+		}
+
+		q.cfg.EventCh <- ev
+	}
+}
+
+func (q *QMP) finaliseCommand(cmdEl *list.Element, cmdQueue *list.List, succeeded bool) {
+	cmd := cmdEl.Value.(*qmpCommand)
+	cmdQueue.Remove(cmdEl)
+	select {
+	case <-cmd.ctx.Done():
+	default:
+		if succeeded {
+			cmd.res <- qmpResult{}
+		} else {
+			cmd.res <- qmpResult{err: fmt.Errorf("QMP command failed")}
+		}
+	}
+	if cmdQueue.Len() > 0 {
+		q.writeNextQMPCommand(cmdQueue)
+	}
+}
+
+func (q *QMP) processQMPInput(line []byte, cmdQueue *list.List) {
+	var vmData map[string]interface{}
+	err := json.Unmarshal(line, &vmData)
+	if err != nil {
+		q.cfg.Logger.Warningf("Unable to decode response [%s] from VM: %v",
+			string(line), err)
+		return
+	}
+	if evname, found := vmData["event"]; found {
+		q.processQMPEvent(cmdQueue, evname, vmData["data"], vmData["timestamp"])
+		return
+	}
+
+	_, succeeded := vmData["return"]
+	_, failed := vmData["error"]
+
+	if !succeeded && !failed {
+		return
+	}
+
+	cmdEl := cmdQueue.Front()
+	if cmdEl == nil {
+		q.cfg.Logger.Warningf("Unexpected command response received [%s] from VM",
+			string(line))
+		return
+	}
+	cmd := cmdEl.Value.(*qmpCommand)
+	if failed || cmd.filter == nil {
+		q.finaliseCommand(cmdEl, cmdQueue, succeeded)
+	} else {
+		cmd.resultReceived = true
+	}
+}
+
+func (q *QMP) writeNextQMPCommand(cmdQueue *list.List) {
+	cmdEl := cmdQueue.Front()
+	cmd := cmdEl.Value.(*qmpCommand)
+	cmdData := make(map[string]interface{})
+	cmdData["execute"] = cmd.name
+	if cmd.args != nil {
+		cmdData["arguments"] = cmd.args
+	}
+	encodedCmd, err := json.Marshal(&cmdData)
+	if err != nil {
+		cmd.res <- qmpResult{
+			err: fmt.Errorf("Unable to marhsall command %s: %v",
+				cmd.name, err),
+		}
+		cmdQueue.Remove(cmdEl)
+	}
+	q.cfg.Logger.Infof("%s", string(encodedCmd))
+	encodedCmd = append(encodedCmd, '\n')
+	_, err = q.conn.Write(encodedCmd)
+	if err != nil {
+		cmd.res <- qmpResult{
+			err: fmt.Errorf("Unable to write command to qmp socket %v", err),
+		}
+		cmdQueue.Remove(cmdEl)
+	}
+}
+
+func failOutstandingCommands(cmdQueue *list.List) {
+	for e := cmdQueue.Front(); e != nil; e = e.Next() {
+		cmd := e.Value.(*qmpCommand)
+		select {
+		case cmd.res <- qmpResult{
+			err: errors.New("exitting QMP loop, command cancelled"),
+		}:
+		case <-cmd.ctx.Done():
+		}
+	}
+}
+
+func (q *QMP) parseVersion(version []byte) *QMPVersion {
+	var qmp map[string]interface{}
+	err := json.Unmarshal(version, &qmp)
+	if err != nil {
+		q.cfg.Logger.Errorf("Invalid QMP greeting: %s", string(version))
+		return nil
+	}
+
+	versionMap := qmp
+	for _, k := range []string{"QMP", "version", "qemu"} {
+		versionMap, _ = versionMap[k].(map[string]interface{})
+		if versionMap == nil {
+			q.cfg.Logger.Errorf("Invalid QMP greeting: %s", string(version))
+			return nil
+		}
+	}
+
+	micro, _ := versionMap["micro"].(float64)
+	minor, _ := versionMap["minor"].(float64)
+	major, _ := versionMap["major"].(float64)
+	capabilities, _ := qmp["QMP"].(map[string]interface{})["capabilities"].([]interface{})
+	stringcaps := make([]string, 0, len(capabilities))
+	for _, c := range capabilities {
+		if cap, ok := c.(string); ok {
+			stringcaps = append(stringcaps, cap)
+		}
+	}
+	return &QMPVersion{Major: int(major),
+		Minor:        int(minor),
+		Micro:        int(micro),
+		Capabilities: stringcaps,
+	}
+}
+
+func (q *QMP) mainLoop() {
+	cmdQueue := list.New().Init()
+	fromVMCh := make(chan []byte)
+	go q.readLoop(fromVMCh)
+
+	defer func() {
+		if q.cfg.EventCh != nil {
+			close(q.cfg.EventCh)
+		}
+		_ = q.conn.Close()
+		_ = <-fromVMCh
+		failOutstandingCommands(cmdQueue)
+		close(q.disconnectedCh)
+	}()
+
+	version := []byte{}
+
+DONE:
+	for {
+		ok := false
+		select {
+		case cmd, ok := <-q.cmdCh:
+			if !ok {
+				return
+			}
+			_ = cmdQueue.PushBack(&cmd)
+		case version, ok = <-fromVMCh:
+			if !ok {
+				return
+			}
+			if cmdQueue.Len() >= 1 {
+				q.writeNextQMPCommand(cmdQueue)
+			}
+			break DONE
+		}
+	}
+
+	q.connectedCh <- q.parseVersion(version)
+
+	for {
+		select {
+		case cmd, ok := <-q.cmdCh:
+			if !ok {
+				return
+			}
+			_ = cmdQueue.PushBack(&cmd)
+			if cmdQueue.Len() >= 1 {
+				q.writeNextQMPCommand(cmdQueue)
+			}
+		case line, ok := <-fromVMCh:
+			if !ok {
+				return
+			}
+			q.processQMPInput(line, cmdQueue)
+		}
+	}
+}
+
+func startQMPLoop(conn io.ReadWriteCloser, cfg QMPConfig,
+	connectedCh chan<- *QMPVersion, disconnectedCh chan struct{}) *QMP {
+	q := &QMP{
+		cmdCh:          make(chan qmpCommand),
+		conn:           conn,
+		cfg:            cfg,
+		connectedCh:    connectedCh,
+		disconnectedCh: disconnectedCh,
+	}
+	go q.mainLoop()
+	return q
+}
+
+func (q *QMP) executeCommand(ctx context.Context, name string, args map[string]interface{},
+	filter *qmpEventFilter) error {
+	var err error
+	resCh := make(chan qmpResult)
+	select {
+	case <-q.disconnectedCh:
+		err = errors.New("exitting QMP loop, command cancelled")
+	case q.cmdCh <- qmpCommand{
+		ctx:    ctx,
+		res:    resCh,
+		name:   name,
+		args:   args,
+		filter: filter,
+	}:
+	}
+
+	if err != nil {
+		return err
+	}
+
+	select {
+	case res := <-resCh:
+		err = res.err
+	case <-ctx.Done():
+		err = ctx.Err()
+	}
+
+	return err
+}
+
+// QMPStart connects to a unix domain socket maintained by a QMP instance.  It
+// waits to receive the QMP welcome message via the socket and spawns some go
+// routines to manage the socket.  The function returns a *QMP which can be
+// used by callers to send commands to the QEMU instance or to close the
+// socket and all the go routines that have been spawned to monitor it.  A
+// *QMPVersion is also returned.  This structure contains the version and
+// capabilities information returned by the QEMU instance in its welcome
+// message.
+//
+// socket contains the path to the domain socket. cfg contains some options
+// that can be specified by the caller, namely where the qemu package should
+// send logs and QMP events.  disconnectedCh is a channel that must be supplied
+// by the caller.  It is closed when an error occurs openning or writing to
+// or reading from the unix domain socket.  This implies that the QEMU instance
+// that opened the socket has closed.
+//
+// If this function returns without error, callers should call QMP.Shutdown
+// when they wish to stop monitoring the QMP instance.  This is not strictly
+// necessary if the QEMU instance exits and the disconnectedCh is closed, but
+// doing so will not cause any problems.
+//
+// Commands can be sent to the QEMU instance via the QMP.Execute methods.
+// These commands are executed serially, even if the QMP.Execute methods
+// are called from different go routines.  The QMP.Execute methods will
+// block until they have received a success or failure message from QMP,
+// i.e., {"return": {}} or {"error":{}}, and in some cases certain events
+// are received.
+func QMPStart(ctx context.Context, socket string, cfg QMPConfig, disconnectedCh chan struct{}) (*QMP, *QMPVersion, error) {
+	if cfg.Logger == nil {
+		cfg.Logger = qmpNullLogger{}
+	}
+	dialer := net.Dialer{Cancel: ctx.Done()}
+	conn, err := dialer.Dial("unix", socket)
+	if err != nil {
+		cfg.Logger.Warningf("Unable to connect to unix socket (%s): %v", socket, err)
+		close(disconnectedCh)
+		return nil, nil, err
+	}
+
+	connectedCh := make(chan *QMPVersion)
+
+	var version *QMPVersion
+	q := startQMPLoop(conn, cfg, connectedCh, disconnectedCh)
+	select {
+	case <-ctx.Done():
+		q.Shutdown()
+		<-disconnectedCh
+		return nil, nil, fmt.Errorf("Canceled by caller")
+	case <-disconnectedCh:
+		return nil, nil, fmt.Errorf("Lost connection to VM")
+	case version = <-connectedCh:
+		if version == nil {
+			return nil, nil, fmt.Errorf("Failed to find QMP version information")
+		}
+	}
+
+	return q, version, nil
+}
+
+// Shutdown closes the domain socket used to monitor a QEMU instance and
+// terminates all the go routines spawned by QMPStart to manage that instance.
+// QMP.Shutdown does not shut down the running instance.  Calling QMP.Shutdown
+// will result in the disconnectedCh channel being closed, indicating that we
+// have lost connection to the QMP instance.  In this case it does not indicate
+// that the instance has quit.
+//
+// QMP.Shutdown should not be called concurrently with other QMP methods.  It
+// should not be called twice on the same QMP instance.
+//
+// Calling QMP.Shutdown after the disconnectedCh channel is closed is permitted but
+// will not have any effect.
+func (q *QMP) Shutdown() {
+	close(q.cmdCh)
+}
+
+// ExecuteQMPCapabilities executes the qmp_capabilities command on the instance.
+func (q *QMP) ExecuteQMPCapabilities(ctx context.Context) error {
+	return q.executeCommand(ctx, "qmp_capabilities", nil, nil)
+}
+
+// ExecuteStop sends the stop command to the instance.
+func (q *QMP) ExecuteStop(ctx context.Context) error {
+	return q.executeCommand(ctx, "stop", nil, nil)
+}
+
+// ExecuteCont sends the cont command to the instance.
+func (q *QMP) ExecuteCont(ctx context.Context) error {
+	return q.executeCommand(ctx, "cont", nil, nil)
+}
+
+// ExecuteSystemPowerdown sends the system_powerdown command to the instance.
+// This function will block until the SHUTDOWN event is received.
+func (q *QMP) ExecuteSystemPowerdown(ctx context.Context) error {
+	filter := &qmpEventFilter{
+		eventName: "SHUTDOWN",
+	}
+	return q.executeCommand(ctx, "system_powerdown", nil, filter)
+}
+
+// ExecuteQuit sends the quit command to the instance, terminating
+// the QMP instance immediately.
+func (q *QMP) ExecuteQuit(ctx context.Context) error {
+	return q.executeCommand(ctx, "quit", nil, nil)
+}
+
+// ExecuteBlockdevAdd sends a blockdev-add to the QEMU instance.  device is the
+// path of the device to add, e.g., /dev/rdb0, and blockdevID is an identifier
+// used to name the device.  As this identifier will be passed directly to QMP,
+// it must obey QMP's naming rules, e,g., it must start with a letter.
+func (q *QMP) ExecuteBlockdevAdd(ctx context.Context, device, blockdevID string) error {
+	args := map[string]interface{}{
+		"options": map[string]interface{}{
+			"driver": "raw",
+			"file": map[string]interface{}{
+				"driver":   "file",
+				"filename": device,
+			},
+			"id": blockdevID,
+		},
+	}
+	return q.executeCommand(ctx, "blockdev-add", args, nil)
+}
+
+// ExecuteDeviceAdd adds the guest portion of a device to a QEMU instance
+// using the device_add command.  blockdevID should match the blockdevID passed
+// to a previous call to ExecuteBlockdevAdd.  devID is the id of the device to
+// add.  Both strings must be valid QMP identifiers.  driver is the name of the
+// driver,e.g., virtio-blk-pci, and bus is the name of the bus.  bus is optional.
+func (q *QMP) ExecuteDeviceAdd(ctx context.Context, blockdevID, devID, driver, bus string) error {
+	args := map[string]interface{}{
+		"id":     devID,
+		"driver": driver,
+		"drive":  blockdevID,
+	}
+	if bus != "" {
+		args["bus"] = bus
+	}
+	return q.executeCommand(ctx, "device_add", args, nil)
+}
+
+// ExecuteXBlockdevDel deletes a block device by sending a x-blockdev-del command.
+// blockdevID is the id of the block device to be deleted.  Typically, this will
+// match the id passed to ExecuteBlockdevAdd.  It must be a valid QMP id.
+func (q *QMP) ExecuteXBlockdevDel(ctx context.Context, blockdevID string) error {
+	args := map[string]interface{}{
+		"id": blockdevID,
+	}
+	return q.executeCommand(ctx, "x-blockdev-del", args, nil)
+}
+
+// ExecuteDeviceDel deletes guest portion of a QEMU device by sending a
+// device_del command.   devId is the identifier of the device to delete.
+// Typically it would match the devID parameter passed to an earlier call
+// to ExecuteDeviceAdd.  It must be a valid QMP identidier.
+//
+// This method blocks until a DEVICE_DELETED event is received for devID.
+func (q *QMP) ExecuteDeviceDel(ctx context.Context, devID string) error {
+	args := map[string]interface{}{
+		"id": devID,
+	}
+	filter := &qmpEventFilter{
+		eventName: "DEVICE_DELETED",
+		dataKey:   "device",
+		dataValue: devID,
+	}
+	return q.executeCommand(ctx, "device_del", args, filter)
+}

--- a/qemu/qmp.go
+++ b/qemu/qmp.go
@@ -29,9 +29,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-// Code to launch qemu
-// move to package and document
-
 // QMPLog is a logging interface used by the qemu package to log various
 // interesting pieces of information.  Rather than introduce a dependency
 // on a given logging package, qemu presents this interface that allows

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -1,0 +1,697 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package qemu
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/01org/ciao/testutil"
+)
+
+const (
+	microStr   = "50"
+	minorStr   = "6"
+	majorStr   = "2"
+	micro      = 50
+	minor      = 6
+	major      = 2
+	cap1       = "one"
+	cap2       = "two"
+	qmpHello   = `{ "QMP": { "version": { "qemu": { "micro": ` + microStr + `, "minor": ` + minorStr + `, "major": ` + majorStr + ` }, "package": ""}, "capabilities": ["` + cap1 + `","` + cap2 + `"]}}` + "\n"
+	qmpSuccess = `{ "return": {}}` + "\n"
+	qmpFailure = `{ "error": {}}` + "\n"
+)
+
+type qmpTestLogger struct{}
+
+func (l qmpTestLogger) V(level int32) bool {
+	return true
+}
+
+func (l qmpTestLogger) Infof(format string, v ...interface{}) {
+	log.Printf(format, v...)
+}
+
+func (l qmpTestLogger) Warningf(format string, v ...interface{}) {
+	l.Infof(format, v)
+}
+
+func (l qmpTestLogger) Errorf(format string, v ...interface{}) {
+	l.Infof(format, v)
+}
+
+type qmpTestCommand struct {
+	name string
+	args map[string]interface{}
+}
+
+type qmpTestEvent struct {
+	name      string
+	data      map[string]interface{}
+	timestamp map[string]interface{}
+	after     time.Duration
+}
+
+type qmpTestResult struct {
+	result string
+	data   map[string]interface{}
+}
+
+type qmpTestCommandBuffer struct {
+	newDataCh  chan []byte
+	t          *testing.T
+	buf        *bytes.Buffer
+	cmds       []qmpTestCommand
+	events     []qmpTestEvent
+	results    []qmpTestResult
+	currentCmd int
+	forceFail  chan struct{}
+}
+
+func newQMPTestCommandBuffer(t *testing.T) *qmpTestCommandBuffer {
+	b := &qmpTestCommandBuffer{
+		newDataCh: make(chan []byte, 1),
+		t:         t,
+		buf:       bytes.NewBuffer([]byte{}),
+		forceFail: make(chan struct{}),
+	}
+	b.cmds = make([]qmpTestCommand, 0, 8)
+	b.events = make([]qmpTestEvent, 0, 8)
+	b.results = make([]qmpTestResult, 0, 8)
+	b.newDataCh <- []byte(qmpHello)
+	return b
+}
+
+func (b *qmpTestCommandBuffer) startEventLoop(wg *sync.WaitGroup) {
+	wg.Add(1)
+	go func() {
+		for _, ev := range b.events {
+			time.Sleep(ev.after)
+			eventMap := map[string]interface{}{
+				"event": ev.name,
+			}
+
+			if ev.data != nil {
+				eventMap["data"] = ev.data
+			}
+
+			if ev.timestamp != nil {
+				eventMap["timestamp"] = ev.timestamp
+			}
+
+			encodedEvent, err := json.Marshal(&eventMap)
+			if err != nil {
+				b.t.Errorf("Unable to encode event: %v", err)
+			}
+			encodedEvent = append(encodedEvent, '\n')
+			b.newDataCh <- encodedEvent
+		}
+		wg.Done()
+	}()
+}
+
+func (b *qmpTestCommandBuffer) AddCommmand(name string, args map[string]interface{},
+	result string, data map[string]interface{}) {
+	b.cmds = append(b.cmds, qmpTestCommand{name, args})
+	if data == nil {
+		data = make(map[string]interface{})
+	}
+	b.results = append(b.results, qmpTestResult{result, data})
+}
+
+func (b *qmpTestCommandBuffer) AddEvent(name string, after time.Duration,
+	data map[string]interface{}, timestamp map[string]interface{}) {
+	b.events = append(b.events, qmpTestEvent{
+		name:      name,
+		data:      data,
+		timestamp: timestamp,
+		after:     after,
+	})
+}
+
+func (b *qmpTestCommandBuffer) Close() error {
+	close(b.newDataCh)
+	return nil
+}
+
+func (b *qmpTestCommandBuffer) Read(p []byte) (n int, err error) {
+	if b.buf.Len() == 0 {
+		ok := false
+		var data []byte
+		select {
+		case <-b.forceFail:
+			return 0, errors.New("Connection shutdown")
+		case data, ok = <-b.newDataCh:
+			select {
+			case <-b.forceFail:
+				return 0, errors.New("Connection shutdown")
+			default:
+			}
+		}
+		if !ok {
+			return 0, nil
+		}
+		_, err := b.buf.Write(data)
+		if err != nil {
+			if err != nil {
+				b.t.Errorf("Unable to buffer result: %v", err)
+			}
+		}
+	}
+	return b.buf.Read(p)
+}
+
+func (b *qmpTestCommandBuffer) Write(p []byte) (int, error) {
+	var cmdJSON map[string]interface{}
+	if b.currentCmd >= len(b.cmds) {
+		b.t.Fatalf("Unexpected command")
+	}
+	err := json.Unmarshal(p, &cmdJSON)
+	if err != nil {
+		b.t.Fatalf("Unexpected command")
+	}
+	cmdName := cmdJSON["execute"]
+	gotCmdName := cmdName.(string)
+	result := b.results[b.currentCmd].result
+	if gotCmdName != b.cmds[b.currentCmd].name {
+		b.t.Errorf("Unexpected command.  Expected %s found %s",
+			b.cmds[b.currentCmd].name, gotCmdName)
+		result = "error"
+	}
+	resultMap := make(map[string]interface{})
+	resultMap[result] = b.results[b.currentCmd].data
+	encodedRes, err := json.Marshal(&resultMap)
+	if err != nil {
+		b.t.Errorf("Unable to encode result: %v", err)
+	}
+	encodedRes = append(encodedRes, '\n')
+	b.newDataCh <- encodedRes
+	return len(p), nil
+}
+
+func checkVersion(t *testing.T, connectedCh <-chan *QMPVersion) {
+	var version *QMPVersion
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("Timed out waiting for qmp to connect")
+	case version = <-connectedCh:
+	}
+
+	if version == nil {
+		t.Fatal("Invalid version information received")
+	}
+	if version.Micro != micro || version.Minor != minor ||
+		version.Major != major {
+		t.Fatal("Invalid version number")
+	}
+
+	if len(version.Capabilities) != 2 {
+		if version.Capabilities[0] != cap1 || version.Capabilities[1] != cap2 {
+			t.Fatal("Invalid capabilities")
+		}
+	}
+}
+
+// Checks that a QMP Loop can be started and shutdown.
+//
+// We start a QMPLoop and shut it down.
+//
+// Loop should start up and shutdown correctly.  The version information
+// returned from startQMPLoop should be correct.
+func TestQMPStartStopLoop(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	q.Shutdown()
+	<-disconnectedCh
+}
+
+// Checks that the qmp_capabilities command is correctly sent.
+//
+// We start a QMPLoop, send the qmp_capabilities command and stop the
+// loop.
+//
+// The qmp_capabilities should be correctly sent and the QMP loop
+// should exit gracefully.
+func TestQMPCapabilities(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommmand("qmp_capabilities", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	err := q.ExecuteQMPCapabilities(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}
+
+// Checks that the stop command is correctly sent.
+//
+// We start a QMPLoop, send the stop command and stop the
+// loop.
+//
+// The stop command should be correctly sent and the QMP loop
+// should exit gracefully.
+func TestQMPStop(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommmand("stop", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	err := q.ExecuteStop(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}
+
+// Checks that the cont command is correctly sent.
+//
+// We start a QMPLoop, send the cont command and stop the
+// loop.
+//
+// The cont command should be correctly sent and the QMP loop
+// should exit gracefully.
+func TestQMPCont(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommmand("cont", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	err := q.ExecuteCont(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}
+
+// Checks that the quit command is correctly sent.
+//
+// We start a QMPLoop, send the quit command and wait for the loop to exit.
+//
+// The quit command should be correctly sent and the QMP loop should exit
+// gracefully without the test calling q.Shutdown().
+func TestQMPQuit(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommmand("quit", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	err := q.ExecuteQuit(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	close(buf.forceFail)
+	<-disconnectedCh
+}
+
+// Checks that the blockdev-add command is correctly sent.
+//
+// We start a QMPLoop, send the blockdev-add command and stop the loop.
+//
+// The blockdev-add command should be correctly sent and the QMP loop should
+// exit gracefully.
+func TestQMPBlockdevAdd(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommmand("blockdev-add", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	err := q.ExecuteBlockdevAdd(context.Background(), "/dev/rbd0",
+		fmt.Sprintf("drive_%s", testutil.VolumeUUID))
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}
+
+// Checks that the device_add command is correctly sent.
+//
+// We start a QMPLoop, send the device_add command and stop the loop.
+//
+// The device_add command should be correctly sent and the QMP loop should
+// exit gracefully.
+func TestQMPDeviceAdd(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommmand("device_add", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	blockdevID := fmt.Sprintf("drive_%s", testutil.VolumeUUID)
+	devID := fmt.Sprintf("device_%s", testutil.VolumeUUID)
+	err := q.ExecuteDeviceAdd(context.Background(), blockdevID, devID,
+		"virtio-blk-pci", "")
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}
+
+// Checks that the x-blockdev-del command is correctly sent.
+//
+// We start a QMPLoop, send the x-blockdev-del command and stop the loop.
+//
+// The x-blockdev-del command should be correctly sent and the QMP loop should
+// exit gracefully.
+func TestQMPXBlockdevDel(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommmand("x-blockdev-del", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	err := q.ExecuteXBlockdevDel(context.Background(),
+		fmt.Sprintf("drive_%s", testutil.VolumeUUID))
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}
+
+// Checks that the device_del command is correctly sent.
+//
+// We start a QMPLoop, send the device_del command and wait for it to complete.
+// This command generates some events so we start a separate go routine to check
+// that they are received.
+//
+// The device_del command should be correctly sent and the QMP loop should
+// exit gracefully.  We should also receive two events on the eventCh.
+func TestQMPDeviceDel(t *testing.T) {
+	const (
+		seconds         = 1352167040730
+		microsecondsEv1 = 123456
+		microsecondsEv2 = 123556
+		device          = "device_" + testutil.VolumeUUID
+		path            = "/dev/rbd0"
+	)
+
+	var wg sync.WaitGroup
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommmand("device_del", nil, "return", nil)
+	buf.AddEvent("DEVICE_DELETED", time.Millisecond*200,
+		map[string]interface{}{
+			"path": path,
+		},
+		map[string]interface{}{
+			"seconds":      seconds,
+			"microseconds": microsecondsEv1,
+		})
+	buf.AddEvent("DEVICE_DELETED", time.Millisecond*200,
+		map[string]interface{}{
+			"device": device,
+			"path":   path,
+		},
+		map[string]interface{}{
+			"seconds":      seconds,
+			"microseconds": microsecondsEv2,
+		})
+	eventCh := make(chan QMPEvent)
+	cfg := QMPConfig{EventCh: eventCh, Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	wg.Add(1)
+	go func() {
+		for i := 0; i < 2; i++ {
+			select {
+			case <-eventCh:
+			case <-time.After(time.Second):
+				t.Error("Timedout waiting for event")
+			}
+		}
+		wg.Done()
+	}()
+	checkVersion(t, connectedCh)
+	buf.startEventLoop(&wg)
+	err := q.ExecuteDeviceDel(context.Background(),
+		fmt.Sprintf("device_%s", testutil.VolumeUUID))
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+	wg.Wait()
+}
+
+// Checks that contexts can be used to timeout a command.
+//
+// We start a QMPLoop and send the device_del command with a context that times
+// out after 1 second.  We don't however arrangefor any DEVICE_DELETED events
+// to be sent so the device_del command should not complete normally.  We then
+// shutdown the QMP loop.
+//
+// The device_del command should timeout after 1 second and the QMP loop
+// should exit gracefully.
+func TestQMPDeviceDelTimeout(t *testing.T) {
+	const (
+		seconds         = 1352167040730
+		microsecondsEv1 = 123456
+		device          = "device_" + testutil.VolumeUUID
+		path            = "/dev/rbd0"
+	)
+
+	var wg sync.WaitGroup
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommmand("device_del", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	err := q.ExecuteDeviceDel(ctx,
+		fmt.Sprintf("device_%s", testutil.VolumeUUID))
+	cancel()
+	if err != context.DeadlineExceeded {
+		t.Fatalf("Timeout expected found %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+	wg.Wait()
+}
+
+// Checks that contexts can be used to cancel a command.
+//
+// We start a QMPLoop and send two qmp_capabilities commands, cancelling
+// the first.  The second is allowed to proceed normally.
+//
+// The first call to ExecuteQMPCapabilities should fail with
+// context.Canceled.  The second should succeed.
+func TestQMPCancel(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommmand("qmp_capabilities", nil, "return", nil)
+	buf.AddCommmand("qmp_capabilities", nil, "return", nil)
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := q.ExecuteQMPCapabilities(ctx)
+	if err != context.Canceled {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	err = q.ExecuteQMPCapabilities(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+}
+
+// Checks that the system_powerdown command is correctly sent.
+//
+// We start a QMPLoop, send the system_powerdown command and stop the loop.
+//
+// The system_powerdown command should be correctly sent and should return
+// as we've provisioned a SHUTDOWN event.  The QMP loop should exit gracefully.
+func TestQMPSystemPowerdown(t *testing.T) {
+	const (
+		seconds         = 1352167040730
+		microsecondsEv1 = 123456
+	)
+
+	var wg sync.WaitGroup
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddCommmand("system_powerdown", nil, "return", nil)
+	buf.AddEvent("SHUTDOWN", time.Millisecond*100,
+		nil,
+		map[string]interface{}{
+			"seconds":      seconds,
+			"microseconds": microsecondsEv1,
+		})
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	buf.startEventLoop(&wg)
+	err := q.ExecuteSystemPowerdown(context.Background())
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	q.Shutdown()
+	<-disconnectedCh
+	wg.Wait()
+}
+
+// Checks that events can be received and parsed.
+//
+// Two events are provisioned and the QMPLoop is started with an valid eventCh.
+// We wait for both events to be received and check that their contents are
+// correct.  We then shutdown the QMP loop.
+//
+// Both events are received and their contents are correct.  The QMP loop should
+// shut down gracefully.
+func TestQMPEvents(t *testing.T) {
+	const (
+		seconds         = 1352167040730
+		microsecondsEv1 = 123456
+		microsecondsEv2 = 123556
+		device          = "device_" + testutil.VolumeUUID
+		path            = "/dev/rbd0"
+	)
+	var wg sync.WaitGroup
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+	buf.AddEvent("DEVICE_DELETED", time.Millisecond*100,
+		map[string]interface{}{
+			"device": device,
+			"path":   path,
+		},
+		map[string]interface{}{
+			"seconds":      seconds,
+			"microseconds": microsecondsEv1,
+		})
+	buf.AddEvent("POWERDOWN", time.Millisecond*200, nil,
+		map[string]interface{}{
+			"seconds":      seconds,
+			"microseconds": microsecondsEv2,
+		})
+	eventCh := make(chan QMPEvent)
+	cfg := QMPConfig{EventCh: eventCh, Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	buf.startEventLoop(&wg)
+
+	ev := <-eventCh
+	if ev.Name != "DEVICE_DELETED" {
+		t.Errorf("incorrect event name received.  Expected %s, found %s",
+			"DEVICE_DELETED", ev.Name)
+	}
+	if ev.Timestamp != time.Unix(seconds, microsecondsEv1) {
+		t.Error("incorrect timestamp")
+	}
+	deviceName := ev.Data["device"].(string)
+	if deviceName != device {
+		t.Errorf("Unexpected device field.  Expected %s, found %s",
+			"device_"+testutil.VolumeUUID, device)
+	}
+	pathName := ev.Data["path"].(string)
+	if pathName != path {
+		t.Errorf("Unexpected path field.  Expected %s, found %s",
+			"/dev/rbd0", path)
+	}
+
+	ev = <-eventCh
+	if ev.Name != "POWERDOWN" {
+		t.Errorf("incorrect event name received.  Expected %s, found %s",
+			"POWERDOWN", ev.Name)
+	}
+	if ev.Timestamp != time.Unix(seconds, microsecondsEv2) {
+		t.Error("incorrect timestamp")
+	}
+	if ev.Data != nil {
+		t.Errorf("event data expected to be nil")
+	}
+
+	q.Shutdown()
+
+	select {
+	case _, ok := <-eventCh:
+		if ok {
+			t.Errorf("Expected eventCh to be closed")
+		}
+	case <-time.After(time.Second):
+		t.Error("Timed out waiting for eventCh to close")
+	}
+
+	<-disconnectedCh
+	wg.Wait()
+}
+
+// Checks that commands issued after the QMP loop exits fail (and don't hang)
+//
+// We start the QMP loop but force it to fail immediately simulating a QEMU
+// instance exit.  We then send two qmp_cabilities commands.
+//
+// Both commands should fail with an error.  The QMP loop should exit.
+func TestQMPLostLoop(t *testing.T) {
+	connectedCh := make(chan *QMPVersion)
+	disconnectedCh := make(chan struct{})
+	buf := newQMPTestCommandBuffer(t)
+
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
+	checkVersion(t, connectedCh)
+	close(buf.forceFail)
+	buf.AddCommmand("qmp_capabilities", nil, "return", nil)
+	err := q.ExecuteQMPCapabilities(context.Background())
+	if err == nil {
+		t.Error("Expected executeQMPCapabilities to fail")
+	}
+	<-disconnectedCh
+	buf.AddCommmand("qmp_capabilities", nil, "return", nil)
+	err = q.ExecuteQMPCapabilities(context.Background())
+	if err == nil {
+		t.Error("Expected executeQMPCapabilities to fail")
+	}
+}


### PR DESCRIPTION
The PR introduces a new ciao package, qemu, that provides a set of methods and types for launching and managing qemu instances.  This code is a re-write of the qemu management code originally written for launcher.  ciao-launcher now uses the new qemu package in preference to its old qemu code.  A nice side effect of this change is that the volume detach now works properly as the qemu package correctly implements this function.