### PR TITLE
Single VM: Fix dev environment

### DIFF
--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
 
+if [ -z "$HOSTS_FILE_BACKUP" ]; then
+    echo "HOSTS_FILE_BACKUP" is not set.
+    echo "Please run"
+    echo ""
+    echo ". ~/local/demo.sh"
+    exit 1
+fi
+ciao_gobin="$GOPATH"/bin
 sudo killall ciao-scheduler
 sudo killall ciao-controller
 sudo killall ciao-launcher
-sudo killall qemu-system-x86_64
-sudo rm -rf /var/lib/ciao/instances
+sleep 2
+sudo "$ciao_gobin"/ciao-launcher --hard-reset
+sudo ip link del eth10
+sudo pkill -F /tmp/dnsmasq.macvlan0.pid
+sudo mv $HOSTS_FILE_BACKUP /etc/hosts

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -22,7 +22,6 @@ cleanup()
 	"$ciao_gobin"/ciao-cli instance delete --all
 	#Also kill the CNCI (as there is no other way to delete it today)
 	sudo killall qemu-system-x86_64
-	sudo rm -rf /var/lib/ciao/instances
 	sudo ip link del eth10
 	sudo pkill -F /tmp/dnsmasq.macvlan0.pid
 	sudo mv $hosts_file_backup /etc/hosts
@@ -262,7 +261,8 @@ cd "$ciao_bin"
 "$ciao_bin"/run_launcher.sh &> /dev/null
 "$ciao_bin"/run_controller.sh &> /dev/null
 
-echo "export CIAO_CONTROLLER=""$ciao_host" > "$ciao_env"
+echo "export HOSTS_FILE_BACKUP=""$hosts_file_backup" > "$ciao_env"
+echo "export CIAO_CONTROLLER=""$ciao_host" >> "$ciao_env"
 echo "export CIAO_USERNAME=admin" >> "$ciao_env"
 echo "export CIAO_PASSWORD=giveciaoatry" >> "$ciao_env"
 sleep 5

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -378,4 +378,12 @@ then
 fi
 
 "$ciao_gobin"/ciao-cli instance list
-cleanup
+"$ciao_gobin"/ciao-cli instance delete --all
+echo "Your ciao development environment has been initialised."
+echo "To get started run:"
+echo ""
+echo ". ~/local/demo.sh"
+echo ""
+echo "When you're finished run the following command to cleanup"
+echo ""
+echo "./cleanup.sh"


### PR DESCRIPTION
This PR updates the singlevm scripts so that they can be used as a development environment.  In short:

1. The cluster is no longer torn down when the setup.sh exits.  Instead all we do is to delete the test instances created by setup.sh.  The cluster remains up and functional.
2. Some information is printed out when the script ends informing the user that he needs to source a file containing some environment variables needed to communicate with ciao and also to teardown the cluster.
3. The cleanup.sh script has been updated to correctly teardown the cluster.

The PR also fixes #518 which left bridges and tap devices hanging around.