### PR TITLE
ciao-controller: add name and description to block_data

### DIFF
--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -200,6 +200,8 @@ func (d blockData) Init() error {
 		size integer,
 		state string,
 		create_time DATETIME,
+		name string,
+		description string,
 		foreign key(tenant_id) references tenants(id)
 		);`
 
@@ -2094,7 +2096,9 @@ func (ds *sqliteDB) getTenantDevices(tenantID string) (map[string]types.BlockDat
 				block_data.tenant_id,
 				block_data.size,
 				block_data.state,
-				block_data.create_time
+				block_data.create_time,
+				block_data.name,
+				block_data.description
 		  FROM	block_data
 		  WHERE block_data.tenant_id = ?`
 
@@ -2109,7 +2113,7 @@ func (ds *sqliteDB) getTenantDevices(tenantID string) (map[string]types.BlockDat
 		var state string
 		var data types.BlockData
 
-		err = rows.Scan(&data.ID, &data.TenantID, &data.Size, &state, &data.CreateTime)
+		err = rows.Scan(&data.ID, &data.TenantID, &data.Size, &state, &data.CreateTime, &data.Name, &data.Description)
 		if err != nil {
 			continue
 		}
@@ -2136,7 +2140,9 @@ func (ds *sqliteDB) getAllBlockData() (map[string]types.BlockData, error) {
 				block_data.tenant_id,
 				block_data.size,
 				block_data.state,
-				block_data.create_time
+				block_data.create_time,
+				block_data.name,
+				block_data.description
 		  FROM	block_data `
 
 	rows, err := datastore.Query(query)
@@ -2149,7 +2155,7 @@ func (ds *sqliteDB) getAllBlockData() (map[string]types.BlockData, error) {
 		var data types.BlockData
 		var state string
 
-		err = rows.Scan(&data.ID, &data.TenantID, &data.Size, &state, &data.CreateTime)
+		err = rows.Scan(&data.ID, &data.TenantID, &data.Size, &state, &data.CreateTime, &data.Name, &data.Description)
 		if err != nil {
 			continue
 		}
@@ -2166,7 +2172,7 @@ func (ds *sqliteDB) getAllBlockData() (map[string]types.BlockData, error) {
 
 func (ds *sqliteDB) createBlockData(data types.BlockData) error {
 	ds.dbLock.Lock()
-	err := ds.create("block_data", data.ID, data.TenantID, data.Size, string(data.State), data.CreateTime.Format(time.RFC3339Nano))
+	err := ds.create("block_data", data.ID, data.TenantID, data.Size, string(data.State), data.CreateTime.Format(time.RFC3339Nano), data.Name, data.Description)
 	ds.dbLock.Unlock()
 
 	return err

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -36,7 +36,6 @@ func (c *controller) GetAbsoluteLimits(tenant string) (block.AbsoluteLimits, err
 // CreateVolume will create a new block device and store it in the datastore.
 // TBD: we need a better way to do bootable.
 func (c *controller) CreateVolume(tenant string, req block.RequestedVolume) (block.Volume, error) {
-
 	t, err := c.ds.GetTenant(tenant)
 	if err != nil {
 		return block.Volume{}, err
@@ -73,6 +72,15 @@ func (c *controller) CreateVolume(tenant string, req block.RequestedVolume) (blo
 		TenantID:    tenant,
 		State:       types.Available,
 	}
+
+	if req.Name != nil {
+		data.Name = *req.Name
+	}
+
+	if req.Description != nil {
+		data.Description = *req.Description
+	}
+
 	err = c.ds.AddBlockDevice(data)
 	if err != nil {
 		c.DeleteBlockDevice(bd.ID)
@@ -276,6 +284,14 @@ func (c *controller) ListVolumesDetail(tenant string) ([]block.VolumeDetail, err
 		vol.OSVolTenantAttr = data.TenantID
 		vol.CreatedAt = &data.CreateTime
 
+		if data.Name != "" {
+			vol.Name = &data.Name
+		}
+
+		if data.Description != "" {
+			vol.Description = &data.Description
+		}
+
 		switch data.State {
 		case types.Attaching:
 			vol.Status = block.Attaching
@@ -309,6 +325,14 @@ func (c *controller) ShowVolumeDetails(tenant string, volume string) (block.Volu
 	vol.Size = data.Size
 	vol.OSVolTenantAttr = data.TenantID
 	vol.CreatedAt = &data.CreateTime
+
+	if data.Name != "" {
+		vol.Name = &data.Name
+	}
+
+	if data.Description != "" {
+		vol.Description = &data.Description
+	}
 
 	switch data.State {
 	case types.Attaching:

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -228,10 +228,12 @@ const (
 // or can we use a set of interfaces to get the info?
 type BlockData struct {
 	storage.BlockDevice
-	TenantID   string     // the tenant who owns this volume
-	Size       int        // size in GB
-	State      BlockState // status of
-	CreateTime time.Time  // when we created the volume
+	TenantID    string     // the tenant who owns this volume
+	Size        int        // size in GB
+	State       BlockState // status of
+	CreateTime  time.Time  // when we created the volume
+	Name        string     // a human readable name for this volume
+	Description string     // some text to describe this volume.
 }
 
 // StorageAttachment represents a link between a block device and


### PR DESCRIPTION
Support storage of a name and description field with block data.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>