### PR TITLE
ciao-launcher: Fix launching of docker containers.

### DIFF
--- a/ciao-launcher/docker.go
+++ b/ciao-launcher/docker.go
@@ -193,7 +193,7 @@ func (d *docker) createImage(bridge string, userData, metaData []byte) error {
 
 	if d.cfg.Cpus > 0 {
 		// CFS quota period - default to 100ms.
-		hostConfig.CPUPeriod = (time.Millisecond * 100).Nanoseconds()
+		hostConfig.CPUPeriod = 100 * 1000
 		hostConfig.CPUQuota = hostConfig.CPUPeriod * int64(d.cfg.Cpus)
 	}
 


### PR DESCRIPTION
PR #590 broke launching of docker containers by specifying an invalid cpu
period.  It was specifying the period in nanoseconds.  Unfortunately, docker
was expecting milliseconds.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>