### PR TITLE
documentation: enable swagger to use vendoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,11 +63,9 @@ script:
    - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -text -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/ssntp
    - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -text -short -tags travis -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/networking/libsnnet
    # API Documentation is automated by swagger, every PR will verify the documentation can be generated
-   # swagger requires all dependencies of the package to be docummented to obtain models (structs, our case the payloads)
-   - go list ./... | sed -e "s/github\.com\/01org\/ciao\/vendor\///" | xargs go get
    # verify ciao-controller api documentation can be generated with swagger
    - go get github.com/yvasiyarov/swagger
-   - $GOPATH/bin/swagger  -apiPackage=github.com/01org/ciao/ciao-controller -mainApiFile=github.com/01org/ciao/ciao-controller/main.go -format=markdown -contentsTable=false -models=false -ignore "golang_org|context"
+   - $GOPATH/bin/swagger  -apiPackage=github.com/01org/ciao/ciao-controller -mainApiFile=github.com/01org/ciao/ciao-controller/main.go -format=markdown -contentsTable=false -models=false -vendoringPath $HOME/gopath/src/github.com/01org/ciao/vendor
 
 after_success:
    - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=/tmp/cover.out


### PR DESCRIPTION
Swagger is a tool used to generate documentation based on
declarative comments in the code, the problem with it was that it
had an issue with vendoring. We have fixed that issue in
https://github.com/yvasiyarov/swagger/pull/120
and now we can use our vendor directory. This fix was need because
we were bringing dependencies with 'go get' which in some PRs were
causing to fail for time outs, an issue aside of the PRs.

In this change we add the required argument to enforce to check for
vendor directory and remove the 'go get'.

Signed-off-by: Leoswaldo Macias <leoswaldo.macias@intel.com>