### PR TITLE
ciao-image: Add delete image support

### DIFF
--- a/ciao-image/datastore/datastore.go
+++ b/ciao-image/datastore/datastore.go
@@ -15,7 +15,6 @@
 package datastore
 
 import (
-	"errors"
 	"io"
 	"time"
 
@@ -81,14 +80,6 @@ type Image struct {
 	CreateTime time.Time
 	Type       Type
 }
-
-var (
-	// ErrNoImage is returned when an image is not found.
-	ErrNoImage = errors.New("Image not found")
-
-	// ErrImageSaving is returned when an image is being uploaded.
-	ErrImageSaving = errors.New("Image being uploaded")
-)
 
 // DataStore is the image data storage interface.
 type DataStore interface {

--- a/ciao-image/service/service.go
+++ b/ciao-image/service/service.go
@@ -102,10 +102,23 @@ func (is ImageService) ListImages() ([]image.DefaultResponse, error) {
 }
 
 // UploadImage will upload a raw image data and update its status.
-func (is ImageService) UploadImage(imageID string, body io.Reader) (image.UploadImageResponse, error) {
-	var response image.UploadImageResponse
+func (is ImageService) UploadImage(imageID string, body io.Reader) (image.NoContentImageResponse, error) {
+	var response image.NoContentImageResponse
 
 	err := is.ds.UploadImage(imageID, body)
+	if err != nil {
+		return response, err
+	}
+
+	response.ImageID = imageID
+	return response, nil
+}
+
+// DeleteImage will delete a raw image and its metadata
+func (is ImageService) DeleteImage(imageID string) (image.NoContentImageResponse, error) {
+	var response image.NoContentImageResponse
+
+	err := is.ds.DeleteImage(imageID)
 	if err != nil {
 		return response, err
 	}

--- a/openstack/image/api_test.go
+++ b/openstack/image/api_test.go
@@ -68,6 +68,14 @@ var tests = []test{
 		http.StatusOK,
 		`{"status":"active","container_format":"bare","min_ram":0,"updated_at":"2014-05-05T17:15:11Z","owner":"5ef70662f8b34079a6eddb8da9d75fe8","min_disk":0,"tags":[],"locations":[],"visibility":"public","id":"1bea47ed-f6a9-463b-b423-14b9cca9ad27","size":13167616,"virtual_size":null,"name":"cirros-0.3.2-x86_64-disk","checksum":"64d7c1cd2b6f60c92c14662941cb7913","created_at":"2014-05-05T17:15:10Z","disk_format":"qcow2","properties":null,"protected":false,"self":"/v2/images/1bea47ed-f6a9-463b-b423-14b9cca9ad27","file":"/v2/images/1bea47ed-f6a9-463b-b423-14b9cca9ad27/file","schema":"/v2/schemas/image"}`,
 	},
+	{
+		"DELETE",
+		"/v2/images/1bea47ed-f6a9-463b-b423-14b9cca9ad27",
+		deleteImage,
+		"",
+		http.StatusNoContent,
+		`null`,
+	},
 }
 
 func myHostname() string {
@@ -177,8 +185,12 @@ func (is testImageService) GetImage(ID string) (DefaultResponse, error) {
 	}, nil
 }
 
-func (is testImageService) UploadImage(string, io.Reader) (UploadImageResponse, error) {
-	return UploadImageResponse{}, nil
+func (is testImageService) UploadImage(string, io.Reader) (NoContentImageResponse, error) {
+	return NoContentImageResponse{}, nil
+}
+
+func (is testImageService) DeleteImage(string) (NoContentImageResponse, error) {
+	return NoContentImageResponse{}, nil
 }
 
 func TestRoutes(t *testing.T) {


### PR DESCRIPTION
This commit adds support for deleting images. Now, you will be able to
delete images with the command:
```
  ciao-cli image delete -image 78306709-9720-417e-97c6-7b941cb5565b
```
If the operation was successful, you will get a 204 HTTP return code.
If not, it may return the proper error, for example a 404 error could
come when the image does not exist.
Signed-off-by: Munoz, Obed N <obed.n.munoz@intel.com>