### PR TITLE
Fix logging wrappers to give correct source information

### DIFF
--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -102,23 +102,27 @@ const (
 )
 
 func debugf(format string, args ...interface{}) {
-	glog.V(2).Infof("ciao-cli DEBUG: "+format, args...)
+	if glog.V(2) {
+		glog.InfoDepth(1, fmt.Sprintf("ciao-cli DEBUG: "+format, args...))
+	}
 }
 
 func infof(format string, args ...interface{}) {
-	glog.V(1).Infof("ciao-cli INFO: "+format, args...)
+	if glog.V(1) {
+		glog.InfoDepth(1, fmt.Sprintf("ciao-cli INFO: "+format, args...))
+	}
 }
 
 func warningf(format string, args ...interface{}) {
-	glog.Warningf("ciao-cli WARNING: "+format, args...)
+	glog.WarningDepth(1, fmt.Sprintf("ciao-cli WARNING: "+format, args...))
 }
 
 func errorf(format string, args ...interface{}) {
-	glog.Errorf("ciao-cli ERROR: "+format, args...)
+	glog.ErrorDepth(1, fmt.Sprintf("ciao-cli ERROR: "+format, args...))
 }
 
 func fatalf(format string, args ...interface{}) {
-	glog.Fatalf("ciao-cli FATAL: "+format, args...)
+	glog.FatalDepth(1, fmt.Sprintf("ciao-cli FATAL: "+format, args...))
 	os.Exit(1)
 }
 

--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -123,7 +123,6 @@ func errorf(format string, args ...interface{}) {
 
 func fatalf(format string, args ...interface{}) {
 	glog.FatalDepth(1, fmt.Sprintf("ciao-cli FATAL: "+format, args...))
-	os.Exit(1)
 }
 
 var (

--- a/ssntp/ssntp.go
+++ b/ssntp/ssntp.go
@@ -888,17 +888,17 @@ type glogLog struct{}
 
 func (l glogLog) Infof(format string, args ...interface{}) {
 	if glog.V(2) {
-		glog.Infof("SSNTP Info: "+format, args...)
+		glog.InfoDepth(2, fmt.Sprintf("SSNTP Info: "+format, args...))
 	}
 }
 
 func (l glogLog) Errorf(format string, args ...interface{}) {
-	glog.Errorf("SSNTP Error: "+format, args...)
+	glog.ErrorDepth(2, fmt.Sprintf("SSNTP Error: "+format, args...))
 }
 
 func (l glogLog) Warningf(format string, args ...interface{}) {
 	if glog.V(1) {
-		glog.Warningf("SSNTP Warning: "+format, args...)
+		glog.WarningDepth(2, fmt.Sprintf("SSNTP Warning: "+format, args...))
 	}
 }
 


### PR DESCRIPTION
Using the *Depth variants of the glog functions makes the log messages through the wrapper have the line number they were called at, not the line number inside the wrapper.