### PR TITLE
ciao-launcher: install bootstrap dependencies

### DIFF
--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -143,6 +143,7 @@ func main() {
 		*cephID = clusterConfig.Configure.Storage.CephID
 	}
 
+	osprepare.Bootstrap()
 	osprepare.InstallDeps(controllerDeps)
 
 	if *singleMachine {

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -238,6 +238,7 @@ func (client *agentClient) ErrorNotify(err ssntp.Error, frame *ssntp.Frame) {
 
 func (client *agentClient) installLauncherDeps() {
 	role := client.conn.Role()
+	osprepare.Bootstrap()
 	if role.IsNetAgent() {
 		osprepare.InstallDeps(launcherNetNodeDeps)
 	}

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -1042,6 +1042,7 @@ func configSchedulerServer() (sched *ssntpSchedulerServer) {
 
 func main() {
 	flag.Parse()
+	osprepare.Bootstrap()
 	osprepare.InstallDeps(schedDeps)
 
 	sched := configSchedulerServer()


### PR DESCRIPTION
osprepare.Bootstrap function was designed to install
dependencies required in all ciao cluster nodes but
was unused.

This change makes use of osprepare.Bootstrap() function
to install ceph cli on all nodes.

Signed-off-by: Alberto Murillo <alberto.murillo.silva@intel.com>