### PR TITLE
Single VM: Enable Ceph and script refactor

### DIFF
--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -12,7 +12,7 @@ sudo killall ciao-scheduler
 sudo killall ciao-controller
 sudo killall ciao-launcher
 sleep 2
-sudo "$ciao_gobin"/ciao-launcher --hard-reset
+sudo "$ciao_gobin"/ciao-launcher --alsologtostderr -v 3 --hard-reset
 sudo ip link del eth10
 sudo pkill -F /tmp/dnsmasq.macvlan0.pid
 sudo mv $HOSTS_FILE_BACKUP /etc/hosts

--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-if [ -z "$HOSTS_FILE_BACKUP" ]; then
-    echo "HOSTS_FILE_BACKUP" is not set.
-    echo "Please run"
-    echo ""
-    echo ". ~/local/demo.sh"
-    exit 1
+if [ ! -z $1 ]; then
+    hosts_file_backup=$1
+else
+    . ~/local/demo.sh
+    hosts_file_backup=$HOSTS_FILE_BACKUP
 fi
+
 ciao_gobin="$GOPATH"/bin
 sudo killall ciao-scheduler
 sudo killall ciao-controller
@@ -15,6 +15,6 @@ sleep 2
 sudo "$ciao_gobin"/ciao-launcher --alsologtostderr -v 3 --hard-reset
 sudo ip link del eth10
 sudo pkill -F /tmp/dnsmasq.macvlan0.pid
