### PR TITLE
Bring ssntp/examples up to date with latest API

### DIFF
--- a/ssntp/examples/client.go
+++ b/ssntp/examples/client.go
@@ -119,7 +119,7 @@ func clientThread(config *ssntp.Config, n int, threads int, nFrames int, delay i
 func main() {
 	var serverURL = flag.String("url", "localhost", "Server URL")
 	var cert = flag.String("cert", "/etc/pki/ciao/client.pem", "Client certificate")
-	var CAcert = flag.String("cacert", "/etc/pki/ciao/ciao_ca_cert.crt", "CA certificate")
+	var CAcert = flag.String("cacert", "/etc/pki/ciao/ca_cert.crt", "CA certificate")
 	var nFrames = flag.Int("frames", 10, "Number of frames to send")
 	var delay = flag.Int("delay", 500, "Delay(ms) between frames")
 	var threads = flag.Int("threads", 1, "Number of client threads")

--- a/ssntp/examples/server.go
+++ b/ssntp/examples/server.go
@@ -49,12 +49,12 @@ func (l logger) Warningf(format string, args ...interface{}) {
 	fmt.Printf("WARNING: Server example: "+format, args...)
 }
 
-func (server *ssntpEchoServer) ConnectNotify(uuid string, role Role) {
+func (server *ssntpEchoServer) ConnectNotify(uuid string, role ssntp.Role) {
 	server.nConnections++
 	fmt.Printf("%s: %s connected (role 0x%x, current connections %d)\n", server.name, uuid, role, server.nConnections)
 }
 
-func (server *ssntpEchoServer) DisconnectNotify(uuid string, role Role) {
+func (server *ssntpEchoServer) DisconnectNotify(uuid string, role ssntp.Role) {
 	server.nConnections--
 	fmt.Printf("%s: %s disconnected (role 0x%x, current connections %d)\n", server.name, uuid, role, server.nConnections)
 }
@@ -82,7 +82,7 @@ func (server *ssntpEchoServer) ErrorNotify(uuid string, error ssntp.Error, frame
 
 func main() {
 	var cert = flag.String("cert", "/etc/pki/ciao/client.pem", "Client certificate")
-	var CAcert = flag.String("cacert", "/etc/pki/ciao/ciao_ca_cert.crt", "CA certificate")
+	var CAcert = flag.String("cacert", "/etc/pki/ciao/ca_cert.crt", "CA certificate")
 	var cpuprofile = flag.String("cpuprofile", "", "Write cpu profile to file")
 	var config ssntp.Config
 


### PR DESCRIPTION
Examples in ssntp needed to be updated to work properly with the
latest version of the ssntp package. This patch brings the examples up
to date on the naming of the certificates from ciao_ca_cert to ca_cert
and usage of the Role struct needing to be changed to ssntp.Role.

Signed-off-by: John Andersen <john.s.andersen@intel.com>