### PR TITLE
[RFC] qemu: Create Qemu launch custom API

### DIFF
--- a/ciao-launcher/qemu.go
+++ b/ciao-launcher/qemu.go
@@ -357,7 +357,14 @@ func launchQemuWithNC(params []string, fds []*os.File, ipAddress string) (int, e
 		ncString := "socket,port=%d,host=%s,server,id=gnc0,server,nowait"
 		params[len(params)-1] = fmt.Sprintf(ncString, port, ipAddress)
 		var errStr string
-		errStr, err = qemu.LaunchQemu(context.Background(), params, fds, qmpGlogLogger{})
+
+		config := qemu.Config{
+			Ctx:         context.Background(),
+			ExtraParams: params,
+			FDs:         fds,
+		}
+
+		errStr, err = qemu.LaunchQemu(config, qmpGlogLogger{})
 		if err == nil {
 			glog.Info("============================================")
 			glog.Infof("Connect to vm with netcat %s %d", ipAddress, port)
@@ -374,7 +381,12 @@ func launchQemuWithNC(params []string, fds []*os.File, ipAddress string) (int, e
 
 	if port == 0 || (err != nil && tries == vcTries) {
 		glog.Warning("Failed to launch qemu due to chardev error.  Relaunching without virtual console")
-		_, err = qemu.LaunchQemu(context.Background(), params[:len(params)-4], fds, qmpGlogLogger{})
+		config := qemu.Config{
+			Ctx:         context.Background(),
+			ExtraParams: params[:len(params)-4],
+			FDs:         fds,
+		}
+		_, err = qemu.LaunchQemu(config, qmpGlogLogger{})
 	}
 
 	return port, err
@@ -393,7 +405,12 @@ func launchQemuWithSpice(params []string, fds []*os.File, ipAddress string) (int
 		}
 		params[len(params)-1] = fmt.Sprintf("port=%d,addr=%s,disable-ticketing", port, ipAddress)
 		var errStr string
-		errStr, err = qemu.LaunchQemu(context.Background(), params, fds, qmpGlogLogger{})
+		config := qemu.Config{
+			Ctx:         context.Background(),
+			ExtraParams: params,
+			FDs:         fds,
+		}
+		errStr, err = qemu.LaunchQemu(config, qmpGlogLogger{})
 		if err == nil {
 			glog.Info("============================================")
 			glog.Infof("Connect to vm with spicec -h %s -p %d", ipAddress, port)
@@ -412,7 +429,12 @@ func launchQemuWithSpice(params []string, fds []*os.File, ipAddress string) (int
 	if port == 0 || (err != nil && tries == vcTries) {
 		glog.Warning("Failed to launch qemu due to spice error.  Relaunching without virtual console")
 		params = append(params[:len(params)-2], "-display", "none", "-vga", "none")
-		_, err = qemu.LaunchQemu(context.Background(), params, fds, qmpGlogLogger{})
+		config := qemu.Config{
+			Ctx:         context.Background(),
+			ExtraParams: params,
+			FDs:         fds,
+		}
+		_, err = qemu.LaunchQemu(config, qmpGlogLogger{})
 	}
 
 	return port, err
@@ -510,7 +532,12 @@ func (q *qemuV) startVM(vnicName, ipAddress, cephID string) error {
 
 	if !launchWithUI.Enabled() {
 		params = append(params, "-display", "none", "-vga", "none")
-		_, err = qemu.LaunchQemu(context.Background(), params, fds, qmpGlogLogger{})
+		config := qemu.Config{
+			Ctx:         context.Background(),
+			ExtraParams: params,
+			FDs:         fds,
+		}
+		_, err = qemu.LaunchQemu(config, qmpGlogLogger{})
 	} else if launchWithUI.String() == "spice" {
 		var port int
 		port, err = launchQemuWithSpice(params, fds, ipAddress)

--- a/qemu/examples_test.go
+++ b/qemu/examples_test.go
@@ -37,10 +37,15 @@ func Example() {
 	// resources
 	params = append(params, "-m", "370", "-smp", "cpus=2")
 
+	config := qemu.Config{
+		Ctx:         context.Background(),
+		ExtraParams: params,
+	}
+
 	// LaunchQemu should return as soon as the instance has launched as we
 	// are using the --daemonize flag.  It will set up a unix domain socket
 	// called /tmp/qmp-socket that we can use to manage the instance.
-	_, err := qemu.LaunchQemu(context.Background(), params, nil, nil)
+	_, err := qemu.LaunchQemu(config, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -26,14 +26,78 @@ package qemu
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 
 	"golang.org/x/net/context"
 )
 
-// LaunchQemu can be used to launch a new qemu instance by invoking the
-// qemu-system-x86_64 binary.
+// Config is the qemu configuration structure.
+// It allows for passing custom settings and parameters to the qemu API.
+type Config struct {
+	// Path is the qemu binary path.
+	Path string
+
+	// Ctx is not used at the moment.
+	Ctx context.Context
+
+	// MachineType is the machine type to be used by qemu.
+	MachineType string
+
+	// MachineTypeAcceleration are the machine acceleration option to be used by qemu.
+	MachineTypeAcceleration string
+
+	// CPUModel is the CPU model to be used by qemu.
+	CPUModel string
+
+	// ExtraParams is a slice of options to pass to qemu.
+	ExtraParams []string
+
+	// FDs is a list of open file descriptors to be passed to the spawned qemu process
+	FDs []*os.File
+}
+
+func appendMachineParams(params []string, config Config) []string {
+	if config.MachineType != "" && config.MachineTypeAcceleration != "" {
+		params = append(params, "-machine")
+		params = append(params, fmt.Sprintf("%s,accel=%s", config.MachineType, config.MachineTypeAcceleration))
+	}
+
+	return params
+}
+
+func appendCPUModel(params []string, config Config) []string {
+	if config.CPUModel != "" {
+		params = append(params, "-cpu")
+		params = append(params, config.CPUModel)
+	}
+
+	return params
+}
+
+// LaunchQemu can be used to launch a new qemu instance.
+//
+// The Config parameter contains a set of qemu parameters and settings.
+//
+// This function writes its log output via logger parameter.
+//
+// The function will block until the launched qemu process exits.  "", nil
+// will be returned if the launch succeeds.  Otherwise a string containing
+// the contents of stderr + a Go error object will be returned.
+func LaunchQemu(config Config, logger QMPLog) (string, error) {
+	var params []string
+
+	params = appendMachineParams(params, config)
+	params = appendCPUModel(params, config)
+	params = append(params, config.ExtraParams...)
+
+	return LaunchCustomQemu(config.Ctx, config.Path, params, config.FDs, logger)
+}
+
+// LaunchCustomQemu can be used to launch a new qemu instance.
+//
+// The path parameter is used to pass the qemu executable path.
 //
 // The ctx parameter is not currently used but has been added so that the
 // signature of this function will not need to change when launch cancellation
@@ -48,13 +112,18 @@ import (
 // The function will block until the launched qemu process exits.  "", nil
 // will be returned if the launch succeeds.  Otherwise a string containing
 // the contents of stderr + a Go error object will be returned.
-func LaunchQemu(ctx context.Context, params []string, fds []*os.File, logger QMPLog) (string, error) {
+func LaunchCustomQemu(ctx context.Context, path string, params []string, fds []*os.File, logger QMPLog) (string, error) {
 	if logger == nil {
 		logger = qmpNullLogger{}
 	}
 
 	errStr := ""
-	cmd := exec.Command("qemu-system-x86_64", params...)
+
+	if path == "" {
+		path = "qemu-system-x86_64"
+	}
+
+	cmd := exec.Command(path, params...)
 	if len(fds) > 0 {
 		logger.Infof("Adding extra file %v", fds)
 		cmd.ExtraFiles = fds


### PR DESCRIPTION
In order to provide custom details about the qemu instance settings
and parameters, we create a LaunchCustomQemu() API. It takes a Config
structure that can embed further details without impacting the API
callers. For now it only contains the qemu executable path.

LaunchQemu() is now calling LaunchCustomQemu() with the right pre-built
Config instance.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>