### PR TITLE
Add storage support to docker containers

### DIFF
--- a/ciao-launcher/attachvolume_instance.go
+++ b/ciao-launcher/attachvolume_instance.go
@@ -73,7 +73,8 @@ func processAttachVolume(storageDriver storage.BlockDriver, monitorCh chan inter
 
 		err = <-responseCh
 		if err != nil {
-			glog.Errorf("Unable to attach volume %s to instance %s", volumeUUID, instance)
+			glog.Errorf("Unable to attach volume %s to instance %s: %v",
+				volumeUUID, instance, err)
 			_ = storageDriver.UnmapVolumeFromNode(devName)
 			attachErr := &attachVolumeError{err, payloads.AttachVolumeAttachFailure}
 			return attachErr

--- a/ciao-launcher/attachvolume_instance.go
+++ b/ciao-launcher/attachvolume_instance.go
@@ -24,6 +24,13 @@ import (
 
 func processAttachVolume(storageDriver storage.BlockDriver, monitorCh chan interface{}, cfg *vmConfig,
 	instance, instanceDir, volumeUUID string, conn serverConn) *attachVolumeError {
+
+	if cfg.Container {
+		attachErr := &attachVolumeError{nil, payloads.AttachVolumeNotSupported}
+		glog.Errorf("Cannot attach a volume to a container [%s]", string(attachErr.code))
+		return attachErr
+	}
+
 	if cfg.findVolume(volumeUUID) != nil {
 		attachErr := &attachVolumeError{nil, payloads.AttachVolumeAlreadyAttached}
 		glog.Errorf("%s is already attached to attach instance %s [%s]",

--- a/ciao-launcher/detachvolume_instance.go
+++ b/ciao-launcher/detachvolume_instance.go
@@ -23,6 +23,13 @@ import (
 )
 
 func processDetachVolume(storageDriver storage.BlockDriver, monitorCh chan interface{}, cfg *vmConfig, instance, instanceDir, volumeUUID string, conn serverConn) *detachVolumeError {
+
+	if cfg.Container {
+		detachErr := &detachVolumeError{nil, payloads.DetachVolumeNotSupported}
+		glog.Errorf("Cannot detach a volume from a container [%s]", string(detachErr.code))
+		return detachErr
+	}
+
 	vol := cfg.findVolume(volumeUUID)
 	if vol == nil {
 		detachErr := &detachVolumeError{nil, payloads.DetachVolumeNotAttached}

--- a/ciao-launcher/docker.go
+++ b/ciao-launcher/docker.go
@@ -241,7 +241,7 @@ func (d *docker) umountVolumes(vols []volumeConfig) {
 	for _, vol := range vols {
 		vd := path.Join(d.instanceDir, volumesDir, vol.UUID)
 		if err := d.mount.Unmount(vd, 0); err != nil {
-			glog.Warningf("Unable to unmount %s", vd)
+			glog.Warningf("Unable to unmount %s: %v", vd, err)
 			continue
 		}
 		glog.Infof("%s successfully unmounted", vol.UUID)
@@ -251,7 +251,7 @@ func (d *docker) umountVolumes(vols []volumeConfig) {
 func (d *docker) unmapVolumes() {
 	for _, vol := range d.cfg.Volumes {
 		if err := d.storageDriver.UnmapVolumeFromNode(vol.UUID); err != nil {
-			glog.Warningf("Unable to unmap %s", vol.UUID)
+			glog.Warningf("Unable to unmap %s: %v", vol.UUID, err)
 			continue
 		}
 		glog.Infof("Unmapping volume %s", vol.UUID)
@@ -407,7 +407,7 @@ DONE:
 			case virtualizerStopCmd:
 				err := cli.ContainerKill(context.Background(), dockerID, "KILL")
 				if err != nil {
-					glog.Errorf("Unable to stop instance %s:%s", instance, dockerID)
+					glog.Errorf("Unable to stop instance %s:%s: %v", instance, dockerID, err)
 				}
 			case virtualizerAttachCmd:
 				err := fmt.Errorf("Live Attach of volumes not supported for containers")

--- a/ciao-launcher/docker_test.go
+++ b/ciao-launcher/docker_test.go
@@ -112,10 +112,15 @@ func TestDockerMountUnmount(t *testing.T) {
 		mount:         dockerTestMounter{mounts: mounts},
 	}
 
-	_, err = d.mountVolumes()
+	_, err = d.prepareVolumes()
 	if err != nil {
-		t.Fatalf("Unable to mount volumes: %v", err)
+		t.Fatalf("Unable to prepare volumes: %v", err)
 	}
+	err = d.mapAndMountVolumes()
+	if err != nil {
+		t.Fatalf("Unable to map and mount volumes: %v", err)
+	}
+
 	dirInfo, err := ioutil.ReadDir(instanceDir)
 	if err != nil {
 		t.Fatalf("Unable to readdir %s: %v", instanceDir, err)
@@ -146,7 +151,7 @@ func TestDockerMountUnmount(t *testing.T) {
 		}
 	}
 
-	d.dockerUmountVolumes(d.cfg.Volumes)
+	d.umountVolumes(d.cfg.Volumes)
 	if len(mounts) != 0 {
 		t.Fatalf("Not all volumes have been unmounted")
 	}
@@ -187,7 +192,12 @@ func TestDockerBadMount(t *testing.T) {
 		mount:         dockerTestMounter{mounts: mounts},
 	}
 
-	_, err = d.mountVolumes()
+	_, err = d.prepareVolumes()
+	if err != nil {
+		t.Fatalf("Unable to prepare volumes: %v", err)
+	}
+
+	err = d.mapAndMountVolumes()
 	if err == nil {
 		t.Fatal("d.mountVolumes was expected to fail")
 	}

--- a/ciao-launcher/docker_test.go
+++ b/ciao-launcher/docker_test.go
@@ -1,0 +1,198 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	storage "github.com/01org/ciao/ciao-storage"
+)
+
+type dockerTestMounter struct {
+	mounts map[string]string
+}
+
+func (m dockerTestMounter) Mount(source, destination string) error {
+	m.mounts[path.Base(destination)] = source
+	return nil
+}
+
+func (m dockerTestMounter) Unmount(destination string, flags int) error {
+	delete(m.mounts, path.Base(destination))
+	return nil
+}
+
+type dockerTestStorage struct {
+	root      string
+	failAfter int
+	count     int
+}
+
+func (s dockerTestStorage) MapVolumeToNode(volumeUUID string) (string, error) {
+	if s.failAfter != -1 && s.failAfter >= s.count {
+		return "", fmt.Errorf("MapVolumeToNode failure forced")
+	}
+	s.count++
+
+	return "", nil
+}
+
+func (s dockerTestStorage) CreateBlockDevice(image *string, sizeGB int) (storage.BlockDevice, error) {
+	return storage.BlockDevice{}, nil
+}
+
+func (s dockerTestStorage) DeleteBlockDevice(string) error {
+	return nil
+}
+
+func (s dockerTestStorage) UnmapVolumeFromNode(volumeUUID string) error {
+	return nil
+}
+
+func (s dockerTestStorage) GetVolumeMapping() (map[string][]string, error) {
+	return nil, nil
+}
+
+func (s dockerTestStorage) cleanup() error {
+	return os.RemoveAll(s.root)
+}
+
+// Checks that the logic of the code that mounts and unmounts ceph volumes in
+// docker containers.
+//
+// We mount 4 volumes, check the mount commands are received correctly and check
+// the correct directories are created.  We then unmount, and check that everything
+// gets unmounted as expected.
+//
+// Calls to docker.mountVolumes and docker.unmountVolumes should succeed and the
+// mounted volumes should be correctly cleaned up.
+func TestDockerMountUnmount(t *testing.T) {
+	root, err := ioutil.TempDir("", "mount-unmount")
+	if err != nil {
+		t.Fatalf("Unable to create temporary directory: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(root) }()
+
+	instanceDir := path.Join(root, "volumes")
+
+	s := dockerTestStorage{
+		root:      root,
+		failAfter: -1,
+	}
+	mounts := make(map[string]string)
+	d := docker{
+		cfg: &vmConfig{
+			Volumes: []volumeConfig{
+				{UUID: "92a1e4fa-8448-4260-adb1-4d2dd816cc7c"},
+				{UUID: "5ce2c5bf-58d9-4573-b433-05550b945866"},
+				{UUID: "11773eac-6b27-4bc1-8717-02e75ae5e063"},
+				{UUID: "590603fb-c73e-4efa-941e-454b5d4f9857"},
+			},
+		},
+		instanceDir:   root,
+		storageDriver: s,
+		mount:         dockerTestMounter{mounts: mounts},
+	}
+
+	_, err = d.mountVolumes()
+	if err != nil {
+		t.Fatalf("Unable to mount volumes: %v", err)
+	}
+	dirInfo, err := ioutil.ReadDir(instanceDir)
+	if err != nil {
+		t.Fatalf("Unable to readdir %s: %v", instanceDir, err)
+	}
+
+	if len(dirInfo) != len(d.cfg.Volumes) {
+		t.Fatalf("Unexpected number of volumes directories.  Found %d, expected %d",
+			len(dirInfo), len(d.cfg.Volumes))
+	}
+
+	if len(dirInfo) != len(mounts) {
+		t.Fatalf("Unexpected number of volumes mounted.  Found %d, expected %d",
+			len(dirInfo), len(mounts))
+	}
+
+	for _, vol := range d.cfg.Volumes {
+		var i int
+		for i = 0; i < len(dirInfo); i++ {
+			if vol.UUID == dirInfo[i].Name() {
+				break
+			}
+		}
+		if i == len(dirInfo) {
+			t.Fatalf("%s not mounted", vol.UUID)
+		}
+		if _, ok := mounts[vol.UUID]; !ok {
+			t.Fatalf("%s does not seem to have been mounted", vol.UUID)
+		}
+	}
+
+	d.dockerUmountVolumes(d.cfg.Volumes)
+	if len(mounts) != 0 {
+		t.Fatalf("Not all volumes have been unmounted")
+	}
+}
+
+// Checks that everything is cleaned up correctly when a call to
+// docker.mountVolumes fails.
+//
+// We call docker.mountVolumes with 4 volumes but arrange for the call to fail
+// after the second volume has been created.
+//
+// docker.mountVolumes should fail but everything should be cleaned up despite
+// the failure.
+func TestDockerBadMount(t *testing.T) {
+	root, err := ioutil.TempDir("", "mount-unmount")
+	if err != nil {
+		t.Fatalf("Unable to create temporary directory: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(root) }()
+
+	s := dockerTestStorage{
+		root:      root,
+		failAfter: 2,
+	}
+
+	mounts := make(map[string]string)
+	d := docker{
+		cfg: &vmConfig{
+			Volumes: []volumeConfig{
+				{UUID: "92a1e4fa-8448-4260-adb1-4d2dd816cc7c"},
+				{UUID: "5ce2c5bf-58d9-4573-b433-05550b945866"},
+				{UUID: "11773eac-6b27-4bc1-8717-02e75ae5e063"},
+				{UUID: "590603fb-c73e-4efa-941e-454b5d4f9857"},
+			},
+		},
+		instanceDir:   root,
+		storageDriver: s,
+		mount:         dockerTestMounter{mounts: mounts},
+	}
+
+	_, err = d.mountVolumes()
+	if err == nil {
+		t.Fatal("d.mountVolumes was expected to fail")
+	}
+
+	if len(mounts) != 0 {
+		t.Fatal("mounts not cleaned up correctly")
+	}
+}

--- a/ciao-launcher/instance.go
+++ b/ciao-launcher/instance.go
@@ -408,17 +408,18 @@ func startInstanceWithVM(instance string, cfg *vmConfig, wg *sync.WaitGroup, don
 func startInstance(instance string, cfg *vmConfig, wg *sync.WaitGroup, doneCh chan struct{},
 	ac *agentClient, ovsCh chan<- interface{}) chan<- interface{} {
 
+	storageDriver := storage.CephDriver{
+		SecretPath: secretPath,
+		ID:         cephID,
+	}
+
 	var vm virtualizer
 	if simulate == true {
 		vm = &simulation{}
 	} else if cfg.Container {
-		vm = &docker{}
+		vm = &docker{storageDriver: storageDriver}
 	} else {
 		vm = &qemuV{}
 	}
-	return startInstanceWithVM(instance, cfg, wg, doneCh, ac, ovsCh, vm,
-		storage.CephDriver{
-			SecretPath: secretPath,
-			ID:         cephID,
-		})
+	return startInstanceWithVM(instance, cfg, wg, doneCh, ac, ovsCh, vm, storageDriver)
 }

--- a/payloads/attachvolumefailure.go
+++ b/payloads/attachvolumefailure.go
@@ -51,6 +51,10 @@ const (
 	// be attached as the instance has failed to start and is being
 	// deleted
 	AttachVolumeInstanceFailure = "instance_failure"
+
+	// AttachVolumeNotSupported indicates that the attach volume command
+	// is not supported for the given workload type, e.g., a container.
+	AttachVolumeNotSupported = "not_supported"
 )
 
 // ErrorAttachVolumeFailure represents the unmarshalled version of the contents of a
@@ -84,6 +88,8 @@ func (r AttachVolumeFailureReason) String() string {
 		return "State failure"
 	case AttachVolumeInstanceFailure:
 		return "Instance failure"
+	case AttachVolumeNotSupported:
+		return "Not Supported"
 	}
 
 	return ""

--- a/payloads/attachvolumefailure_test.go
+++ b/payloads/attachvolumefailure_test.go
@@ -74,6 +74,7 @@ func TestAttachVolmeFailureString(t *testing.T) {
 		{AttachVolumeAlreadyAttached, "Volume already attached"},
 		{AttachVolumeStateFailure, "State failure"},
 		{AttachVolumeInstanceFailure, "Instance failure"},
+		{AttachVolumeNotSupported, "Not Supported"},
 	}
 	error := ErrorAttachVolumeFailure{
 		InstanceUUID: testutil.InstanceUUID,

--- a/payloads/detachvolumefailure.go
+++ b/payloads/detachvolumefailure.go
@@ -51,6 +51,10 @@ const (
 	// be detached as the instance has failed to start and is being
 	// deleted
 	DetachVolumeInstanceFailure = "instance_failure"
+
+	// DetachVolumeNotSupported indicates that the detach volume command
+	// is not supported for the given workload type, e.g., a container.
+	DetachVolumeNotSupported = "not_supported"
 )
 
 // ErrorDetachVolumeFailure represents the unmarshalled version of the contents of a
@@ -84,6 +88,8 @@ func (r DetachVolumeFailureReason) String() string {
 		return "State failure"
 	case DetachVolumeInstanceFailure:
 		return "Instance failure"
+	case DetachVolumeNotSupported:
+		return "Not Supported"
 	}
 
 	return ""

--- a/payloads/detachvolumefailure_test.go
+++ b/payloads/detachvolumefailure_test.go
@@ -74,6 +74,7 @@ func TestDetachVolmeFailureString(t *testing.T) {
 		{DetachVolumeNotAttached, "Volume not attached"},
 		{DetachVolumeStateFailure, "State failure"},
 		{DetachVolumeInstanceFailure, "Instance failure"},
+		{DetachVolumeNotSupported, "Not Supported"},
 	}
 	error := ErrorDetachVolumeFailure{
 		InstanceUUID: testutil.InstanceUUID,


### PR DESCRIPTION
This PR adds storage support to docker containers.  It allows clients to attach ceph volumes to docker containers when the containers are created.  All containers are currently mounted as RW to the path /volumes/UUID where UUID is the uuid of the ceph volume.  It is not possible to Attach or Detach a volume to a container after it has been created.

Fixes: #527 