### PR TITLE
testing: add coverage for ciao-cert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
    - sudo mkdir -p /var/lib/ciao/instances
    - sudo chmod 0777 /var/lib/ciao/instances
    - test-cases -v -timeout 9 -text -coverprofile /tmp/cover.out -short github.com/01org/ciao/ciao-controller/...
-   - test-cases -v -timeout 9 -text -coverprofile /tmp/cover.out -append-profile -short github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/payloads github.com/01org/ciao/configuration github.com/01org/ciao/testutil github.com/01org/ciao/ssntp/uuid github.com/01org/ciao/qemu
+   - test-cases -v -timeout 9 -text -coverprofile /tmp/cover.out -append-profile -short github.com/01org/ciao/ciao-cert github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/payloads github.com/01org/ciao/configuration github.com/01org/ciao/testutil github.com/01org/ciao/ssntp/uuid github.com/01org/ciao/qemu
    - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -text -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/ssntp
    - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -text -short -tags travis -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/networking/libsnnet
    # API Documentation is automated by swagger, every PR will verify the documentation can be generated


### PR DESCRIPTION
Actually there's no coverage, based on inspection, but coveralls doesn't
notice because we don't try to run the nothing that's there.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>