### PR TITLE
ciao-controller: Honor compute API port override

### DIFF
--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -33,6 +33,7 @@ import (
 	datastore "github.com/01org/ciao/ciao-controller/internal/datastore"
 	image "github.com/01org/ciao/ciao-image/client"
 	storage "github.com/01org/ciao/ciao-storage"
+	"github.com/01org/ciao/openstack/compute"
 	"github.com/01org/ciao/osprepare"
 	"github.com/01org/ciao/ssntp"
 	"github.com/01org/ciao/testutil"
@@ -55,7 +56,7 @@ var serverURL = flag.String("url", "", "Server URL")
 var identityURL = "identity:35357"
 var serviceUser = "csr"
 var servicePassword = ""
-var computeAPIPort = 8774
+var computeAPIPort = compute.APIPort
 var httpsCAcert = "/etc/pki/ciao/ciao-controller-cacert.pem"
 var httpsKey = "/etc/pki/ciao/ciao-controller-key.pem"
 var tablesInitPath = flag.String("tables_init_path", "./tables", "path to csv files")

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -304,7 +304,7 @@ func (c *controller) ShowFlavorDetails(tenant string, flavorID string) (compute.
 // then wrap them in keystone validation. It will then start the https
 // service.
 func (c *controller) startComputeService() error {
-	config := compute.APIConfig{Port: compute.APIPort, ComputeService: c}
+	config := compute.APIConfig{Port: computeAPIPort, ComputeService: c}
 
 	r := compute.Routes(config)
 	if r == nil {
@@ -344,7 +344,7 @@ func (c *controller) startComputeService() error {
 	}
 
 	// start service.
-	service := fmt.Sprintf(":%d", compute.APIPort)
+	service := fmt.Sprintf(":%d", computeAPIPort)
 
 	return http.ListenAndServeTLS(service, httpsCAcert, httpsKey, r)
 }


### PR DESCRIPTION
The code to start the compute API service was using the const
defined in the openstack package for the compute service and not
allowing the value to be overriden via the configuration command.
Set the default value of ciao-controller's computeAPI port to be
that const from the openstack package and use this value for
starting the service.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>