### PR TITLE
qemu: Build qemu parameters from a configuration structure

### DIFF
--- a/ciao-launcher/qemu.go
+++ b/ciao-launcher/qemu.go
@@ -361,7 +361,8 @@ func launchQemuWithNC(params []string, fds []*os.File, ipAddress string) (int, e
 		ncString := "socket,port=%d,host=%s,server,id=gnc0,server,nowait"
 		params[len(params)-1] = fmt.Sprintf(ncString, port, ipAddress)
 		var errStr string
-		errStr, err = qemu.LaunchQemu(context.Background(), params, fds, qmpGlogLogger{})
+
+		errStr, err = qemu.LaunchCustomQemu(context.Background(), "", params, fds, qmpGlogLogger{})
 		if err == nil {
 			glog.Info("============================================")
 			glog.Infof("Connect to vm with netcat %s %d", ipAddress, port)
@@ -378,7 +379,7 @@ func launchQemuWithNC(params []string, fds []*os.File, ipAddress string) (int, e
 
 	if port == 0 || (err != nil && tries == vcTries) {
 		glog.Warning("Failed to launch qemu due to chardev error.  Relaunching without virtual console")
-		_, err = qemu.LaunchQemu(context.Background(), params[:len(params)-4], fds, qmpGlogLogger{})
+		_, err = qemu.LaunchCustomQemu(context.Background(), "", params[:len(params)-4], fds, qmpGlogLogger{})
 	}
 
 	return port, err
@@ -397,7 +398,7 @@ func launchQemuWithSpice(params []string, fds []*os.File, ipAddress string) (int
 		}
 		params[len(params)-1] = fmt.Sprintf("port=%d,addr=%s,disable-ticketing", port, ipAddress)
 		var errStr string
-		errStr, err = qemu.LaunchQemu(context.Background(), params, fds, qmpGlogLogger{})
+		errStr, err = qemu.LaunchCustomQemu(context.Background(), "", params, fds, qmpGlogLogger{})
 		if err == nil {
 			glog.Info("============================================")
 			glog.Infof("Connect to vm with spicec -h %s -p %d", ipAddress, port)
@@ -416,7 +417,7 @@ func launchQemuWithSpice(params []string, fds []*os.File, ipAddress string) (int
 	if port == 0 || (err != nil && tries == vcTries) {
 		glog.Warning("Failed to launch qemu due to spice error.  Relaunching without virtual console")
 		params = append(params[:len(params)-2], "-display", "none", "-vga", "none")
-		_, err = qemu.LaunchQemu(context.Background(), params, fds, qmpGlogLogger{})
+		_, err = qemu.LaunchCustomQemu(context.Background(), "", params, fds, qmpGlogLogger{})
 	}
 
 	return port, err
@@ -519,7 +520,7 @@ func (q *qemuV) startVM(vnicName, ipAddress, cephID string) error {
 
 	if !launchWithUI.Enabled() {
 		params = append(params, "-display", "none", "-vga", "none")
-		_, err = qemu.LaunchQemu(context.Background(), params, fds, qmpGlogLogger{})
+		_, err = qemu.LaunchCustomQemu(context.Background(), "", params, fds, qmpGlogLogger{})
 	} else if launchWithUI.String() == "spice" {
 		var port int
 		port, err = launchQemuWithSpice(params, fds, ipAddress)

--- a/qemu/examples_test.go
+++ b/qemu/examples_test.go
@@ -38,10 +38,10 @@ func Example() {
 	// resources
 	params = append(params, "-m", "370", "-smp", "cpus=2")
 
-	// LaunchQemu should return as soon as the instance has launched as we
+	// LaunchCustomQemu should return as soon as the instance has launched as we
 	// are using the --daemonize flag.  It will set up a unix domain socket
 	// called /tmp/qmp-socket that we can use to manage the instance.
-	_, err := qemu.LaunchQemu(context.Background(), params, nil, nil)
+	_, err := qemu.LaunchCustomQemu(context.Background(), "", params, nil, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -87,6 +87,15 @@ type QMPSocket struct {
 	NoWait bool
 }
 
+// Kernel is the guest kernel configuration structure.
+type Kernel struct {
+	// Path is the guest kernel path on the host filesystem.
+	Path string
+
+	// Params is the kernel parameters string.
+	Params string
+}
+
 // Config is the qemu configuration structure.
 // It allows for passing custom settings and parameters to the qemu API.
 type Config struct {
@@ -116,6 +125,9 @@ type Config struct {
 
 	// Objects is a list of objects for qemu to create.
 	Objects []Object
+
+	// Kernel is the guest kernel configuration.
+	Kernel Kernel
 
 	// ExtraParams is a slice of options to pass to qemu.
 	ExtraParams []string
@@ -233,6 +245,20 @@ func appendObjects(params []string, config Config) []string {
 	return params
 }
 
+func appendKernel(params []string, config Config) []string {
+	if config.Kernel.Path != "" {
+		params = append(params, "-kernel")
+		params = append(params, config.Kernel.Path)
+
+		if config.Kernel.Params != "" {
+			params = append(params, "-append")
+			params = append(params, config.Kernel.Params)
+		}
+	}
+
+	return params
+}
+
 // LaunchQemu can be used to launch a new qemu instance.
 //
 // The Config parameter contains a set of qemu parameters and settings.
@@ -251,6 +277,7 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	params = appendQMPSocket(params, config)
 	params = appendDevices(params, config)
 	params = appendObjects(params, config)
+	params = appendKernel(params, config)
 
 	params = append(params, config.ExtraParams...)
 

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -148,6 +148,9 @@ type Config struct {
 	// FilesystemDevices is a list of filesystem devices.
 	FilesystemDevices []FSDevice
 
+	// UUID is the qemu process UUID.
+	UUID string
+
 	// Kernel is the guest kernel configuration.
 	Kernel Kernel
 
@@ -303,6 +306,15 @@ func appendFilesystemDevices(params []string, config Config) []string {
 	return params
 }
 
+func appendUUID(params []string, config Config) []string {
+	if config.UUID != "" {
+		params = append(params, "-uuid")
+		params = append(params, config.UUID)
+	}
+
+	return params
+}
+
 func appendKernel(params []string, config Config) []string {
 	if config.Kernel.Path != "" {
 		params = append(params, "-kernel")
@@ -330,6 +342,7 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	var params []string
 
 	params = appendName(params, config)
+	params = appendUUID(params, config)
 	params = appendMachineParams(params, config)
 	params = appendCPUModel(params, config)
 	params = appendQMPSocket(params, config)

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -139,6 +139,9 @@ type Config struct {
 	// Devices is a list of devices for qemu to create.
 	Devices []Device
 
+	// CharDevices is a list of character devices for qemu to export.
+	CharDevices []string
+
 	// Objects is a list of objects for qemu to create.
 	Objects []Object
 
@@ -237,6 +240,15 @@ func appendDevices(params []string, config Config) []string {
 	return params
 }
 
+func appendCharDevices(params []string, config Config) []string {
+	for _, c := range config.CharDevices {
+		params = append(params, "-chardev")
+		params = append(params, c)
+	}
+
+	return params
+}
+
 func appendObjects(params []string, config Config) []string {
 	for _, o := range config.Objects {
 		if o.Type != "" {
@@ -322,6 +334,7 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	params = appendCPUModel(params, config)
 	params = appendQMPSocket(params, config)
 	params = appendDevices(params, config)
+	params = appendCharDevices(params, config)
 	params = appendFilesystemDevices(params, config)
 	params = appendObjects(params, config)
 	params = appendKernel(params, config)

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -191,6 +191,13 @@ type NetDevice struct {
 
 	// Script is the tap interface configuration script.
 	Script string
+
+	// FDs represents the list of already existing file descriptors to be used.
+	// This is mostly useful for mq support.
+	FDs []int
+
+	// VHost enables virtio device emulation from the host kernel instead of from qemu.
+	VHost bool
 }
 
 // Config is the qemu configuration structure.
@@ -555,6 +562,20 @@ func appendNetDevices(params []string, config Config) []string {
 
 			if d.Script != "" {
 				netdevParams = append(netdevParams, fmt.Sprintf(",script=%s", d.Script))
+			}
+
+			if len(d.FDs) > 0 {
+				var fdParams []string
+
+				for _, fd := range d.FDs {
+					fdParams = append(fdParams, fmt.Sprintf("%d", fd))
+				}
+
+				netdevParams = append(netdevParams, fmt.Sprintf(",fds=%s", strings.Join(fdParams, ":")))
+			}
+
+			if d.VHost == true {
+				netdevParams = append(netdevParams, ",vhost=on")
 			}
 
 			params = append(params, "-netdev")

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -45,8 +45,8 @@ type Machine struct {
 
 // Device describes a device to be created by qemu.
 type Device struct {
-	// Type is the qemu device type
-	Type string
+	// Driver is the qemu device driver
+	Driver string
 
 	// ID is the user defined device ID.
 	ID string
@@ -57,12 +57,18 @@ type Device struct {
 	// FSDev is the device filesystem identifier.
 	FSDev string
 
+	// NetDev is the networking device identifier.
+	NetDev string
+
 	// MountTag is the device filesystem mount point tag.
 	// It is only relevant when combined with FSDev.
 	MountTag string
 
 	// CharDev is the device character device identifier.
 	CharDev string
+
+	// MACAddress is the networking device interface MAC address.
+	MACAddress string
 }
 
 // Object is a qemu object representation.
@@ -321,10 +327,10 @@ func appendQMPSocket(params []string, config Config) []string {
 
 func appendDevices(params []string, config Config) []string {
 	for _, d := range config.Devices {
-		if d.Type != "" {
+		if d.Driver != "" {
 			var deviceParams []string
 
-			deviceParams = append(deviceParams, fmt.Sprintf("%s", d.Type))
+			deviceParams = append(deviceParams, fmt.Sprintf("%s", d.Driver))
 
 			if d.ID != "" {
 				deviceParams = append(deviceParams, fmt.Sprintf(",id=%s", d.ID))
@@ -343,6 +349,14 @@ func appendDevices(params []string, config Config) []string {
 
 				if d.MountTag != "" {
 					deviceParams = append(deviceParams, fmt.Sprintf(",mount_tag=%s", d.MountTag))
+				}
+			}
+
+			if d.NetDev != "" {
+				deviceParams = append(deviceParams, fmt.Sprintf(",netdev=%s", d.NetDev))
+
+				if d.MACAddress != "" {
+					deviceParams = append(deviceParams, fmt.Sprintf(",mac=%s", d.MACAddress))
 				}
 			}
 

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -205,6 +205,9 @@ type Config struct {
 	// SMP is the quest multi processors configuration.
 	SMP SMP
 
+	// GlobalParam is the -global parameter
+	GlobalParam string
+
 	// ExtraParams is a slice of options to pass to qemu.
 	ExtraParams []string
 
@@ -433,6 +436,15 @@ func appendRTC(params []string, config Config) []string {
 	return params
 }
 
+func appendGlobalParam(params []string, config Config) []string {
+	if config.GlobalParam != "" {
+		params = append(params, "-global")
+		params = append(params, config.GlobalParam)
+	}
+
+	return params
+}
+
 func appendKernel(params []string, config Config) []string {
 	if config.Kernel.Path != "" {
 		params = append(params, "-kernel")
@@ -472,6 +484,7 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	params = appendObjects(params, config)
 	params = appendRTC(params, config)
 	params = appendKernel(params, config)
+	params = appendGlobalParam(params, config)
 
 	params = append(params, config.ExtraParams...)
 

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -319,6 +319,9 @@ type NetDeviceType string
 const (
 	// TAP is a TAP networking device type.
 	TAP NetDeviceType = "tap"
+
+	// MACVTAP is a MAC virtual TAP networking device type.
+	MACVTAP = "macvtap"
 )
 
 // NetDevice represents a guest networking device
@@ -360,6 +363,8 @@ func (netdev NetDevice) Valid() bool {
 
 	switch netdev.Type {
 	case TAP:
+		return true
+	case MACVTAP:
 		return true
 	default:
 		return false

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -163,6 +163,18 @@ type Kernel struct {
 	Params string
 }
 
+// Knobs regroups a set of qemu boolean settings
+type Knobs struct {
+	// NoUserConfig prevents qemu from loading user config files.
+	NoUserConfig bool
+
+	// NoDefaults prevents qemu from creating default devices.
+	NoDefaults bool
+
+	// NoGraphic completely disables graphic output.
+	NoGraphic bool
+}
+
 // Config is the qemu configuration structure.
 // It allows for passing custom settings and parameters to the qemu API.
 type Config struct {
@@ -214,8 +226,11 @@ type Config struct {
 	// SMP is the quest multi processors configuration.
 	SMP SMP
 
-	// GlobalParam is the -global parameter
+	// GlobalParam is the -global parameter.
 	GlobalParam string
+
+	// Knobs is a set of qemu boolean settings.
+	Knobs Knobs
 
 	// FDs is a list of open file descriptors to be passed to the spawned qemu process
 	FDs []*os.File
@@ -482,6 +497,22 @@ func appendKernel(params []string, config Config) []string {
 	return params
 }
 
+func appendKnobs(params []string, config Config) []string {
+	if config.Knobs.NoUserConfig == true {
+		params = append(params, "-no-user-config")
+	}
+
+	if config.Knobs.NoDefaults == true {
+		params = append(params, "-nodefaults")
+	}
+
+	if config.Knobs.NoGraphic == true {
+		params = append(params, "-nographic")
+	}
+
+	return params
+}
+
 // LaunchQemu can be used to launch a new qemu instance.
 //
 // The Config parameter contains a set of qemu parameters and settings.
@@ -509,6 +540,7 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	params = appendKernel(params, config)
 	params = appendGlobalParam(params, config)
 	params = appendVGA(params, config)
+	params = appendKnobs(params, config)
 
 	return LaunchCustomQemu(config.Ctx, config.Path, params, config.FDs, logger)
 }

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -732,18 +732,18 @@ type Config struct {
 
 	// FDs is a list of open file descriptors to be passed to the spawned qemu process
 	FDs []*os.File
+
+	qemuParams []string
 }
 
-func appendName(params []string, config Config) []string {
+func (config *Config) appendName() {
 	if config.Name != "" {
-		params = append(params, "-name")
-		params = append(params, config.Name)
+		config.qemuParams = append(config.qemuParams, "-name")
+		config.qemuParams = append(config.qemuParams, config.Name)
 	}
-
-	return params
 }
 
-func appendMachine(params []string, config Config) []string {
+func (config *Config) appendMachine() {
 	if config.Machine.Type != "" {
 		var machineParams []string
 
@@ -753,25 +753,21 @@ func appendMachine(params []string, config Config) []string {
 			machineParams = append(machineParams, fmt.Sprintf(",accel=%s", config.Machine.Acceleration))
 		}
 
-		params = append(params, "-machine")
-		params = append(params, strings.Join(machineParams, ""))
+		config.qemuParams = append(config.qemuParams, "-machine")
+		config.qemuParams = append(config.qemuParams, strings.Join(machineParams, ""))
 	}
-
-	return params
 }
 
-func appendCPUModel(params []string, config Config) []string {
+func (config *Config) appendCPUModel() {
 	if config.CPUModel != "" {
-		params = append(params, "-cpu")
-		params = append(params, config.CPUModel)
+		config.qemuParams = append(config.qemuParams, "-cpu")
+		config.qemuParams = append(config.qemuParams, config.CPUModel)
 	}
-
-	return params
 }
 
-func appendQMPSocket(params []string, config Config) []string {
+func (config *Config) appendQMPSocket() {
 	if config.QMPSocket.Valid() == false {
-		return nil
+		return
 	}
 
 	var qmpParams []string
@@ -785,34 +781,28 @@ func appendQMPSocket(params []string, config Config) []string {
 		}
 	}
 
-	params = append(params, "-qmp")
-	params = append(params, strings.Join(qmpParams, ""))
-
-	return params
+	config.qemuParams = append(config.qemuParams, "-qmp")
+	config.qemuParams = append(config.qemuParams, strings.Join(qmpParams, ""))
 }
 
-func appendDevices(params []string, config Config) []string {
+func (config *Config) appendDevices() {
 	for _, d := range config.Devices {
 		if d.Valid() == false {
 			continue
 		}
 
-		params = append(params, d.QemuParams()...)
+		config.qemuParams = append(config.qemuParams, d.QemuParams()...)
 	}
-
-	return params
 }
 
-func appendUUID(params []string, config Config) []string {
+func (config *Config) appendUUID() {
 	if config.UUID != "" {
-		params = append(params, "-uuid")
-		params = append(params, config.UUID)
+		config.qemuParams = append(config.qemuParams, "-uuid")
+		config.qemuParams = append(config.qemuParams, config.UUID)
 	}
-
-	return params
 }
 
-func appendMemory(params []string, config Config) []string {
+func (config *Config) appendMemory() {
 	if config.Memory.Size != "" {
 		var memoryParams []string
 
@@ -826,14 +816,12 @@ func appendMemory(params []string, config Config) []string {
 			memoryParams = append(memoryParams, fmt.Sprintf(",maxmem=%s", config.Memory.MaxMem))
 		}
 
-		params = append(params, "-m")
-		params = append(params, strings.Join(memoryParams, ""))
+		config.qemuParams = append(config.qemuParams, "-m")
+		config.qemuParams = append(config.qemuParams, strings.Join(memoryParams, ""))
 	}
-
-	return params
 }
 
-func appendCPUs(params []string, config Config) []string {
+func (config *Config) appendCPUs() {
 	if config.SMP.CPUs > 0 {
 		var SMPParams []string
 
@@ -851,16 +839,14 @@ func appendCPUs(params []string, config Config) []string {
 			SMPParams = append(SMPParams, fmt.Sprintf(",sockets=%d", config.SMP.Sockets))
 		}
 
-		params = append(params, "-smp")
-		params = append(params, strings.Join(SMPParams, ""))
+		config.qemuParams = append(config.qemuParams, "-smp")
+		config.qemuParams = append(config.qemuParams, strings.Join(SMPParams, ""))
 	}
-
-	return params
 }
 
-func appendRTC(params []string, config Config) []string {
+func (config *Config) appendRTC() {
 	if config.RTC.Valid() == false {
-		return nil
+		return
 	}
 
 	var RTCParams []string
@@ -875,58 +861,48 @@ func appendRTC(params []string, config Config) []string {
 		RTCParams = append(RTCParams, fmt.Sprintf(",clock=%s", config.RTC.Clock))
 	}
 
-	params = append(params, "-rtc")
-	params = append(params, strings.Join(RTCParams, ""))
-
-	return params
+	config.qemuParams = append(config.qemuParams, "-rtc")
+	config.qemuParams = append(config.qemuParams, strings.Join(RTCParams, ""))
 }
 
-func appendGlobalParam(params []string, config Config) []string {
+func (config *Config) appendGlobalParam() {
 	if config.GlobalParam != "" {
-		params = append(params, "-global")
-		params = append(params, config.GlobalParam)
+		config.qemuParams = append(config.qemuParams, "-global")
+		config.qemuParams = append(config.qemuParams, config.GlobalParam)
 	}
-
-	return params
 }
 
-func appendVGA(params []string, config Config) []string {
+func (config *Config) appendVGA() {
 	if config.VGA != "" {
-		params = append(params, "-vga")
-		params = append(params, config.VGA)
+		config.qemuParams = append(config.qemuParams, "-vga")
+		config.qemuParams = append(config.qemuParams, config.VGA)
 	}
-
-	return params
 }
 
-func appendKernel(params []string, config Config) []string {
+func (config *Config) appendKernel() {
 	if config.Kernel.Path != "" {
-		params = append(params, "-kernel")
-		params = append(params, config.Kernel.Path)
+		config.qemuParams = append(config.qemuParams, "-kernel")
+		config.qemuParams = append(config.qemuParams, config.Kernel.Path)
 
 		if config.Kernel.Params != "" {
-			params = append(params, "-append")
-			params = append(params, config.Kernel.Params)
+			config.qemuParams = append(config.qemuParams, "-append")
+			config.qemuParams = append(config.qemuParams, config.Kernel.Params)
 		}
 	}
-
-	return params
 }
 
-func appendKnobs(params []string, config Config) []string {
+func (config *Config) appendKnobs() {
 	if config.Knobs.NoUserConfig == true {
-		params = append(params, "-no-user-config")
+		config.qemuParams = append(config.qemuParams, "-no-user-config")
 	}
 
 	if config.Knobs.NoDefaults == true {
-		params = append(params, "-nodefaults")
+		config.qemuParams = append(config.qemuParams, "-nodefaults")
 	}
 
 	if config.Knobs.NoGraphic == true {
-		params = append(params, "-nographic")
+		config.qemuParams = append(config.qemuParams, "-nographic")
 	}
-
-	return params
 }
 
 // LaunchQemu can be used to launch a new qemu instance.
@@ -939,23 +915,21 @@ func appendKnobs(params []string, config Config) []string {
 // will be returned if the launch succeeds.  Otherwise a string containing
 // the contents of stderr + a Go error object will be returned.
 func LaunchQemu(config Config, logger QMPLog) (string, error) {
-	var params []string
+	config.appendName()
+	config.appendUUID()
+	config.appendMachine()
+	config.appendCPUModel()
+	config.appendQMPSocket()
+	config.appendMemory()
+	config.appendCPUs()
+	config.appendDevices()
+	config.appendRTC()
+	config.appendGlobalParam()
+	config.appendVGA()
+	config.appendKnobs()
+	config.appendKernel()
 
-	params = appendName(params, config)
-	params = appendUUID(params, config)
-	params = appendMachine(params, config)
-	params = appendCPUModel(params, config)
-	params = appendQMPSocket(params, config)
-	params = appendMemory(params, config)
-	params = appendCPUs(params, config)
-	params = appendDevices(params, config)
-	params = appendRTC(params, config)
-	params = appendGlobalParam(params, config)
-	params = appendVGA(params, config)
-	params = appendKnobs(params, config)
-	params = appendKernel(params, config)
-
-	return LaunchCustomQemu(config.Ctx, config.Path, params, config.FDs, logger)
+	return LaunchCustomQemu(config.Ctx, config.Path, config.qemuParams, config.FDs, logger)
 }
 
 // LaunchCustomQemu can be used to launch a new qemu instance.
@@ -966,7 +940,7 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 // signature of this function will not need to change when launch cancellation
 // is implemented.
 //
-// params is a slice of options to pass to qemu-system-x86_64 and fds is a
+// config.qemuParams is a slice of options to pass to qemu-system-x86_64 and fds is a
 // list of open file descriptors that are to be passed to the spawned qemu
 // process.
 //

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -193,6 +193,9 @@ type Config struct {
 	// RTC is the qemu Real Time Clock configuration
 	RTC RTC
 
+	// VGA is the qemu VGA mode.
+	VGA string
+
 	// UUID is the qemu process UUID.
 	UUID string
 
@@ -445,6 +448,15 @@ func appendGlobalParam(params []string, config Config) []string {
 	return params
 }
 
+func appendVGA(params []string, config Config) []string {
+	if config.VGA != "" {
+		params = append(params, "-vga")
+		params = append(params, config.VGA)
+	}
+
+	return params
+}
+
 func appendKernel(params []string, config Config) []string {
 	if config.Kernel.Path != "" {
 		params = append(params, "-kernel")
@@ -485,6 +497,7 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	params = appendRTC(params, config)
 	params = appendKernel(params, config)
 	params = appendGlobalParam(params, config)
+	params = appendVGA(params, config)
 
 	params = append(params, config.ExtraParams...)
 

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -42,6 +42,9 @@ type Config struct {
 	// Ctx is not used at the moment.
 	Ctx context.Context
 
+	// Name is the qemu guest name
+	Name string
+	
 	// MachineType is the machine type to be used by qemu.
 	MachineType string
 
@@ -56,6 +59,15 @@ type Config struct {
 
 	// FDs is a list of open file descriptors to be passed to the spawned qemu process
 	FDs []*os.File
+}
+
+func appendName(params []string, config Config) []string {
+	if config.Name != "" {
+		params = append(params, "-name")
+		params = append(params, config.Name)
+	}
+
+	return params
 }
 
 func appendMachineParams(params []string, config Config) []string {
@@ -88,6 +100,7 @@ func appendCPUModel(params []string, config Config) []string {
 func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	var params []string
 
+	params = appendName(params, config)
 	params = appendMachineParams(params, config)
 	params = appendCPUModel(params, config)
 	params = append(params, config.ExtraParams...)

--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -175,11 +175,14 @@ type Config struct {
 	// Name is the qemu guest name
 	Name string
 
-	// Machine
-	Machine Machine
+	// UUID is the qemu process UUID.
+	UUID string
 
 	// CPUModel is the CPU model to be used by qemu.
 	CPUModel string
+
+	// Machine
+	Machine Machine
 
 	// QMPSocket is the QMP socket description.
 	QMPSocket QMPSocket
@@ -202,9 +205,6 @@ type Config struct {
 	// VGA is the qemu VGA mode.
 	VGA string
 
-	// UUID is the qemu process UUID.
-	UUID string
-
 	// Kernel is the guest kernel configuration.
 	Kernel Kernel
 
@@ -216,9 +216,6 @@ type Config struct {
 
 	// GlobalParam is the -global parameter
 	GlobalParam string
-
-	// ExtraParams is a slice of options to pass to qemu.
-	ExtraParams []string
 
 	// FDs is a list of open file descriptors to be passed to the spawned qemu process
 	FDs []*os.File
@@ -512,8 +509,6 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	params = appendKernel(params, config)
 	params = appendGlobalParam(params, config)
 	params = appendVGA(params, config)
-
-	params = append(params, config.ExtraParams...)
 
 	return LaunchCustomQemu(config.Ctx, config.Path, params, config.FDs, logger)
 }

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -17,6 +17,8 @@
 package qemu
 
 import (
+	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -113,9 +115,15 @@ func TestAppendDeviceFS(t *testing.T) {
 	testAppend(fsdev, deviceFSString, t)
 }
 
-var deviceNetworkString = "-device virtio-net,netdev=tap0,mac=01:02:de:ad:be:ef -netdev tap,id=tap0,ifname=ceth0,downscript=no,script=no,fds=8:9:10,vhost=on"
+var deviceNetworkString = "-device virtio-net,netdev=tap0,mac=01:02:de:ad:be:ef -netdev tap,id=tap0,ifname=ceth0,downscript=no,script=no,fds=3:4,vhost=on"
 
 func TestAppendDeviceNetwork(t *testing.T) {
+	foo, _ := ioutil.TempFile(os.TempDir(), "qemu-ciao-test")
+	bar, _ := ioutil.TempFile(os.TempDir(), "qemu-ciao-test")
+
+	defer os.Remove(foo.Name())
+	defer os.Remove(bar.Name())
+
 	netdev := NetDevice{
 		Driver:     VirtioNet,
 		Type:       TAP,
@@ -123,7 +131,7 @@ func TestAppendDeviceNetwork(t *testing.T) {
 		IFName:     "ceth0",
 		Script:     "no",
 		DownScript: "no",
-		FDs:        []int{8, 9, 10},
+		FDs:        []*os.File{foo, bar},
 		VHost:      true,
 		MACAddress: "01:02:de:ad:be:ef",
 	}

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -53,6 +53,13 @@ func testAppend(structure interface{}, expected string, t *testing.T) {
 		}
 
 		params = appendKnobs([]string{}, config)
+
+	case Kernel:
+		config := Config{
+			Kernel: s,
+		}
+
+		params = appendKernel([]string{}, config)
 	}
 
 	result := strings.Join(params, " ")
@@ -147,4 +154,15 @@ func TestAppendKnobsAllFalse(t *testing.T) {
 	}
 
 	testAppend(knobs, "", t)
+}
+
+var kernelString = "-kernel /opt/vmlinux.container -append root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable"
+
+func TestAppendKernel(t *testing.T) {
+	kernel := Kernel{
+		Path:   "/opt/vmlinux.container",
+		Params: "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable",
+	}
+
+	testAppend(kernel, kernelString, t)
 }

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -39,11 +39,18 @@ func testAppend(structure interface{}, expected string, t *testing.T) {
 		}
 
 		params = appendDevices([]string{}, config)
+
+	case Object:
+		config := Config{
+			Objects: []Object{s},
+		}
+
+		params = appendObjects([]string{}, config)
 	}
 
 	result := strings.Join(params, " ")
 	if result != expected {
-		t.Fatalf("Failed to append Machine [%s] != [%s]", result, expected)
+		t.Fatalf("Failed to append parameters [%s] != [%s]", result, expected)
 	}
 }
 
@@ -89,6 +96,25 @@ func TestAppendDeviceFS(t *testing.T) {
 }
 
 func TestAppendEmptyDevice(t *testing.T) {
+	device := Device{}
+
+	testAppend(device, "", t)
+}
+
+var objectMemoryString = "-object memory-backend-file,id=mem0,mem-path=/root,size=65536"
+
+func TestAppendObjectMemory(t *testing.T) {
+	object := Object{
+		Type:    "memory-backend-file",
+		ID:      "mem0",
+		MemPath: "/root",
+		Size:    1 << 16,
+	}
+
+	testAppend(object, objectMemoryString, t)
+}
+
+func TestAppendEmptyObject(t *testing.T) {
 	device := Device{}
 
 	testAppend(device, "", t)

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -75,6 +75,13 @@ func testAppend(structure interface{}, expected string, t *testing.T) {
 		}
 
 		params = appendQMPSocket([]string{}, config)
+
+	case RTC:
+		config := Config{
+			RTC: s,
+		}
+
+		params = appendRTC([]string{}, config)
 	}
 
 	result := strings.Join(params, " ")
@@ -280,4 +287,16 @@ func TestAppendStrings(t *testing.T) {
 	if result != qemuString {
 		t.Fatalf("Failed to append parameters [%s] != [%s]", result, qemuString)
 	}
+}
+
+var rtcString = "-rtc base=utc,driftfix=slew,clock=host"
+
+func TestAppendRTC(t *testing.T) {
+	rtc := RTC{
+		Base:     UTC,
+		Clock:    Host,
+		DriftFix: Slew,
+	}
+
+	testAppend(rtc, rtcString, t)
 }

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -236,3 +236,25 @@ func TestAppendQMPSocket(t *testing.T) {
 
 	testAppend(qmp, qmpSocketString, t)
 }
+
+var qemuString = "-name cc-qemu -cpu host -uuid 123456789"
+
+func TestAppendStrings(t *testing.T) {
+	var params []string
+
+	config := Config{
+		Path:     "qemu",
+		Name:     "cc-qemu",
+		UUID:     "123456789",
+		CPUModel: "host",
+	}
+
+	params = appendName(params, config)
+	params = appendCPUModel(params, config)
+	params = appendUUID(params, config)
+
+	result := strings.Join(params, " ")
+	if result != qemuString {
+		t.Fatalf("Failed to append parameters [%s] != [%s]", result, qemuString)
+	}
+}

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -60,6 +60,20 @@ func testAppend(structure interface{}, expected string, t *testing.T) {
 		}
 
 		params = appendKernel([]string{}, config)
+
+	case Memory:
+		config := Config{
+			Memory: s,
+		}
+
+		params = appendMemory([]string{}, config)
+
+	case SMP:
+		config := Config{
+			SMP: s,
+		}
+
+		params = appendCPUs([]string{}, config)
 	}
 
 	result := strings.Join(params, " ")
@@ -165,4 +179,29 @@ func TestAppendKernel(t *testing.T) {
 	}
 
 	testAppend(kernel, kernelString, t)
+}
+
+var memoryString = "-m 2G,slots=2,maxmem=3G"
+
+func TestAppendMemory(t *testing.T) {
+	memory := Memory{
+		Size:   "2G",
+		Slots:  2,
+		MaxMem: "3G",
+	}
+
+	testAppend(memory, memoryString, t)
+}
+
+var cpusString = "-smp 2,cores=1,threads=2,sockets=2"
+
+func TestAppendCPUs(t *testing.T) {
+	smp := SMP{
+		CPUs:    2,
+		Sockets: 2,
+		Cores:   1,
+		Threads: 2,
+	}
+
+	testAppend(smp, cpusString, t)
 }

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -74,6 +74,13 @@ func testAppend(structure interface{}, expected string, t *testing.T) {
 		}
 
 		params = appendCPUs([]string{}, config)
+
+	case QMPSocket:
+		config := Config{
+			QMPSocket: s,
+		}
+
+		params = appendQMPSocket([]string{}, config)
 	}
 
 	result := strings.Join(params, " ")
@@ -204,4 +211,28 @@ func TestAppendCPUs(t *testing.T) {
 	}
 
 	testAppend(smp, cpusString, t)
+}
+
+var qmpSocketServerString = "-qmp unix:cc-qmp,server,nowait"
+var qmpSocketString = "-qmp unix:cc-qmp"
+
+func TestAppendQMPSocketServer(t *testing.T) {
+	qmp := QMPSocket{
+		Type:   "unix",
+		Name:   "cc-qmp",
+		Server: true,
+		NoWait: true,
+	}
+
+	testAppend(qmp, qmpSocketServerString, t)
+}
+
+func TestAppendQMPSocket(t *testing.T) {
+	qmp := QMPSocket{
+		Type:   "unix",
+		Name:   "cc-qmp",
+		Server: false,
+	}
+
+	testAppend(qmp, qmpSocketString, t)
 }

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -24,67 +24,43 @@ import (
 )
 
 func testAppend(structure interface{}, expected string, t *testing.T) {
-	var params []string
+	var config Config
 
 	switch s := structure.(type) {
 	case Machine:
-		config := Config{
-			Machine: s,
-		}
-
-		params = appendMachine([]string{}, config)
+		config.Machine = s
+		config.appendMachine()
 
 	case Device:
-		config := Config{
-			Devices: []Device{s},
-		}
-
-		params = appendDevices([]string{}, config)
+		config.Devices = []Device{s}
+		config.appendDevices()
 
 	case Knobs:
-		config := Config{
-			Knobs: s,
-		}
-
-		params = appendKnobs([]string{}, config)
+		config.Knobs = s
+		config.appendKnobs()
 
 	case Kernel:
-		config := Config{
-			Kernel: s,
-		}
-
-		params = appendKernel([]string{}, config)
+		config.Kernel = s
+		config.appendKernel()
 
 	case Memory:
-		config := Config{
-			Memory: s,
-		}
-
-		params = appendMemory([]string{}, config)
+		config.Memory = s
+		config.appendMemory()
 
 	case SMP:
-		config := Config{
-			SMP: s,
-		}
-
-		params = appendCPUs([]string{}, config)
+		config.SMP = s
+		config.appendCPUs()
 
 	case QMPSocket:
-		config := Config{
-			QMPSocket: s,
-		}
-
-		params = appendQMPSocket([]string{}, config)
+		config.QMPSocket = s
+		config.appendQMPSocket()
 
 	case RTC:
-		config := Config{
-			RTC: s,
-		}
-
-		params = appendRTC([]string{}, config)
+		config.RTC = s
+		config.appendRTC()
 	}
 
-	result := strings.Join(params, " ")
+	result := strings.Join(config.qemuParams, " ")
 	if result != expected {
 		t.Fatalf("Failed to append parameters [%s] != [%s]", result, expected)
 	}
@@ -274,8 +250,6 @@ func TestAppendQMPSocket(t *testing.T) {
 var qemuString = "-name cc-qemu -cpu host -uuid " + testutil.AgentUUID
 
 func TestAppendStrings(t *testing.T) {
-	var params []string
-
 	config := Config{
 		Path:     "qemu",
 		Name:     "cc-qemu",
@@ -283,11 +257,11 @@ func TestAppendStrings(t *testing.T) {
 		CPUModel: "host",
 	}
 
-	params = appendName(params, config)
-	params = appendCPUModel(params, config)
-	params = appendUUID(params, config)
+	config.appendName()
+	config.appendCPUModel()
+	config.appendUUID()
 
-	result := strings.Join(params, " ")
+	result := strings.Join(config.qemuParams, " ")
 	if result != qemuString {
 		t.Fatalf("Failed to append parameters [%s] != [%s]", result, qemuString)
 	}

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -117,7 +117,7 @@ var deviceNVDIMMString = "-device nvdimm,id=nv0,memdev=mem0"
 
 func TestAppendDeviceNVDIMM(t *testing.T) {
 	device := Device{
-		Type:   "nvdimm",
+		Driver: "nvdimm",
 		ID:     "nv0",
 		MemDev: "mem0",
 	}
@@ -129,12 +129,24 @@ var deviceFSString = "-device virtio-9p-pci,fsdev=workload9p,mount_tag=rootfs"
 
 func TestAppendDeviceFS(t *testing.T) {
 	device := Device{
-		Type:     "virtio-9p-pci",
+		Driver:   "virtio-9p-pci",
 		FSDev:    "workload9p",
 		MountTag: "rootfs",
 	}
 
 	testAppend(device, deviceFSString, t)
+}
+
+var deviceNetworkString = "-device virtio-net-pci,netdev=eth0,mac=01:02:de:ad:be:ef"
+
+func TestAppendDeviceNetwork(t *testing.T) {
+	device := Device{
+		Driver:     "virtio-net-pci",
+		NetDev:     "eth0",
+		MACAddress: "01:02:de:ad:be:ef",
+	}
+
+	testAppend(device, deviceNetworkString, t)
 }
 
 func TestAppendEmptyDevice(t *testing.T) {

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -1,0 +1,58 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package qemu
+
+import (
+	//	"fmt"
+	"strings"
+	"testing"
+)
+
+func testAppend(structure interface{}, expected string, t *testing.T) {
+	var params []string
+
+	switch s := structure.(type) {
+	case Machine:
+		config := Config{
+			Machine: s,
+		}
+
+		params = appendMachine([]string{}, config)
+	}
+
+	result := strings.Join(params, " ")
+	if result != expected {
+		t.Fatalf("Failed to append Machine [%s] != [%s]", result, expected)
+	}
+}
+
+var machineString = "-machine pc-lite,accel=kvm,kernel_irqchip,nvdimm"
+
+func TestAppendMachine(t *testing.T) {
+	machine := Machine{
+		Type:         "pc-lite",
+		Acceleration: "kvm,kernel_irqchip,nvdimm",
+	}
+
+	testAppend(machine, machineString, t)
+}
+
+func TestAppendEmptyMachine(t *testing.T) {
+	machine := Machine{}
+
+	testAppend(machine, "", t)
+}

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -81,6 +81,13 @@ func testAppend(structure interface{}, expected string, t *testing.T) {
 		}
 
 		params = appendQMPSocket([]string{}, config)
+
+	case NetDevice:
+		config := Config{
+			NetDevices: []NetDevice{s},
+		}
+
+		params = appendNetDevices([]string{}, config)
 	}
 
 	result := strings.Join(params, " ")
@@ -257,4 +264,18 @@ func TestAppendStrings(t *testing.T) {
 	if result != qemuString {
 		t.Fatalf("Failed to append parameters [%s] != [%s]", result, qemuString)
 	}
+}
+
+var netdevString = "-netdev tap,id=ceth0,ifname=ceth0,downscript=no,script=no"
+
+func TestAppendNetDevices(t *testing.T) {
+	netdev := NetDevice{
+		Type:       "tap",
+		ID:         "ceth0",
+		IfName:     "ceth0",
+		Script:     "no",
+		DownScript: "no",
+	}
+
+	testAppend(netdev, netdevString, t)
 }

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -32,6 +32,13 @@ func testAppend(structure interface{}, expected string, t *testing.T) {
 		}
 
 		params = appendMachine([]string{}, config)
+
+	case Device:
+		config := Config{
+			Devices: []Device{s},
+		}
+
+		params = appendDevices([]string{}, config)
 	}
 
 	result := strings.Join(params, " ")
@@ -55,4 +62,34 @@ func TestAppendEmptyMachine(t *testing.T) {
 	machine := Machine{}
 
 	testAppend(machine, "", t)
+}
+
+var deviceNVDIMMString = "-device nvdimm,id=nv0,memdev=mem0"
+
+func TestAppendDeviceNVDIMM(t *testing.T) {
+	device := Device{
+		Type:   "nvdimm",
+		ID:     "nv0",
+		MemDev: "mem0",
+	}
+
+	testAppend(device, deviceNVDIMMString, t)
+}
+
+var deviceFSString = "-device virtio-9p-pci,fsdev=workload9p,mount_tag=rootfs"
+
+func TestAppendDeviceFS(t *testing.T) {
+	device := Device{
+		Type:     "virtio-9p-pci",
+		FSDev:    "workload9p",
+		MountTag: "rootfs",
+	}
+
+	testAppend(device, deviceFSString, t)
+}
+
+func TestAppendEmptyDevice(t *testing.T) {
+	device := Device{}
+
+	testAppend(device, "", t)
 }

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -266,15 +266,16 @@ func TestAppendStrings(t *testing.T) {
 	}
 }
 
-var netdevString = "-netdev tap,id=ceth0,ifname=ceth0,downscript=no,script=no"
+var netdevString = "-netdev tap,id=ceth0,downscript=no,script=no,fds=8:9:10,vhost=on"
 
 func TestAppendNetDevices(t *testing.T) {
 	netdev := NetDevice{
 		Type:       "tap",
 		ID:         "ceth0",
-		IfName:     "ceth0",
 		Script:     "no",
 		DownScript: "no",
+		FDs:        []int{8, 9, 10},
+		VHost:      true,
 	}
 
 	testAppend(netdev, netdevString, t)

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -46,6 +46,13 @@ func testAppend(structure interface{}, expected string, t *testing.T) {
 		}
 
 		params = appendObjects([]string{}, config)
+
+	case Knobs:
+		config := Config{
+			Knobs: s,
+		}
+
+		params = appendKnobs([]string{}, config)
 	}
 
 	result := strings.Join(params, " ")
@@ -118,4 +125,26 @@ func TestAppendEmptyObject(t *testing.T) {
 	device := Device{}
 
 	testAppend(device, "", t)
+}
+
+var knobsString = "-no-user-config -nodefaults -nographic"
+
+func TestAppendKnobsAllTrue(t *testing.T) {
+	knobs := Knobs{
+		NoUserConfig: true,
+		NoDefaults:   true,
+		NoGraphic:    true,
+	}
+
+	testAppend(knobs, knobsString, t)
+}
+
+func TestAppendKnobsAllFalse(t *testing.T) {
+	knobs := Knobs{
+		NoUserConfig: false,
+		NoDefaults:   false,
+		NoGraphic:    false,
+	}
+
+	testAppend(knobs, "", t)
 }

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -166,6 +166,23 @@ func TestAppendDeviceSerial(t *testing.T) {
 	testAppend(sdev, deviceSerialString, t)
 }
 
+var deviceBlockString = "-device virtio-blk,drive=hd0,scsi=off,config-wce=off -drive id=hd0,file=/var/lib/ciao.img,aio=threads,format=qcow2,if=none"
+
+func TestAppendDeviceBlock(t *testing.T) {
+	blkdev := BlockDevice{
+		Driver:    VirtioBlock,
+		ID:        "hd0",
+		File:      "/var/lib/ciao.img",
+		AIO:       Threads,
+		Format:    QCOW2,
+		Interface: NoInterface,
+		SCSI:      false,
+		WCE:       false,
+	}
+
+	testAppend(blkdev, deviceBlockString, t)
+}
+
 func TestAppendEmptyDevice(t *testing.T) {
 	device := SerialDevice{}
 

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -259,7 +259,7 @@ func TestAppendQMPSocketServer(t *testing.T) {
 
 func TestAppendQMPSocket(t *testing.T) {
 	qmp := QMPSocket{
-		Type:   "unix",
+		Type:   Unix,
 		Name:   "cc-qmp",
 		Server: false,
 	}


### PR DESCRIPTION
LaunchQemu() now takes a Config structure that contains more
descriptive fields than raw qemu parameters.

LaunchQemu is now simpler to call and more extensible as supporting more
qemu parameters would mean expanding Config instead of changing the API.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>