### PR TITLE
ciao-cli: Support specifying CA file in environment or command line

### DIFF
--- a/ciao-cli/README.md
+++ b/ciao-cli/README.md
@@ -19,6 +19,8 @@ The options are:
 
   -alsologtostderr
         log to standard error as well as files
+  -ca-file string
+        CA Certificate
   -computeport int
         Openstack Compute API port (default 8774)
   -controller string
@@ -61,7 +63,7 @@ Use "ciao-cli command -help" for more information about that command.
 
 ## Ciao environment variables
 
-ciao-cli first look for Ciao specific environment variables to retrieve
+ciao-cli first looks for Ciao specific environment variables to retrieve
 credentials and networking information:
 
 * `CIAO_CONTROLLER` exports the Ciao controller URL
@@ -70,6 +72,7 @@ credentials and networking information:
 * `CIAO_USERNAME` exports the Ciao username
 * `CIAO_PASSWORD` export the Ciao password for `CIAO_USERNAME`
 * `CIAO_TENANT_NAME` export the Ciao tenant name for `CIAO_USERNAME`
+* `CIAO_CA_CERT_FILE` (optional) use the supplied certificate as the CA
 
 All those environment variables can be set through an rc file.
 For example:
@@ -89,11 +92,9 @@ or overridden from the `ciao-cli` command line.
 
 ## Keystone certificates
 
-ciao-cli interact with the CIAO keystone instance over HTTPS.
-As such you will have to install the keystone CA certificate locally
-in order for ciao-cli to verify the keystone identity.
-
-CA certificate installation is a distribution specific process. For example:
+ciao-cli interacts with the CIAO keystone instance over HTTPS.  As such you
+will need to have the keystone CA certificate available in order to make
+requests. You can either install the CA certificate system-wide:
 
 * On Fedora:
 ```shell
@@ -106,6 +107,9 @@ sudo update-ca-trust
 sudo cp keystone_ca_cert.pem /usr/local/share/ca-certificates/keystone.crt
 sudo update-ca-certificates
 ```
+
+Or, alternatively the CA certificate may be specified with the `-ca-file`
+command line or with the `CIAO_CA_CERT_FILE` environment variable.
 
 ## Priviledged versus non priviledged CIAO users
 

--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -130,6 +131,7 @@ var (
 	tenantID         = flag.String("tenant-id", "", "Tenant UUID")
 	tenantName       = flag.String("tenant-name", "", "Tenant name")
 	computePort      = flag.Int("computeport", openstackComputePort, "Openstack Compute API port")
+	caCertFile       = flag.String("ca-file", "", "CA Certificate")
 )
 
 const (
@@ -139,7 +141,10 @@ const (
 	ciaoPasswordEnv    = "CIAO_PASSWORD"
 	ciaoComputePortEnv = "CIAO_COMPUTEPORT"
 	ciaoTenantNameEnv  = "CIAO_TENANT_NAME"
+	ciaoCACertFileEnv  = "CIAO_CA_CERT_FILE"
 )
+
+var caCertPool *x509.CertPool
 
 type queryValue struct {
 	name, value string
@@ -197,6 +202,10 @@ func sendHTTPRequestToken(method string, url string, values []queryValue, token 
 
 	warningf("Skipping TLS verification\n")
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+
+	if caCertPool != nil {
+		tlsConfig.RootCAs = caCertPool
+	}
 
 	transport := &http.Transport{
 		TLSClientConfig: tlsConfig,
@@ -266,6 +275,7 @@ func getCiaoEnvVariables() {
 	password := os.Getenv(ciaoPasswordEnv)
 	port := os.Getenv(ciaoComputePortEnv)
 	tenant := os.Getenv(ciaoTenantNameEnv)
+	ca := os.Getenv(ciaoCACertFileEnv)
 
 	infof("Ciao environment variables:\n")
 	infof("\t%s:%s\n", ciaoIdentityEnv, identity)
@@ -274,6 +284,7 @@ func getCiaoEnvVariables() {
 	infof("\t%s:%s\n", ciaoPasswordEnv, password)
 	infof("\t%s:%s\n", ciaoComputePortEnv, port)
 	infof("\t%s:%s\n", ciaoTenantNameEnv, tenantName)
+	infof("\t%s:%s\n", ciaoCACertFileEnv, ca)
 
 	if identity != "" && *identityURL == "" {
 		*identityURL = identity
@@ -297,6 +308,10 @@ func getCiaoEnvVariables() {
 
 	if tenant != "" && *tenantName == "" {
 		*tenantName = tenant
+	}
+
+	if ca != "" && *caCertFile == "" {
+		*caCertFile = ca
 	}
 }
 
@@ -337,6 +352,16 @@ func main() {
 	args := flag.Args()
 	if len(args) < 1 {
 		usage()
+	}
+
+	/* Load CA file if necessary */
+	if *caCertFile != "" {
+		caCert, err := ioutil.ReadFile(*caCertFile)
+		if err != nil {
+			fatalf("Unable to load requested CA certificate: %s\n", err)
+		}
+		caCertPool = x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
 	}
 
 	/* If we're missing the tenant name let's try to fetch one */


### PR DESCRIPTION
With this change the CA certificate file used for communicating with
keystone and the controller can be specified:

a.) either on the command line with -ca-file,
b.) or with an envionment variable, CIAO_CA_CERT_FILE,

thus avoiding the need to import the certificate into you local store.

This change required switching from openstack.AuthenticatedClient() to
the lower level API in order to override the transport options on the
HTTP client.

Fixes #180

Signed-off-by: Rob Bradford <robert.bradford@intel.com>