### PR TITLE
singlevm: Fix hardcoded SSH version

### DIFF
--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -290,7 +290,7 @@ do
 
 	echo "Attempting to ssh to: $ssh_ip"
 
-	if [[ "$ssh_check" == *SSH-2.0-OpenSSH_7.2* ]]
+	if [[ "$ssh_check" == *SSH-2.0-OpenSSH_* ]]
 	then
 		echo "SSH connectivity verified"
 		break


### PR DESCRIPTION
This commit fixes the issue with hard coded SSH version validation
on Single VM.
```
    if [[ "$ssh_check" == *SSH-2.0-OpenSSH_7.2* ]]
```
Now, it will validate against ``"*SSH-2.0-OpenSSH_*"`` which will be
more generic for future SSH versions.

Fixes #493 

Signed-off-by: Munoz, Obed N <obed.n.munoz@intel.com>