### PR TITLE
ciao-launcher: Send memory and CPU limits to Docker

### DIFF
--- a/ciao-launcher/docker.go
+++ b/ciao-launcher/docker.go
@@ -185,6 +185,18 @@ func (d *docker) createImage(bridge string, userData, metaData []byte) error {
 	}
 
 	hostConfig := &container.HostConfig{}
+
+	if d.cfg.Mem > 0 {
+		// Docker memory limit is in bytes.
+		hostConfig.Memory = int64(1024 * 1024 * d.cfg.Mem)
+	}
+
+	if d.cfg.Cpus > 0 {
+		// CFS quota period - default to 100ms.
+		hostConfig.CPUPeriod = (time.Millisecond * 100).Nanoseconds()
+		hostConfig.CPUQuota = hostConfig.CPUPeriod * int64(d.cfg.Cpus)
+	}
+
 	networkConfig := &network.NetworkingConfig{}
 	if bridge != "" {
 		config.MacAddress = d.cfg.VnicMAC


### PR DESCRIPTION
This change uses the memory and CPU limits extracted from the START
payload and after converting to the units Docker requires updates the
Docker HostConfig.

Fixes: #16

Signed-off-by: Rob Bradford <robert.bradford@intel.com>