### PR TITLE
ciao-image: Fix image upload operation

### DIFF
--- a/ciao-cli/image.go
+++ b/ciao-cli/image.go
@@ -155,7 +155,10 @@ func (cmd *imageAddCommand) run(args []string) error {
 
 	if cmd.file != "" {
 		uploadTenantImage(*identityUser, *identityPassword, *tenantID, image.ID, cmd.file)
-		image, _ = images.Get(client, image.ID).Extract()
+		image, err = images.Get(client, image.ID).Extract()
+		if err != nil {
+			fatalf("Could not retrieve new created image [%s]\n", err)
+		}
 	}
 
 	fmt.Printf("Created image:\n")

--- a/ciao-image/service/service.go
+++ b/ciao-image/service/service.go
@@ -114,6 +114,19 @@ func (is ImageService) UploadImage(imageID string, body io.Reader) (image.Upload
 	return response, nil
 }
 
+// GetImage will get the raw image data
+func (is ImageService) GetImage(imageID string) (image.CreateImageResponse, error) {
+	var response image.CreateImageResponse
+
+	image, err := is.ds.GetImage(imageID)
+	if err != nil {
+		return response, err
+	}
+
+	response, _ = createImageResponse(image)
+	return response, nil
+}
+
 // Config is required to setup the API context for the image service.
 type Config struct {
 	// Port represents the http port that should be used for the service.

--- a/ciao-image/service/service.go
+++ b/ciao-image/service/service.go
@@ -36,7 +36,7 @@ type ImageService struct {
 }
 
 // CreateImage will create an empty image in the image datastore.
-func (is ImageService) CreateImage(req image.CreateImageRequest) (image.CreateImageResponse, error) {
+func (is ImageService) CreateImage(req image.CreateImageRequest) (image.DefaultResponse, error) {
 	// create an ImageInfo struct and store it in our image
 	// datastore.
 	i := datastore.Image{
@@ -48,10 +48,10 @@ func (is ImageService) CreateImage(req image.CreateImageRequest) (image.CreateIm
 
 	err := is.ds.CreateImage(i)
 	if err != nil {
-		return image.CreateImageResponse{}, err
+		return image.DefaultResponse{}, err
 	}
 
-	return image.CreateImageResponse{
+	return image.DefaultResponse{
 		Status:     image.Queued,
 		CreatedAt:  i.CreateTime,
 		Tags:       make([]string, 0),
@@ -67,8 +67,8 @@ func (is ImageService) CreateImage(req image.CreateImageRequest) (image.CreateIm
 	}, nil
 }
 
-func createImageResponse(img datastore.Image) (image.CreateImageResponse, error) {
-	return image.CreateImageResponse{
+func createImageResponse(img datastore.Image) (image.DefaultResponse, error) {
+	return image.DefaultResponse{
 		Status:     img.State.Status(),
 		CreatedAt:  img.CreateTime,
 		Tags:       make([]string, 0),
@@ -85,8 +85,8 @@ func createImageResponse(img datastore.Image) (image.CreateImageResponse, error)
 }
 
 // ListImages will return a list of all the images in the datastore.
-func (is ImageService) ListImages() ([]image.CreateImageResponse, error) {
-	var response []image.CreateImageResponse
+func (is ImageService) ListImages() ([]image.DefaultResponse, error) {
+	var response []image.DefaultResponse
 
 	images, err := is.ds.GetAllImages()
 	if err != nil {
@@ -115,8 +115,8 @@ func (is ImageService) UploadImage(imageID string, body io.Reader) (image.Upload
 }
 
 // GetImage will get the raw image data
-func (is ImageService) GetImage(imageID string) (image.CreateImageResponse, error) {
-	var response image.CreateImageResponse
+func (is ImageService) GetImage(imageID string) (image.DefaultResponse, error) {
+	var response image.DefaultResponse
 
 	image, err := is.ds.GetImage(imageID)
 	if err != nil {

--- a/openstack/image/api.go
+++ b/openstack/image/api.go
@@ -147,9 +147,9 @@ type CreateImageRequest struct {
 	Properties      interface{}     `json:"properties,omitempty"`
 }
 
-// CreateImageResponse contains information about a created image
+// DefaultResponse contains information about an image
 // http://developer.openstack.org/api-ref-image-v2.html#createImage-v2
-type CreateImageResponse struct {
+type DefaultResponse struct {
 	Status          Status           `json:"status"`
 	ContainerFormat *ContainerFormat `json:"container_format"`
 	MinRAM          *int             `json:"min_ram"`
@@ -176,9 +176,9 @@ type CreateImageResponse struct {
 // ListImagesResponse contains the list of all images that have been created.
 // http://developer.openstack.org/api-ref-image-v2.html#listImages-v2
 type ListImagesResponse struct {
-	Images []CreateImageResponse `json:"images"`
-	Schema string                `json:"schema"`
-	First  string                `json:"first"`
+	Images []DefaultResponse `json:"images"`
+	Schema string            `json:"schema"`
+	First  string            `json:"first"`
 }
 
 // UploadImageResponse contains the UUID of the image which content got uploaded
@@ -200,10 +200,10 @@ type APIConfig struct {
 // Service is the interface that the api requires in order to get
 // information needed to implement the image endpoints.
 type Service interface {
-	CreateImage(CreateImageRequest) (CreateImageResponse, error)
+	CreateImage(CreateImageRequest) (DefaultResponse, error)
 	UploadImage(string, io.Reader) (UploadImageResponse, error)
-	ListImages() ([]CreateImageResponse, error)
-	GetImage(string) (CreateImageResponse, error)
+	ListImages() ([]DefaultResponse, error)
+	GetImage(string) (DefaultResponse, error)
 }
 
 // Context contains data and interfaces that the image api will need.


### PR DESCRIPTION
Image Upload was failing due a missing ``GetImage`` method that was required as the final request in the image upload process. New ``GetImage`` handler was added to ``ciao-image`` service.

Image Upload operation requires a final ``GetImage`` request in order to verify that new image is created.

Signed-off-by: Munoz, Obed N <obed.n.munoz@intel.com>