### PR TITLE
osprepare: Add logging abstraction

### DIFF
--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -143,8 +143,9 @@ func main() {
 		*cephID = clusterConfig.Configure.Storage.CephID
 	}
 
-	osprepare.Bootstrap()
-	osprepare.InstallDeps(controllerDeps)
+	ospLogger := osprepare.OSPGlogLogger{}
+	osprepare.Bootstrap(ospLogger)
+	osprepare.InstallDeps(controllerDeps, ospLogger)
 
 	if *singleMachine {
 		hostname, _ := os.Hostname()

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -239,12 +239,13 @@ func (client *agentClient) ErrorNotify(err ssntp.Error, frame *ssntp.Frame) {
 
 func (client *agentClient) installLauncherDeps() {
 	role := client.conn.Role()
-	osprepare.Bootstrap()
+	ospLogger := osprepare.OSPGlogLogger{}
+	osprepare.Bootstrap(ospLogger)
 	if role.IsNetAgent() {
-		osprepare.InstallDeps(launcherNetNodeDeps)
+		osprepare.InstallDeps(launcherNetNodeDeps, ospLogger)
 	}
 	if role.IsAgent() {
-		osprepare.InstallDeps(launcherComputeNodeDeps)
+		osprepare.InstallDeps(launcherComputeNodeDeps, ospLogger)
 	}
 }
 

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -1042,8 +1042,9 @@ func configSchedulerServer() (sched *ssntpSchedulerServer) {
 
 func main() {
 	flag.Parse()
-	osprepare.Bootstrap()
-	osprepare.InstallDeps(schedDeps)
+	ospLogger := osprepare.OSPGlogLogger{}
+	osprepare.Bootstrap(ospLogger)
+	osprepare.InstallDeps(schedDeps, ospLogger)
 
 	sched := configSchedulerServer()
 	if sched == nil {

--- a/osprepare/main.go
+++ b/osprepare/main.go
@@ -174,15 +174,19 @@ func InstallDeps(reqs PackageRequirements, logger OSPLog) {
 		}
 		return
 	}
+	logger.Infof("OS Detected: %s", distro.getID())
+
 	// Nothing requested to install
 	if reqs == nil {
 		return
 	}
 	if reqPkgs := collectPackages(distro, reqs); reqPkgs != nil {
+		logger.Infof("Missing packages detected: %v", reqPkgs)
 		if distro.InstallPackages(reqPkgs, logger) == false {
 			logger.Errorf("Failed to install: %s", strings.Join(reqPkgs, ", "))
 			return
 		}
+		logger.Infof("Missing packages installed.")
 	}
 }
 

--- a/osprepare/versions.go
+++ b/osprepare/versions.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 )
 
-func getCommandOutput(command string) string {
+func getCommandOutput(command string, logger OSPLog) string {
 	splits := strings.Split(command, " ")
 	c := exec.Command(splits[0], splits[1:]...)
 	c.Env = os.Environ()
@@ -35,15 +35,15 @@ func getCommandOutput(command string) string {
 
 	out, err := c.Output()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to run %s: %s\n", splits[0], err)
+		logger.Warningf("Failed to run %s: %s", splits[0], err)
 		return ""
 	}
 
 	return string(out)
 }
 
-func getDockerVersion() string {
-	ret := getCommandOutput("docker --version")
+func getDockerVersion(logger OSPLog) string {
+	ret := getCommandOutput("docker --version", logger)
 	var version string
 
 	if n, _ := fmt.Sscanf(ret, "Docker version %s, build", &version); n != 1 {
@@ -56,8 +56,8 @@ func getDockerVersion() string {
 	return version
 }
 
-func getQemuVersion() string {
-	ret := getCommandOutput("qemu-system-x86_64 --version")
+func getQemuVersion(logger OSPLog) string {
+	ret := getCommandOutput("qemu-system-x86_64 --version", logger)
 	var version string
 
 	if n, _ := fmt.Sscanf(ret, "QEMU emulator version %s, Copyright (c)", &version); n != 1 {

--- a/osprepare/versions_test.go
+++ b/osprepare/versions_test.go
@@ -24,7 +24,7 @@ func TestGetDocker(t *testing.T) {
 	if pathExists("/usr/bin/docker") == false {
 		t.Skip("Docker not installed, cannot validate version get")
 	}
-	if vers := getDockerVersion(); vers == "" {
+	if vers := getDockerVersion(nil); vers == "" {
 		t.Fatal("Cannot determine docker version")
 	}
 }
@@ -33,7 +33,7 @@ func TestGetQemu(t *testing.T) {
 	if pathExists("/usr/bin/qemu-system-x86_64") == false {
 		t.Skip("Qemu not installed, cannot validate version get")
 	}
-	if vers := getQemuVersion(); vers == "" {
+	if vers := getQemuVersion(ospNullLogger{}); vers == "" {
 		t.Fatal("Cannot determine qemu version")
 	}
 }


### PR DESCRIPTION
Instead of writing to stdout/stderr directly, adopt the use of a glog
using abstraction similar to the qemu component.

Signed-off-by: William Douglas <william.r.douglas@gmail.com>

Address #504