-sudo mv $HOSTS_FILE_BACKUP /etc/hosts
+sudo mv $hosts_file_backup /etc/hosts
 sudo docker rm -f ceph-demo
 sudo rm /etc/ceph/*

--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -16,3 +16,5 @@ sudo "$ciao_gobin"/ciao-launcher --alsologtostderr -v 3 --hard-reset
 sudo ip link del eth10
 sudo pkill -F /tmp/dnsmasq.macvlan0.pid
 sudo mv $HOSTS_FILE_BACKUP /etc/hosts
+sudo docker rm -f ceph-demo
+sudo rm /etc/ceph/*

--- a/testutil/singlevm/configuration.yaml
+++ b/testutil/singlevm/configuration.yaml
@@ -1,6 +1,8 @@
 configure:
   scheduler:
     storage_uri: /etc/ciao/configuration.yaml
+  storage:
+    ceph_id: ciao
   controller:
     compute_ca: /etc/pki/ciao/controller_cert.pem
     compute_cert: /etc/pki/ciao/controller_key.pem

--- a/testutil/singlevm/run_launcher.sh
+++ b/testutil/singlevm/run_launcher.sh
@@ -10,8 +10,6 @@ default_subnet=$(ip -o -f inet addr show $default_if | awk '{print $4}')
 sudo "$GOPATH"/bin/ciao-launcher --cacert=./CAcert-"$ciao_host".pem --cert=./cert-CNAgent-NetworkingAgent-"$ciao_host".pem --alsologtostderr -v 3 --hard-reset
 
 #Cleanup any prior docker instances and networks
-sudo docker rm $(sudo docker ps -qa)
-sudo docker network rm $(sudo docker network ls -q -f "type=custom")
 sudo rm -f /var/lib/ciao/networking/docker_plugin.db
 
 #Run launcher

--- a/testutil/singlevm/run_launcher.sh
+++ b/testutil/singlevm/run_launcher.sh
@@ -7,7 +7,7 @@ default_if=$(ip route list | awk '/^default/ {print $5}')
 default_subnet=$(ip -o -f inet addr show $default_if | awk '{print $4}')
 
 #Cleanup artifacts
-sudo "$GOPATH"/bin/ciao-launcher --cacert=./CAcert-"$ciao_host".pem --cert=./cert-CNAgent-NetworkingAgent-"$ciao_host".pem --alsologtostderr -v 3 --hard-reset
+sudo "$GOPATH"/bin/ciao-launcher --alsologtostderr -v 3 --hard-reset
 
 #Cleanup any prior docker instances and networks
 sudo rm -f /var/lib/ciao/networking/docker_plugin.db

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -19,15 +19,13 @@ fedora_cloud_url="https://download.fedoraproject.org/pub/fedora/linux/releases/2
 download=0
 hosts_file_backup="/etc/hosts.orig.$RANDOM"
 
+# Copy the cleanup scripts
+cp "$ciao_scripts"/cleanup.sh "$ciao_bin"
+
 cleanup()
 {
-	echo "Performing cleanup"
-	"$ciao_gobin"/ciao-cli instance delete --all
-	#Also kill the CNCI (as there is no other way to delete it today)
-	sudo killall qemu-system-x86_64
-	sudo ip link del eth10
-	sudo pkill -F /tmp/dnsmasq.macvlan0.pid
-	sudo mv $hosts_file_backup /etc/hosts
+    echo "Performing cleanup"
+    HOSTS_FILE_BACKUP=$hosts_file_backup "$ciao_bin"/cleanup.sh
 }
 
 # Ctrl-C Trapper

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -293,13 +293,12 @@ echo "export CIAO_ADMIN_USERNAME=admin" >> "$ciao_env"
 echo "export CIAO_ADMIN_PASSWORD=giveciaoatry" >> "$ciao_env"
 echo "export CIAO_CA_CERT_FILE=/etc/pki/ciao/controller_cert.pem" >> "$ciao_env"
 sleep 5
-cat "$ciao_ctl_log"
 identity=$(grep CIAO_IDENTITY $ciao_ctl_log | sed 's/^.*export/export/')
 echo "$identity" >> "$ciao_env"
 
-
-echo "Your ciao development environment has been initialised."
+echo "---------------------------------------------------------------------------------------"
 echo ""
+echo "Your ciao development environment has been initialised."
 echo "To get started run:"
 echo ""
 echo ". ~/local/demo.sh"

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 ciao_host=$(hostname)
 ciao_ip=$(ip route get 8.8.8.8 | head -1 | cut -d' ' -f8)
+ciao_subnet=$(echo $ciao_ip | sed -e 's/\([0-9]\+\).\([0-9]\+\).\([0-9]\+\).\([0-9]\+\)/\1.\2\.\3.0\/24/')
 ciao_bin="$HOME/local"
 ciao_cert="$ciao_bin""/cert-Scheduler-""$ciao_host"".pem"
 export no_proxy=$no_proxy,$ciao_host
@@ -249,6 +250,11 @@ fi
 sudo cp -f $fedora_cloud_image /var/lib/ciao/images
 cd /var/lib/ciao/images
 sudo ln -sf $fedora_cloud_image 73a86d7e-93c0-480e-9c41-ab42f69b7799
+
+# Install ceph
+
+sudo docker run --name ceph-demo -d --net=host -v /etc/ceph:/etc/ceph -e MON_IP=$ciao_ip -e CEPH_PUBLIC_NETWORK=$ciao_subnet ceph/demo
+sudo ceph auth get-or-create client.ciao -o /etc/ceph/ceph.client.ciao.keyring mon 'allow *' osd 'allow *' mds 'allow'
 
 
 # Set macvlan interface

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -91,8 +91,6 @@ sudo mv /etc/hosts $hosts_file_backup
 echo "$ciao_ip $ciao_host" > hosts
 sudo mv hosts /etc/hosts
 sudo rm -rf /var/lib/ciao/instances
-echo "Deleting docker containers. This may take time"
-sudo docker rm -f $(sudo docker ps -a -q)
 
 #Create a directory where all the certificates, binaries and other
 #dependencies are placed

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -25,7 +25,7 @@ cp "$ciao_scripts"/cleanup.sh "$ciao_bin"
 cleanup()
 {
     echo "Performing cleanup"
-    HOSTS_FILE_BACKUP=$hosts_file_backup "$ciao_bin"/cleanup.sh
+    "$ciao_bin"/cleanup.sh $hosts_file_backup
 }
 
 # Ctrl-C Trapper

--- a/testutil/singlevm/verify.sh
+++ b/testutil/singlevm/verify.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+ciao_bin="$HOME/local"
+ciao_gobin="$GOPATH"/bin
+
+# Read cluster env variables
+
+. $ciao_bin/demo.sh
+
+"$ciao_gobin"/ciao-cli workload list
+
+if [ $? -ne 0 ]
+then
+	echo "FATAL ERROR: Unable to list workloads"
+	cleanup
+	exit 1
+fi
+
+"$ciao_gobin"/ciao-cli instance add --workload=e35ed972-c46c-4aad-a1e7-ef103ae079a2 --instances=2
+
+if [ $? -ne 0 ]
+then
+	echo "FATAL ERROR: Unable to launch VMs"
+	cleanup
+	exit 1
+fi
+
+"$ciao_gobin"/ciao-cli instance list
+
+if [ $? -ne 0 ]
+then
+	echo "FATAL ERROR: Unable to list instances"
+	cleanup
+	exit 1
+fi
+
+"$ciao_gobin"/ciao-cli instance add --workload=ab68111c-03a6-11e6-87de-001320fb6e31 --instances=2
+
+if [ $? -ne 0 ]
+then
+	echo "FATAL ERROR: Unable to launch containers"
+	cleanup
+	exit 1
+fi
+
+sleep 5
+
+"$ciao_gobin"/ciao-cli instance list
+if [ $? -ne 0 ]
+then
+	echo "FATAL ERROR: Unable to list instances"
+	cleanup
+	exit 1
+fi
+
+
+#Check SSH connectivity
+"$ciao_gobin"/ciao-cli instance list
+
+#The VM takes time to boot as you are running on two
+#layers of virtualization. Hence wait a bit
+retry=0
+until [ $retry -ge 6 ]
+do
+	ssh_ip=$("$ciao_gobin"/ciao-cli instance list --workload=e35ed972-c46c-4aad-a1e7-ef103ae079a2 --detail |  grep "SSH IP:" | sed 's/^.*SSH IP: //' | head -1)
+
+	if [ "$ssh_ip" == "" ] 
+	then
+		echo "Waiting for instance to boot"
+		let retry=retry+1
+		sleep 30
+		continue
+	fi
+
+	ssh_check=$(head -1 < /dev/tcp/"$ssh_ip"/33002)
+	echo "$ssh_check"
+
+	echo "Attempting to ssh to: $ssh_ip"
+
+	if [[ "$ssh_check" == *SSH-2.0-OpenSSH* ]]
+	then
+		echo "SSH connectivity verified"
+		break
+	else
+		let retry=retry+1
+		echo "Retrying ssh connection $retry"
+	fi
+	sleep 30
+done
+
+if [ $retry -ge 6 ]
+then
+	echo "Unable check ssh connectivity into VM"
+	cleanup
+fi
+
+#Check docker networking
+echo "Checking Docker Networking"
+sleep 30
+docker_id=$(sudo docker ps -q | head -1)
+sudo docker logs "$docker_id"
+
+
+#Now delete all instances
+"$ciao_gobin"/ciao-cli instance delete --all
+
+if [ $? -ne 0 ]
+then
+	echo "FATAL ERROR: Unable to delete instances"
+	exit 1
+fi
+
+"$ciao_gobin"/ciao-cli instance list
+"$ciao_gobin"/ciao-cli instance delete --all


### PR DESCRIPTION
This PR makes some changes to the Single VM scripts.  The first set of changes focus on tidying up the scripts:

1. The cleanup code is now in one place.
2. Misleading instructions from the controller logs are no longer written to the screen
3. The code to remove all docker containers has been removed as it's not needed.
4. Fixed some other bugs related to cleanup
5. The standard tests run by setup.sh have been moved to a new script, verify.sh and are now optional.  This is desirable when using Single VM for development as you don't want to run these scripts each time you run ./setup.sh.

The second set of changes enable ceph inside Single VM.

Fixes PR #536 