### PR TITLE
ciao-controller: Return an empty volumes list

### DIFF
--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -279,7 +279,7 @@ func (c *controller) ListVolumes(tenant string) ([]block.ListVolume, error) {
 }
 
 func (c *controller) ListVolumesDetail(tenant string) ([]block.VolumeDetail, error) {
-	var vols []block.VolumeDetail
+	vols := []block.VolumeDetail{}
 
 	err := c.confirmTenant(tenant)
 	if err != nil {


### PR DESCRIPTION
OpenStack blockstorage v2 api state that the return value
for /v2/tenant/volumes/detail should be a list of volumes,
however, ciao was returning {"volumes":null}.

With this fix ciao now returns the correct response as
{"volumes": []}

Signed-off-by: Alberto Murillo <alberto.murillo.silva@intel.com>