### PR TITLE
ciao-launcher: Fix ciao-launcher-server usage with --network

### DIFF
--- a/ciao-launcher/tests/ciao-launcher-server/server.go
+++ b/ciao-launcher/tests/ciao-launcher-server/server.go
@@ -493,8 +493,12 @@ func createConfigFile(confPath string) error {
 
 	conf.Configure.Launcher.DiskLimit = diskLimit
 	conf.Configure.Launcher.MemoryLimit = memLimit
-	conf.Configure.Launcher.ComputeNetwork = []string{computeNet}
-	conf.Configure.Launcher.ManagementNetwork = []string{mgmtNet}
+	if computeNet != "" {
+		conf.Configure.Launcher.ComputeNetwork = []string{computeNet}
+	}
+	if mgmtNet != "" {
+		conf.Configure.Launcher.ManagementNetwork = []string{mgmtNet}
+	}
 	conf.Configure.Storage.SecretPath = secretPath
 	conf.Configure.Storage.CephID = cephID
 


### PR DESCRIPTION
This small patch allows launcher's test server, ciao-launcher-server, to be
used by launcher instances that have networking enabled, which is now the
default.

Fixes: #502

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>