### PR TITLE
add unit test for block api os-detach action

### DIFF
--- a/openstack/block/api.go
+++ b/openstack/block/api.go
@@ -479,7 +479,6 @@ func showAbsoluteLimits(bc *Context, w http.ResponseWriter, r *http.Request) (AP
 }
 
 func createVolume(bc *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
-	fmt.Println("create volume request!")
 	vars := mux.Vars(r)
 	tenant := vars["tenant"]
 

--- a/openstack/block/api_test.go
+++ b/openstack/block/api_test.go
@@ -111,6 +111,14 @@ var tests = []test{
 		http.StatusAccepted,
 		"null",
 	},
+	{
+		"POST",
+		"/v2/validtenantid/volumes/validvolumeid/action",
+		volumeAction,
+		`{"os-detach":{}}`,
+		http.StatusAccepted,
+		"null",
+	},
 }
 
 type testVolumeService struct{}


### PR DESCRIPTION
update the openstack api unit tests to include one for the os-detach action.