### PR TITLE
ciao-cli: Make volume and image service work with -ca-file

### DIFF
--- a/ciao-cli/authenticate.go
+++ b/ciao-cli/authenticate.go
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"crypto/tls"
+	"net/http"
+
+	"github.com/rackspace/gophercloud"
+	"github.com/rackspace/gophercloud/openstack"
+)
+
+func newAuthenticatedClient(opt gophercloud.AuthOptions) (*gophercloud.ProviderClient, error) {
+	provider, err := openstack.NewClient(opt.IdentityEndpoint)
+	if err != nil {
+		errorf("Could not get ProviderClient %s\n", err)
+		return nil, err
+	}
+
+	if caCertPool != nil {
+		transport := &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: caCertPool},
+		}
+		provider.HTTPClient.Transport = transport
+	}
+
+	err = openstack.Authenticate(provider, opt)
+	if err != nil {
+		errorf("Could not get AuthenticatedClient %s\n", err)
+		return nil, err
+	}
+
+	return provider, nil
+}

--- a/ciao-cli/identity.go
+++ b/ciao-cli/identity.go
@@ -17,9 +17,7 @@
 package main
 
 import (
-	"crypto/tls"
 	"fmt"
-	"net/http"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/rackspace/gophercloud"
@@ -123,22 +121,9 @@ func getScopedToken(username string, password string, projectScope string) (stri
 		AllowReauth:      true,
 	}
 
-	provider, err := openstack.NewClient(opt.IdentityEndpoint)
+	provider, err := newAuthenticatedClient(opt)
 	if err != nil {
-		errorf("Could not get ProviderClient %s\n", err)
-		return "", "", "", nil
-	}
-
-	if caCertPool != nil {
-		transport := &http.Transport{
-			TLSClientConfig: &tls.Config{RootCAs: caCertPool},
-		}
-		provider.HTTPClient.Transport = transport
-	}
-
-	err = openstack.Authenticate(provider, opt)
-	if err != nil {
-		errorf("Could not get AuthenticatedClient %s\n", err)
+		errorf("Failed to create an AuthenticatedClient")
 		return "", "", "", nil
 	}
 

--- a/ciao-cli/image.go
+++ b/ciao-cli/image.go
@@ -465,9 +465,10 @@ func imageServiceClient(username, password, tenant string) (*gophercloud.Service
 		AllowReauth:      true,
 	}
 
-	provider, err := openstack.AuthenticatedClient(opt)
+	provider, err := newAuthenticatedClient(opt)
 	if err != nil {
 		errorf("Could not get AuthenticatedClient %s\n", err)
+		return nil, err
 	}
 
 	return openstack.NewImageServiceV2(provider, gophercloud.EndpointOpts{

--- a/ciao-cli/volume.go
+++ b/ciao-cli/volume.go
@@ -380,9 +380,10 @@ func storageServiceClient(username, password, tenant string) (*gophercloud.Servi
 		AllowReauth:      true,
 	}
 
-	provider, err := openstack.AuthenticatedClient(opt)
+	provider, err := newAuthenticatedClient(opt)
 	if err != nil {
 		errorf("Could not get AuthenticatedClient %s\n", err)
+		return nil, err
 	}
 
 	return openstack.NewBlockStorageV2(provider, gophercloud.EndpointOpts{


### PR DESCRIPTION
The volume and image service were not passing the CA certificate,
specified either on the command line or via an environment
variable, down to gophercloud.  This meant that these services
could not work inside the Single VM.  As we now have three different
gophercloud services requiring the same authentication code, the
original code that implemented this feature for the identity service,
has been moved to a new function.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>