### PR TITLE
Updated ssntp/README.md added link to ciao-cert

### DIFF
--- a/ssntp/README.md
+++ b/ssntp/README.md
@@ -97,6 +97,11 @@ UUIDs.
 3. Connection is successfully established. Both ends of the connection
    can now asynchronously send SSNTP frames.
 
+## SSNTP certificates ##
+
+SSNTP uses ciao-cert to generate the certificates it needs to communicate. They
+can be generated with instructions found in [ciao-cert] (https://github.com/01org/ciao/tree/master/ciao-cert).
+
 ## SSNTP frames ##
 
 Each SSNTP frame is composed of a fixed length, 8 bytes long header and


### PR DESCRIPTION
Added a link to the ciao-cert repo in the ssntp README to provided
instructions on certificate generation for ssntp.

Signed-off-by: John Andersen <john.s.andersen@intel.com>