### PR TITLE
ciao-controller: check error on tenant out of bounds test.

### DIFF
--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -208,7 +208,10 @@ func TestTenantOutOfBounds(t *testing.T) {
 	}
 
 	/* put tenant limit of 1 instance */
-	_ = context.ds.AddLimit(tenant.ID, 1, 1)
+	err = context.ds.AddLimit(tenant.ID, 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	wls, err := context.ds.GetWorkloads()
 	if err != nil || len(wls) == 0 {


### PR DESCRIPTION
If we don't add the tenant limit correctly, do not proceed
with the test.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>