### PR TITLE
storage: implement ceph block delete

### DIFF
--- a/ciao-storage/ceph.go
+++ b/ciao-storage/ceph.go
@@ -58,9 +58,10 @@ func (d CephDriver) CreateBlockDevice(imagePath *string, size int) (BlockDevice,
 }
 
 // DeleteBlockDevice will remove a rbd image from the ceph cluster.
-// Not implemented yet.
-func (d CephDriver) DeleteBlockDevice(string) error {
-	return nil
+func (d CephDriver) DeleteBlockDevice(volumeUUID string) error {
+	cmd := exec.Command("rbd", "--keyring", d.SecretPath, "--id", d.ID, "rm", volumeUUID)
+	_, err := cmd.CombinedOutput()
+	return err
 }
 
 func (d CephDriver) getCredentials() []string {

--- a/ciao-storage/ceph.go
+++ b/ciao-storage/ceph.go
@@ -48,8 +48,7 @@ func (d CephDriver) CreateBlockDevice(imagePath *string, size int) (BlockDevice,
 		cmd = exec.Command("rbd", "--keyring", d.SecretPath, "--id", d.ID, "--image-format", "1", "create", "--size", strconv.Itoa(size), ID)
 	}
 
-	_, err := cmd.CombinedOutput()
-
+	err := cmd.Run()
 	if err != nil {
 		return BlockDevice{}, err
 	}
@@ -60,8 +59,7 @@ func (d CephDriver) CreateBlockDevice(imagePath *string, size int) (BlockDevice,
 // DeleteBlockDevice will remove a rbd image from the ceph cluster.
 func (d CephDriver) DeleteBlockDevice(volumeUUID string) error {
 	cmd := exec.Command("rbd", "--keyring", d.SecretPath, "--id", d.ID, "rm", volumeUUID)
-	_, err := cmd.CombinedOutput()
-	return err
+	return cmd.Run()
 }
 
 func (d CephDriver) getCredentials() []string {

--- a/ciao-storage/ceph_test.go
+++ b/ciao-storage/ceph_test.go
@@ -19,18 +19,25 @@ import (
 	"testing"
 )
 
+var driver = CephDriver{
+	SecretPath: "/etc/ceph/ceph.client.kristen.keyring",
+	ID:         "kristen",
+}
+
+var imagePath = "/var/lib/ciao/images/73a86d7e-93c0-480e-9c41-ab42f69b7799"
+
 func TestCreateBlockDevice(t *testing.T) {
-	driver := cephDriver{
-		SecretPath: "/etc/ceph/ceph.client.kristen.keyring",
-		ID:         "kristen",
-	}
-
-	imagePath := "/var/lib/ciao/images/73a86d7e-93c0-480e-9c41-ab42f69b7799"
-
 	device, err := driver.CreateBlockDevice(&imagePath, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	fmt.Println(device.ID)
+}
+
+func TestDeleteBlockDevice(t *testing.T) {
+	err := driver.DeleteBlockDevice(imagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
This is a trivial implementation of the missing delete function in our ceph
driver and addition of a simple test case.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>