### PR TITLE
[DO NOT MERGE] testutil: increase Results channel timeouts

### DIFF
--- a/testutil/agent.go
+++ b/testutil/agent.go
@@ -124,7 +124,7 @@ func (client *SsntpTestClient) GetCmdChanResult(c *chan Result, cmd ssntp.Comman
 		if result.Err != nil {
 			err = fmt.Errorf("Client error sending %s command: %s\n", cmd, result.Err)
 		}
-	case <-time.After(25 * time.Second):
+	case <-time.After(60 * time.Second):
 		err = fmt.Errorf("Timeout waiting for client %s command result\n", cmd)
 	}
 
@@ -163,7 +163,7 @@ func (client *SsntpTestClient) GetEventChanResult(c *chan Result, evt ssntp.Even
 		if result.Err != nil {
 			err = fmt.Errorf("Client error sending %s event: %s\n", evt, result.Err)
 		}
-	case <-time.After(25 * time.Second):
+	case <-time.After(60 * time.Second):
 		err = fmt.Errorf("Timeout waiting for client %s event result\n", evt)
 	}
 
@@ -202,7 +202,7 @@ func (client *SsntpTestClient) GetErrorChanResult(c *chan Result, error ssntp.Er
 		if result.Err != nil {
 			err = fmt.Errorf("Client error sending %s error: %s\n", error, result.Err)
 		}
-	case <-time.After(25 * time.Second):
+	case <-time.After(60 * time.Second):
 		err = fmt.Errorf("Timeout waiting for client %s error result\n", error)
 	}
 
@@ -241,7 +241,7 @@ func (client *SsntpTestClient) GetStatusChanResult(c *chan Result, status ssntp.
 		if result.Err != nil {
 			err = fmt.Errorf("Client error sending %s status: %s\n", status, result.Err)
 		}
-	case <-time.After(25 * time.Second):
+	case <-time.After(60 * time.Second):
 		err = fmt.Errorf("Timeout waiting for client %s status result\n", status)
 	}
 

--- a/testutil/controller.go
+++ b/testutil/controller.go
@@ -98,7 +98,7 @@ func (ctl *SsntpTestController) GetCmdChanResult(c *chan Result, cmd ssntp.Comma
 		if result.Err != nil {
 			err = fmt.Errorf("Controller error sending %s command: %s\n", cmd, result.Err)
 		}
-	case <-time.After(25 * time.Second):
+	case <-time.After(60 * time.Second):
 		err = fmt.Errorf("Timeout waiting for controller %s command result\n", cmd)
 	}
 
@@ -137,7 +137,7 @@ func (ctl *SsntpTestController) GetEventChanResult(c *chan Result, evt ssntp.Eve
 		if result.Err != nil {
 			err = fmt.Errorf("Controller error sending %s event: %s\n", evt, result.Err)
 		}
-	case <-time.After(25 * time.Second):
+	case <-time.After(60 * time.Second):
 		err = fmt.Errorf("Timeout waiting for controller %s event result\n", evt)
 	}
 
@@ -176,7 +176,7 @@ func (ctl *SsntpTestController) GetErrorChanResult(c *chan Result, error ssntp.E
 		if result.Err != nil {
 			err = fmt.Errorf("Controller error sending %s error: %s\n", error, result.Err)
 		}
-	case <-time.After(25 * time.Second):
+	case <-time.After(60 * time.Second):
 		err = fmt.Errorf("Timeout waiting for controller %s error result\n", error)
 	}
 

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -65,7 +65,7 @@ func (server *SsntpTestServer) GetCmdChanResult(c *chan Result, cmd ssntp.Comman
 		if result.Err != nil {
 			err = fmt.Errorf("Server error on %s command: %s\n", cmd, result.Err)
 		}
-	case <-time.After(25 * time.Second):
+	case <-time.After(60 * time.Second):
 		err = fmt.Errorf("Timeout waiting for server %s command result\n", cmd)
 	}
 
@@ -104,7 +104,7 @@ func (server *SsntpTestServer) GetEventChanResult(c *chan Result, evt ssntp.Even
 		if result.Err != nil {
 			err = fmt.Errorf("Server error handling %s event: %s\n", evt, result.Err)
 		}
-	case <-time.After(25 * time.Second):
+	case <-time.After(60 * time.Second):
 		err = fmt.Errorf("Timeout waiting for server %s event result\n", evt)
 	}
 
@@ -143,7 +143,7 @@ func (server *SsntpTestServer) GetErrorChanResult(c *chan Result, error ssntp.Er
 		if result.Err != nil {
 			err = fmt.Errorf("Server error handling %s error: %s\n", error, result.Err)
 		}
-	case <-time.After(25 * time.Second):
+	case <-time.After(60 * time.Second):
 		err = fmt.Errorf("Timeout waiting for server %s error result\n", error)
 	}
 
@@ -182,7 +182,7 @@ func (server *SsntpTestServer) GetStatusChanResult(c *chan Result, status ssntp.
 		if result.Err != nil {
 			err = fmt.Errorf("Server error handling %s status: %s\n", status, result.Err)
 		}
-	case <-time.After(25 * time.Second):
+	case <-time.After(60 * time.Second):
 		err = fmt.Errorf("Timeout waiting for server %s status result\n", status)
 	}
 


### PR DESCRIPTION
Back in commit 0e16917936eabe454ada1df8bc0bc601d4a4a954 I rationlized why
we sometime see timeouts on the testutil Results channels, but took a stab
at a reasonable timeout.  In the meantime we have a considerable amount of
travis failures where, eg:

ciao-scheduler     TestReconnects                           26.03s     FAIL
ciao-scheduler     TestTenantAdded                          25.00s     FAIL
ciao-scheduler     TestTenantRemoved                        25.00s     FAIL

we clearly hit the 25s timeout.

Therefore this patch bumps the timeout to 60 seconds.  If it keeps causing
problems, I'll just remove the timeout completely.  This is purely test
code, and go-test does have it's own hang detection.

Fixes https://github.com/01org/ciao/issues/580

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>