### PR TITLE
ciao-launcher: Support volume attach on start

### DIFF
--- a/ciao-launcher/docker.go
+++ b/ciao-launcher/docker.go
@@ -243,7 +243,7 @@ func (d *docker) deleteImage() error {
 	return err
 }
 
-func (d *docker) startVM(vnicName, ipAddress string) error {
+func (d *docker) startVM(vnicName, ipAddress, cephID string) error {
 	cli, err := getDockerClient()
 	if err != nil {
 		return err

--- a/ciao-launcher/instance_test.go
+++ b/ciao-launcher/instance_test.go
@@ -86,7 +86,7 @@ func (v *instanceTestState) deleteImage() error {
 	return nil
 }
 
-func (v *instanceTestState) startVM(vnicName, ipAddress string) error {
+func (v *instanceTestState) startVM(vnicName, ipAddress, cephID string) error {
 	if v.failStartVM {
 		return fmt.Errorf("Failed to start VM")
 	}

--- a/ciao-launcher/payload.go
+++ b/ciao-launcher/payload.go
@@ -98,6 +98,23 @@ func computeSSHPort(networkNode bool, vnicIP string) int {
 	return port
 }
 
+func parseVMTtype(start *payloads.StartCmd) (container bool, image string, err error) {
+	vmType := start.VMType
+	if vmType != "" && vmType != payloads.QEMU && vmType != payloads.Docker {
+		err = fmt.Errorf("Invalid vmtype received: %s", vmType)
+		return
+	}
+
+	container = vmType == payloads.Docker
+	if container {
+		image = start.DockerImage
+	} else {
+		image = start.ImageUUID
+	}
+
+	return
+}
+
 func parseStartPayload(data []byte) (*vmConfig, *payloadError) {
 	var clouddata payloads.Start
 
@@ -122,21 +139,11 @@ func parseStartPayload(data []byte) (*vmConfig, *payloadError) {
 	}
 	legacy := fwType == payloads.Legacy
 
-	vmType := start.VMType
-	if vmType != "" && vmType != payloads.QEMU && vmType != payloads.Docker {
-		err = fmt.Errorf("Invalid vmtype received: %s", vmType)
-		return nil, &payloadError{err, payloads.InvalidData}
-	}
-
 	var disk, cpus, mem int
 	var networkNode bool
-	var image string
-
-	container := vmType == payloads.Docker
-	if container {
-		image = start.DockerImage
-	} else {
-		image = start.ImageUUID
+	container, image, err := parseVMTtype(start)
+	if err != nil {
+		return nil, &payloadError{err, payloads.InvalidData}
 	}
 
 	for i := range start.RequestedResources {

--- a/ciao-launcher/payload.go
+++ b/ciao-launcher/payload.go
@@ -155,6 +155,10 @@ func parseStartPayload(data []byte) (*vmConfig, *payloadError) {
 	net := &start.Networking
 	vnicIP := strings.TrimSpace(net.PrivateIP)
 	sshPort := computeSSHPort(networkNode, vnicIP)
+	volumes := make(map[string]struct{})
+	if start.Storage.ID != "" {
+		volumes[start.Storage.ID] = struct{}{}
+	}
 
 	return &vmConfig{Cpus: cpus,
 		Mem:         mem,
@@ -172,7 +176,7 @@ func parseStartPayload(data []byte) (*vmConfig, *payloadError) {
 		ConcUUID:    strings.TrimSpace(net.ConcentratorUUID),
 		VnicUUID:    strings.TrimSpace(net.VnicUUID),
 		SSHPort:     sshPort,
-		Volumes:     make(map[string]struct{}),
+		Volumes:     volumes,
 	}, nil
 }
 

--- a/ciao-launcher/qemu_test.go
+++ b/ciao-launcher/qemu_test.go
@@ -155,7 +155,7 @@ func TestGenerateQEMULaunchParams(t *testing.T) {
 	params := genQEMUParams(nil)
 	cfg.Legacy = true
 	genParams := generateQEMULaunchParams(&cfg, "/var/lib/ciao/instance/1/seed.iso",
-		"/var/lib/ciao/instance/1", nil)
+		"/var/lib/ciao/instance/1", nil, "ciao")
 	if !reflect.DeepEqual(params, genParams) {
 		t.Fatalf("%s and %s do not match", params, genParams)
 	}
@@ -166,7 +166,7 @@ func TestGenerateQEMULaunchParams(t *testing.T) {
 	cfg.Cpus = 0
 	params = append(params, "-bios", qemuEfiFw)
 	genParams = generateQEMULaunchParams(&cfg, "/var/lib/ciao/instance/1/seed.iso",
-		"/var/lib/ciao/instance/1", nil)
+		"/var/lib/ciao/instance/1", nil, "ciao")
 	if !reflect.DeepEqual(params, genParams) {
 		t.Fatalf("%s and %s do not match", params, genParams)
 	}
@@ -177,7 +177,7 @@ func TestGenerateQEMULaunchParams(t *testing.T) {
 	cfg.Legacy = true
 	params = append(params, "-m", "100")
 	genParams = generateQEMULaunchParams(&cfg, "/var/lib/ciao/instance/1/seed.iso",
-		"/var/lib/ciao/instance/1", nil)
+		"/var/lib/ciao/instance/1", nil, "ciao")
 	if !reflect.DeepEqual(params, genParams) {
 		t.Fatalf("%s and %s do not match", params, genParams)
 	}
@@ -188,7 +188,7 @@ func TestGenerateQEMULaunchParams(t *testing.T) {
 	cfg.Legacy = true
 	params = append(params, "-smp", "cpus=4")
 	genParams = generateQEMULaunchParams(&cfg, "/var/lib/ciao/instance/1/seed.iso",
-		"/var/lib/ciao/instance/1", nil)
+		"/var/lib/ciao/instance/1", nil, "ciao")
 	if !reflect.DeepEqual(params, genParams) {
 		t.Fatalf("%s and %s do not match", params, genParams)
 	}
@@ -199,7 +199,7 @@ func TestGenerateQEMULaunchParams(t *testing.T) {
 	cfg.Cpus = 0
 	cfg.Legacy = true
 	genParams = generateQEMULaunchParams(&cfg, "/var/lib/ciao/instance/1/seed.iso",
-		"/var/lib/ciao/instance/1", netParams)
+		"/var/lib/ciao/instance/1", netParams, "ciao")
 	if !reflect.DeepEqual(params, genParams) {
 		t.Fatalf("%s and %s do not match", params, genParams)
 	}

--- a/ciao-launcher/restart_instance.go
+++ b/ciao-launcher/restart_instance.go
@@ -39,7 +39,7 @@ func processRestart(instanceDir string, vm virtualizer, conn serverConn, cfg *vm
 		}
 	}
 
-	err = vm.startVM(vnicName, getNodeIPAddress())
+	err = vm.startVM(vnicName, getNodeIPAddress(), cephID)
 	if err != nil {
 		return &restartError{err, payloads.RestartLaunchFailure}
 	}

--- a/ciao-launcher/simulation.go
+++ b/ciao-launcher/simulation.go
@@ -98,7 +98,7 @@ VM:
 
 }
 
-func (s *simulation) startVM(vnicName, ipAddress string) error {
+func (s *simulation) startVM(vnicName, ipAddress, cephID string) error {
 	glog.Infof("startVM\n")
 
 	s.killCh = make(chan struct{})

--- a/ciao-launcher/start_instance.go
+++ b/ciao-launcher/start_instance.go
@@ -141,7 +141,7 @@ func processStart(cmd *insStartCmd, instanceDir string, vm virtualizer, conn ser
 
 	st.creationStamp = time.Now()
 
-	err = vm.startVM(vnicName, getNodeIPAddress())
+	err = vm.startVM(vnicName, getNodeIPAddress(), cephID)
 	if err != nil {
 		return nil, &startError{err, payloads.LaunchFailure}
 	}

--- a/ciao-launcher/tests/examples/start_legacy_volume.yaml
+++ b/ciao-launcher/tests/examples/start_legacy_volume.yaml
@@ -1,0 +1,42 @@
+---
+start:
+  requested_resources:
+     - type: vcpus
+       value: 2
+     - type: mem_mb
+       value: 370
+     - type: disk_mb
+       value: 8000
+  instance_uuid: d7d86208-b46c-4465-9018-fe14087d415f
+  tenant_uuid: 67d86208-000-4465-9018-fe14087d415f
+  image_uuid: b286cd45-7d0c-4525-a140-4db6c95e41fa
+  fw_type: legacy
+  networking:
+    vnic_mac: 02:00:e6:f5:af:f9
+    vnic_uuid: 67d86208-b46c-0000-9018-fe14087d415f
+    concentrator_ip: 192.168.42.21
+    concentrator_uuid: 67d86208-b46c-4465-0000-fe14087d415f
+    subnet: 192.168.8.0/21
+    private_ip: 192.168.8.2
+  storage:
+    id: 67d86208-000-4465-9018-fe14087d415f
+...
+---
+#cloud-config
+runcmd:
+  - [ touch, "/etc/bootdone" ]
+users:
+  - name: demouser
+    gecos: CIAO Demo User
+    lock-passwd: false
+    passwd: $1$vzmNmLLD$04bivxcjdXRzZLUd.enRl1
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh-authorized-keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDerQfD+qkb0V0XdQs8SBWqy4sQmqYFP96n/kI4Cq162w4UE8pTxy0ozAPldOvBJjljMvgaNKSAddknkhGcrNUvvJsUcZFm2qkafi32WyBdGFvIc45A+8O7vsxPXgHEsS9E3ylEALXAC3D0eX7pPtRiAbasLlY+VcACRqr3bPDSZTfpCmIkV2334uZD9iwOvTVeR+FjGDqsfju4DyzoAIqpPasE0+wk4Vbog7osP+qvn1gj5kQyusmr62+t0wx+bs2dF5QemksnFOswUrv9PGLhZgSMmDQrRYuvEfIAC7IdN/hfjTn0OokzljBiuWQ4WIIba/7xTYLVujJV65qH3heaSMxJJD7eH9QZs9RdbbdTXMFuJFsHV2OF6wZRp18tTNZZJMqiHZZSndC5WP1WrUo3Au/9a+ighSaOiVddHsPG07C/TOEnr3IrwU7c9yIHeeRFHmcQs9K0+n9XtrmrQxDQ9/mLkfje80Ko25VJ/QpAQPzCKh2KfQ4RD+/PxBUScx/lHIHOIhTSCh57ic629zWgk0coSQDi4MKSa5guDr3cuDvt4RihGviDM6V68ewsl0gh6Z9c0Hw7hU0vky4oxak5AiySiPz0FtsOnAzIL0UON+yMuKzrJgLjTKodwLQ0wlBXu43cD+P8VXwQYeqNSzfrhBnHqsrMf4lTLtc7kDDTcw== ciao@ciao
+...
+---
+{
+  "uuid": "ciao",
+  "hostname": "ciao"
+}
+...

--- a/ciao-launcher/virtualizer.go
+++ b/ciao-launcher/virtualizer.go
@@ -73,7 +73,7 @@ type virtualizer interface {
 	deleteImage() error
 
 	// Boots a VM.  This method is called by both START and RESTART.
-	startVM(vnicName, ipAddress string) error
+	startVM(vnicName, ipAddress, cephID string) error
 
 	//BUG(markus): Need to use context rather than the monitor channel to
 	//detect when we need to quit.

--- a/ciao-storage/block.go
+++ b/ciao-storage/block.go
@@ -28,7 +28,7 @@ type BlockDriver interface {
 	CreateBlockDevice(image *string, sizeGB int) (BlockDevice, error)
 	DeleteBlockDevice(string) error
 	MapVolumeToNode(volumeUUID string) (string, error)
-	UnmapVolumeFromNode(devName string) error
+	UnmapVolumeFromNode(volumeUUID string) error
 	GetVolumeMapping() (map[string][]string, error)
 }
 

--- a/ciao-storage/noop.go
+++ b/ciao-storage/noop.go
@@ -43,7 +43,7 @@ func (d *NoopDriver) MapVolumeToNode(volumeUUID string) (string, error) {
 }
 
 // UnmapVolumeFromNode pretends to unmap a volume from a local device on a node.
-func (d *NoopDriver) UnmapVolumeFromNode(devNmae string) error {
+func (d *NoopDriver) UnmapVolumeFromNode(volumeUUID string) error {
 	return nil
 }
 


### PR DESCRIPTION
This PR fixes some storage related issues in launcher.  The main change is provided by 70c4da3 which adds support to attaching volumes to launcher instances when they are started, i.e., when the instance is specified in the start workload.  Such instances can be live detached at a later stage if required.  Attaching the volumes on boot should be faster than live attaching as we do not need to rbd map the volume first.

The other commits rename a poorly named parameter in an interface that was inconsistently named among the types that implement that interface and also fix a gocyclo issue introduced by 70c4da3.