### PR TITLE
qemu: Fix security model typo

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -219,7 +219,7 @@ func (fsdev FSDevice) QemuParams(config *Config) []string {
 	fsParams = append(fsParams, string(fsdev.FSDriver))
 	fsParams = append(fsParams, fmt.Sprintf(",id=%s", fsdev.ID))
 	fsParams = append(fsParams, fmt.Sprintf(",path=%s", fsdev.Path))
-	fsParams = append(fsParams, fmt.Sprintf(",security-model=%s", fsdev.SecurityModel))
+	fsParams = append(fsParams, fmt.Sprintf(",security_model=%s", fsdev.SecurityModel))
 
 	qemuParams = append(qemuParams, "-device")
 	qemuParams = append(qemuParams, strings.Join(deviceParams, ""))

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -100,7 +100,7 @@ func TestAppendDeviceNVDIMM(t *testing.T) {
 	testAppend(object, deviceNVDIMMString, t)
 }
 
-var deviceFSString = "-device virtio-9p-pci,fsdev=workload9p,mount_tag=rootfs -fsdev local,id=workload9p,path=/var/lib/docker/devicemapper/mnt/e31ebda2,security-model=none"
+var deviceFSString = "-device virtio-9p-pci,fsdev=workload9p,mount_tag=rootfs -fsdev local,id=workload9p,path=/var/lib/docker/devicemapper/mnt/e31ebda2,security_model=none"
 
 func TestAppendDeviceFS(t *testing.T) {
 	fsdev := FSDevice{


### PR DESCRIPTION
The right qemu parameter is "security_model", not "security-model".

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>