### PR TITLE
ciao-launcher: Fix docker dependency in ubuntu

### DIFF
--- a/ciao-launcher/deps.go
+++ b/ciao-launcher/deps.go
@@ -62,5 +62,5 @@ var launcherComputeNodeDeps = map[string][]osprepare.PackageRequirement{
 	"fedora": append(launcherFedoraCommonDeps,
 		osprepare.PackageRequirement{BinaryName: "/usr/bin/docker", PackageName: "docker-engine"}),
 	"ubuntu": append(launcherUbuntuCommonDeps,
-		osprepare.PackageRequirement{BinaryName: "/usr/bin/docker", PackageName: "docker"}),
+		osprepare.PackageRequirement{BinaryName: "/usr/bin/docker", PackageName: "docker-engine"}),
 }


### PR DESCRIPTION
The 'docker' package is being installed as a dependency to
get docker insalled in Ubuntu, however, the package needed
is 'docker-engine'

From apt-cache search docker
  - docker - System tray for KDE3/GNOME2 docklet applications
  - docker-engine - Docker: the open-source application container engine

Fixes #508

Signed-off-by: Alberto Murillo <alberto.murillo.silva@intel.com>