### PR TITLE
[DONOTMERGE] Enable floating IPs on CIAO CNCI agent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ script:
    - docker --version
    - sudo docker pull debian
    - sudo ip link add testdummy type dummy
+   - export FWIFINT_ENV=testdummy
    - sudo ip addr add 198.51.100.1/24 dev testdummy
    - go get github.com/google/gofuzz github.com/stretchr/testify
    - go get github.com/golang/lint/golint github.com/client9/misspell/cmd/misspell

--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -267,6 +267,31 @@ func (client *ssntpClient) RestartInstance(instanceID string, nodeID string) err
 	return err
 }
 
+func (client *ssntpClient) AssignFloatingIP(floatingIP payloads.FloatingIP) error {
+	floatingIPCmd := payloads.PublicIPCommand{
+		PublicIP:     floatingIP.AssignFloatingIP.Address,
+		PrivateIP:    floatingIP.AssignFloatingIP.InternalIP,
+		TenantUUID:   floatingIP.AssignFloatingIP.TenantUUID,
+		InstanceUUID: floatingIP.AssignFloatingIP.InstanceUUID,
+	}
+
+	payload := payloads.CommandAssignPublicIP{
+		AssignIP: floatingIPCmd,
+	}
+
+	y, err := yaml.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	glog.Info("Assing Floating IP %s to internal %s", floatingIP.AssignFloatingIP.Address, floatingIP.AssignFloatingIP.InternalIP)
+	glog.V(1).Info(string(y))
+
+	_, err = client.ssntp.SendCommand(ssntp.AssignPublicIP, y)
+
+	return err
+}
+
 func (client *ssntpClient) EvacuateNode(nodeID string) error {
 	evacuateCmd := payloads.EvacuateCmd{
 		WorkloadAgentUUID: nodeID,

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -86,6 +86,17 @@ func (c *controller) deleteInstance(instanceID string) error {
 	return nil
 }
 
+func (c *controller) assignFloatingIP(floatingIP payloads.FloatingIP) error {
+	// validate the tenant exists
+	_, err := c.ds.GetTenant(floatingIP.AssignFloatingIP.TenantUUID)
+	if err != nil {
+		return err
+	}
+
+	go c.client.AssignFloatingIP(floatingIP)
+	return nil
+}
+
 func (c *controller) confirmTenant(tenantID string) error {
 	tenant, err := c.ds.GetTenant(tenantID)
 	if err != nil {

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -212,6 +212,19 @@ func (c *controller) StopServer(tenant string, ID string) error {
 	return c.stopInstance(ID)
 }
 
+func (c *controller) AssignFloatingIP(floatingIP payloads.FloatingIP) error {
+	i, err := c.ds.GetInstance(floatingIP.AssignFloatingIP.InstanceUUID)
+	if err != nil {
+		return err
+	}
+
+	if i.TenantID != floatingIP.AssignFloatingIP.TenantUUID {
+		return compute.ErrServerOwner
+	}
+
+	return c.assignFloatingIP(floatingIP)
+}
+
 func (c *controller) ListFlavors(tenant string) (compute.Flavors, error) {
 	flavors := compute.NewComputeFlavors()
 

--- a/networking/ciao-cnci-agent/client.go
+++ b/networking/ciao-cnci-agent/client.go
@@ -200,7 +200,8 @@ func processCommand(client *ssntpConn, cmd *cmdWrapper) {
 			glog.Infof("Processing: CiaoCommandAssignPublicIP %v", c)
 			err := assignPubIP(c)
 			if err != nil {
-				glog.Infof("Error Processing: CiaoCommandAssignPublicIP %v", err)
+				glog.Errorf("%v", err)
+				glog.Errorf("Error Processing: CiaoCommandAssignPublicIP %v", err)
 			}
 		}(cmd)
 
@@ -211,6 +212,7 @@ func processCommand(client *ssntpConn, cmd *cmdWrapper) {
 			glog.Infof("Processing: CiaoCommandReleasePublicIP %v", c)
 			err := releasePubIP(c)
 			if err != nil {
+				glog.Errorf("%v", err)
 				glog.Errorf("Error Processing: CiaoCommandReleasePublicIP %v", err)
 			}
 		}(cmd)

--- a/networking/ciao-cnci-agent/network.go
+++ b/networking/ciao-cnci-agent/network.go
@@ -325,7 +325,7 @@ func releasePubIP(cmd *payloads.PublicIPCommand) error {
 		return fmt.Errorf("cnci.releasePubIP invalid params %v %v", err, cmd)
 	}
 
-	err = gFw.PublicIPAccess(libsnnet.FwEnable, prIP, puIP, gCnci.ComputeLink[0].Attrs().Name)
+	err = gFw.PublicIPAccess(libsnnet.FwDisable, prIP, puIP, gCnci.ComputeLink[0].Attrs().Name)
 	if err != nil {
 		return fmt.Errorf("%v", err)
 	}

--- a/networking/ciao-cnci-agent/network.go
+++ b/networking/ciao-cnci-agent/network.go
@@ -306,13 +306,13 @@ func unmarshallPubIP(cmd *payloads.PublicIPCommand) (net.IP, net.IP, error) {
 func assignPubIP(cmd *payloads.PublicIPCommand) error {
 
 	prIP, puIP, err := unmarshallPubIP(cmd)
-
 	if err != nil {
-		glog.Errorf("cnci.assignPubIP invalid params %v %v", err, cmd)
+		return fmt.Errorf("cnci.assignPubIP invalid params %v %v", err, cmd)
 	}
 
-	if enableNetwork {
-		glog.Infof("cnci.assignPubIP success %v %v %v", prIP, puIP, cmd)
+	err = gFw.PublicIPAccess(libsnnet.FwEnable, prIP, puIP, gCnci.ComputeLink[0].Attrs().Name)
+	if err != nil {
+		return fmt.Errorf("%v", err)
 	}
 
 	return nil
@@ -321,13 +321,13 @@ func assignPubIP(cmd *payloads.PublicIPCommand) error {
 func releasePubIP(cmd *payloads.PublicIPCommand) error {
 
 	prIP, puIP, err := unmarshallPubIP(cmd)
-
 	if err != nil {
-		glog.Errorf("cnci.releasePubIP invalid params %v %v", err, cmd)
+		return fmt.Errorf("cnci.releasePubIP invalid params %v %v", err, cmd)
 	}
 
-	if enableNetwork {
-		glog.Infof("cnci.releasePubIP success %v %v %v", prIP, puIP, cmd)
+	err = gFw.PublicIPAccess(libsnnet.FwEnable, prIP, puIP, gCnci.ComputeLink[0].Attrs().Name)
+	if err != nil {
+		return fmt.Errorf("%v", err)
 	}
 
 	return nil

--- a/networking/libsnnet/firewall.go
+++ b/networking/libsnnet/firewall.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 
 	"github.com/coreos/go-iptables/iptables"
+	"github.com/vishvananda/netlink"
 )
 
 /* https://wiki.archlinux.org/index.php/iptables
@@ -307,8 +308,6 @@ func (f *Firewall) ExtPortAccess(action FwAction, protocol string, extDevice str
 	return nil
 }
 
-/* Not implemented
-
 func ipAssign(action FwAction, ip net.IP, iface string) error {
 
 	link, err := netlink.LinkByName(iface)
@@ -359,95 +358,109 @@ func ipAssign(action FwAction, ip net.IP, iface string) error {
 	}
 
 	return nil
-
 }
 
-*/
-
-/* Not implemented
-
 //PublicIPAccess Enables/Disables public access to an internal IP
-//TODO: Consider NATing only when exiting
-//TODO: Create our own tables vs using default one
 func (f *Firewall) PublicIPAccess(action FwAction,
 	internalIP net.IP, publicIP net.IP, extInterface string) error {
 
+	intIP := internalIP.String()
+	pubIP := publicIP.String()
+
 	switch action {
 	case FwEnable:
-
+		// assign the pubIP to the cnci agent
 		err := ipAssign(FwEnable, publicIP, extInterface)
 		if err != nil {
 			return fmt.Errorf("Public IP Assignment failure %v", err)
 		}
-
-		//iptables -t nat -A PREROUTING -d $publicIP/32 -j DNAT --to-destination $internalIP
-		err = f.AppendUnique("nat", "PREROUTING",
-			"-d", publicIP.String()+"/32", "-j", "DNAT", "--to-destination", internalIP.String())
-
-		if err != nil {
-			ok, err2 := f.Exists("nat", "PREROUTING",
-				"-d", publicIP.String()+"/32", "-j", "DNAT", "--to-destination", internalIP.String())
-
-			if !ok {
-				err = fmt.Errorf("Unable to perform public IP PREROUTING %v %s %s [%v],[%v]",
-					action, internalIP, publicIP, err, err2)
-			}
-		}
-
-		//iptables -t nat -A POSTROUTING -s $internalIP/32 -j SNAT -–to-source $publicIP
-		err = f.AppendUnique("nat", "POSTROUTING",
-			"-s", internalIP.String()+"/32", "-j", "SNAT", "--to-source", publicIP.String())
-
-		if err != nil {
-			ok, err2 := f.Exists("nat", "POSTROUTING",
-				"-s", internalIP.String()+"/32", "-j", "SNAT", "--to-source", publicIP.String())
-
-			if !ok {
-				err = fmt.Errorf("Unable to perform public IP POSTROUTNG %v %s %s [%v],[%v]",
-					action, internalIP, publicIP, err, err2)
-			}
-		}
-
-		return err
-
+		return enablePublicIP(intIP, pubIP)
 	case FwDisable:
+		// remove the pubIP from the cnci agent
 		err := ipAssign(FwDisable, publicIP, extInterface)
 		if err != nil {
 			return fmt.Errorf("Public IP Assignment failure %v", err)
 		}
 
-		//iptables -t nat -D PREROUTING -d $publicIP/32 -j DNAT –to-destination $internalIP
-		err = f.Delete("nat", "PREROUTING",
-			"-d", publicIP.String()+"/32", "-j", "DNAT", "--to-destination", internalIP.String())
-		if err != nil {
-			ok, err1 := f.Exists("nat", "PREROUTING",
-				"-d", publicIP.String()+"/32", "-j", "DNAT", "--to-destination", internalIP.String())
-			if ok {
-				return fmt.Errorf("Unable to disable public IP PREROUTING %s %s %v %v",
-					publicIP, internalIP, err, err1)
-
-			}
-		}
-
-		//iptables -t nat -D POSTROUTING -s $internalIP/32 -j SNAT –to-source $publicIP
-		err = f.Delete("nat", "POSTROUTING",
-			"-s", internalIP.String()+"/32", "-j", "SNAT", "--to-source", publicIP.String())
-
-		if err != nil {
-			ok, err1 := f.Exists("nat", "POSTROUTING",
-				"-s", internalIP.String()+"/32", "-j", "SNAT", "--to-source", publicIP.String())
-			if ok {
-				return fmt.Errorf("Unable to disable public IP POSTROUTING %s %s %v %v",
-					publicIP, internalIP, err, err1)
-			}
-		}
-		return nil
+		return disablePublicIP(intIP, pubIP)
 	default:
 		return fmt.Errorf("Invalid parameter %v", action)
 	}
 }
 
-*/
+func enablePublicIP(intIP, pubIP string) error {
+	ipt, err := iptables.New()
+	if err != nil {
+		return fmt.Errorf("initFirewall: Unable to setup iptables %v", err)
+	}
+
+	// insert DNAT rule of PREROUTING
+	// iptables -t nat -I ciao-floating-ip-pre -d <pubIP> -j DNAT --to-destination <intIP>
+	ok, err := ipt.Exists("nat", "ciao-floating-ip-pre", "-d", pubIP+"/32", "-j", "DNAT", "--to-destination", intIP)
+	if err != nil {
+		return fmt.Errorf("Error: InitFirewall could not verify existence of PREROUTING rule %s to %s", pubIP, intIP)
+	}
+
+	if !ok {
+		err := ipt.Insert("nat", "ciao-floating-ip-pre", 1, "-d", pubIP+"/32", "-j", "DNAT", "--to-destination", intIP)
+		if err != nil {
+			return fmt.Errorf("Could not insert firewall PREROUTING rule %s to %s into chain ciao-floating-ip-pre", pubIP, intIP)
+		}
+	}
+
+	// insert SNAT rule of POSTROUTING
+	// iptables -t nat -I ciao-floating-ip-post -s <intIP> -j SNAT --to-source <pubIP>
+	ok, err = ipt.Exists("nat", "ciao-floating-ip-post", "-s", intIP+"/32", "-j", "SNAT", "--to-source", pubIP)
+	if err != nil {
+		return fmt.Errorf("Error: InitFirewall could not verify existence of POSTROUTING rule %s to %s", intIP, pubIP)
+	}
+
+	if !ok {
+		err := ipt.Insert("nat", "ciao-floating-ip-post", 1, "-s", intIP+"/32", "-j", "SNAT", "--to-source", pubIP)
+		if err != nil {
+			return fmt.Errorf("Could not insert firewall POSTROUTING rule %s to %s into chain ciao-floating-ip-post", intIP, pubIP)
+		}
+	}
+
+	return nil
+}
+
+func disablePublicIP(intIP, pubIP string) error {
+	ipt, err := iptables.New()
+	if err != nil {
+		return fmt.Errorf("initFirewall: Unable to setup iptables %v", err)
+	}
+
+	// delete DNAT PREROUTING rule
+	// iptables -t nat -D ciao-floating-ip-pre -d <pubIP> -j DNAT --to-destination <intIP>
+	ok, err := ipt.Exists("nat", "ciao-floating-ip-pre", "-d", pubIP+"/32", "-j", "DNAT", "--to-destination", intIP)
+	if err != nil {
+		return fmt.Errorf("Error: InitFirewall could not verify existence of PREROUTING rule %s to %s", pubIP, intIP)
+	}
+
+	if !ok {
+		err := ipt.Delete("nat", "ciao-floating-ip-pre", "-d", pubIP+"/32", "-j", "DNAT", "--to-destination", intIP)
+		if err != nil {
+			return fmt.Errorf("Could not delete firewall PREROUTING rule %s to %s into chain ciao-floating-ip-pre", pubIP, intIP)
+		}
+	}
+
+	// delete SNAT POSTROUTING rule
+	// iptables -t nat -D ciao-floating-ip-post -s <intIP> -j SNAT --to-source <pubIP>
+	ok, err = ipt.Exists("nat", "ciao-floating-ip-post", "-s", intIP+"/32", "-j", "SNAT", "--to-source", pubIP)
+	if err != nil {
+		return fmt.Errorf("Error: InitFirewall could not verify existence of POSTROUTING rule %s to %s", intIP, pubIP)
+	}
+
+	if ok {
+		err := ipt.Delete("nat", "ciao-floating-ip-post", "-s", intIP+"/32", "-j", "SNAT", "--to-source", pubIP)
+		if err != nil {
+			return fmt.Errorf("Could not delete firewall POSTROUTING rule %s to %s into chain ciao-floating-ip-post", intIP, pubIP)
+		}
+	}
+
+	return nil
+}
 
 //DumpIPTables provides a utility routine that returns
 //the current state of the iptables

--- a/networking/libsnnet/firewall_test.go
+++ b/networking/libsnnet/firewall_test.go
@@ -104,12 +104,12 @@ func TestFw_Nat(t *testing.T) {
 	assert.Nil(err)
 }
 
-/*
-//Not fully implemented
+//Test assigment and removeal of floating IP
 //
-//Not fully implemented
+//Test if given a private IP and Public IP can be
+//assinged and removed as floating IP
 //
-//Expected to pass
+//Test is expected to pass
 func TestFw_PublicIP(t *testing.T) {
 	fwinit()
 	fw, err := InitFirewall(fwIf)
@@ -135,7 +135,6 @@ func TestFw_PublicIP(t *testing.T) {
 		t.Errorf("Error: Unable to shutdown firewall %v", err)
 	}
 }
-*/
 
 //Exercises all valid CNCI Firewall APIs
 //

--- a/openstack/compute/api_test.go
+++ b/openstack/compute/api_test.go
@@ -20,6 +20,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/01org/ciao/payloads"
 )
 
 type test struct {
@@ -182,6 +184,10 @@ func (cs testComputeService) StartServer(tenant string, server string) error {
 }
 
 func (cs testComputeService) StopServer(tenant string, server string) error {
+	return nil
+}
+
+func (cs testComputeService) AssignFloatingIP(floatingIP payloads.FloatingIP) error {
 	return nil
 }
 

--- a/openstack/compute/api_test.go
+++ b/openstack/compute/api_test.go
@@ -88,6 +88,14 @@ var tests = []test{
 		"null",
 	},
 	{
+		"POST",
+		"/v2.1/{tenant}/servers/{server}/action",
+		serverAction,
+		`{"addFloatingIp":{"address":"172.16.0.7", "fixed_address": "172.16.0.8"}}`,
+		http.StatusAccepted,
+		"null",
+	},
+	{
 		"GET",
 		"/v2.1/{tenant}/flavors/",
 		listFlavors,

--- a/payloads/assignpublicIP.go
+++ b/payloads/assignpublicIP.go
@@ -91,3 +91,17 @@ func (r PublicIPFailureReason) String() string {
 	}
 	return ""
 }
+
+// FloatingIPDetails is the definition of the data required to assign a
+// floating ip to a given instance
+type FloatingIPDetails struct {
+	Address      string `json:"address"`
+	InternalIP   string `json:"fixed_address"`
+	TenantUUID   string
+	InstanceUUID string
+}
+
+// FloatingIP represents a FloatingIPDetails
+type FloatingIP struct {
+	AssignFloatingIP FloatingIPDetails `json:"addFloatingIp"`
+}


### PR DESCRIPTION
This PR will adds support of Floating ips to the CIAO CNCI agent:

CNCI agent will be ready to support operations to assign and release public IP as it is indicated to them.

Overall design:
Two user define chains into nat table of iptables

- ciao-floating-ip-pre added to PREROUTING chanin
- ciao-floating-ip-post added to POSTROUTING chain

We need to create two different chains, one for incoming routing and another for outgoing, so whenever any hook trigger the corresponding chains (POST/PRE routing) they will trigger ones we created and follow the traversal order, looking into rules that will match the traffic. The user define chains will have priority since we are adding them as first rule (target) for all network protools.

