### PR TITLE
travis: Fix Go 1.6 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,8 @@ script:
    - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -text -short -tags travis -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/networking/libsnnet
    # API Documentation is automated by swagger, every PR will verify the documentation can be generated
    # swagger requires all dependencies of the package to be docummented to obtain models (structs, our case the payloads)
-   - go list ./... | sed -e "s/github\.com\/01org\/ciao\/vendor\///" | xargs go get
    # verify ciao-controller api documentation can be generated with swagger
-   - go get github.com/yvasiyarov/swagger
-   - $GOPATH/bin/swagger  -apiPackage=github.com/01org/ciao/ciao-controller -mainApiFile=github.com/01org/ciao/ciao-controller/main.go -format=markdown -contentsTable=false -models=false -ignore "golang_org|context"
+   - if [[ "$TRAVIS_GO_VERSION" != "1.6" ]] ; then go list ./... | sed -e "s/github\.com\/01org\/ciao\/vendor\///" | xargs go get && go get github.com/yvasiyarov/swagger && $GOPATH/bin/swagger  -apiPackage=github.com/01org/ciao/ciao-controller -mainApiFile=github.com/01org/ciao/ciao-controller/main.go -format=markdown -contentsTable=false -models=false -ignore "golang_org|context" ;  fi
 
 after_success:
    - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=/tmp/cover.out


### PR DESCRIPTION
The Go 1.6 builds are currently failing as the swagger documentation checks
require the latest version of ciao's dependencies to be downloaded to the
GOPATH and built.  Sadly, some of the latest versions of our dependencies,
notably docker, no longer compile with 1.6, and so the build fails.  This
commit simply disables the swagger checks on 1.6 builds.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>