### PR TITLE
ssntp: Fix ineffassign error

### DIFF
--- a/ssntp/ssntp.go
+++ b/ssntp/ssntp.go
@@ -1250,6 +1250,10 @@ certsLoop:
 	}
 
 	certPEM, err := ioutil.ReadFile(cacert)
+	if err != nil {
+		return "", "", err
+	}
+
 	certPool := x509.NewCertPool()
 	certPool.AppendCertsFromPEM(certPEM)
 	vOpts := x509.VerifyOptions{Roots: certPool}


### PR DESCRIPTION
We are not using an ioutil error:
ssntp.go:1252:11: ineffectual assignment to err

We should check for a non nil error instead.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>