### PR TITLE
ciao-image: Add unit testing for uploadImage function

### DIFF
--- a/openstack/image/api_test.go
+++ b/openstack/image/api_test.go
@@ -76,6 +76,14 @@ var tests = []test{
 		http.StatusNoContent,
 		`null`,
 	},
+	{
+		"PUT",
+		"/v2/images/1bea47ed-f6a9-463b-b423-14b9cca9ad27",
+		uploadImage,
+		"",
+		http.StatusNoContent,
+		`null`,
+	},
 }
 
 func myHostname() string {


### PR DESCRIPTION
Add the test case for uploading an Image. Basically, adds the new
HTTP PUT request to the list of image API tests.

This fixes #575

Signed-off-by: Munoz, Obed N <obed.n.munoz@intel.com>