### PR TITLE
ciao-controller: datastore: intialize tenant devices correctly

### DIFF
--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -1128,6 +1128,11 @@ func (ds *sqliteDB) getTenantsNoCache() ([]*tenant, error) {
 			return nil, err
 		}
 
+		t.devices, err = ds.getTenantDevices(t.ID)
+		if err != nil {
+			return nil, err
+		}
+
 		tenants = append(tenants, t)
 	}
 	if err = rows.Err(); err != nil {


### PR DESCRIPTION
When getting tenants using getTenants make sure to get the
any block devices for those tenants.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>