### PR TITLE
controller, payloads, configuration, testutil: Enable volume service

### DIFF
--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -33,6 +33,7 @@ import (
 	datastore "github.com/01org/ciao/ciao-controller/internal/datastore"
 	image "github.com/01org/ciao/ciao-image/client"
 	storage "github.com/01org/ciao/ciao-storage"
+	"github.com/01org/ciao/openstack/block"
 	"github.com/01org/ciao/openstack/compute"
 	"github.com/01org/ciao/osprepare"
 	"github.com/01org/ciao/ssntp"
@@ -56,6 +57,7 @@ var serverURL = flag.String("url", "", "Server URL")
 var identityURL = "identity:35357"
 var serviceUser = "csr"
 var servicePassword = ""
+var volumeAPIPort = block.APIPort
 var computeAPIPort = compute.APIPort
 var httpsCAcert = "/etc/pki/ciao/ciao-controller-cacert.pem"
 var httpsKey = "/etc/pki/ciao/ciao-controller-key.pem"
@@ -131,6 +133,7 @@ func main() {
 		return
 	}
 
+	volumeAPIPort = clusterConfig.Configure.Controller.VolumePort
 	computeAPIPort = clusterConfig.Configure.Controller.ComputePort
 	httpsCAcert = clusterConfig.Configure.Controller.HTTPSCACert
 	httpsKey = clusterConfig.Configure.Controller.HTTPSKey
@@ -147,8 +150,10 @@ func main() {
 
 	if *singleMachine {
 		hostname, _ := os.Hostname()
+		volumeURL := "https://" + hostname + ":" + strconv.Itoa(volumeAPIPort)
 		computeURL := "https://" + hostname + ":" + strconv.Itoa(computeAPIPort)
 		testIdentityConfig := testutil.IdentityConfig{
+			VolumeURL:  volumeURL,
 			ComputeURL: computeURL,
 			ProjectID:  "f452bbc7-5076-44d5-922c-3b9d2ce1503f",
 		}

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -372,7 +372,7 @@ func (c *controller) ShowVolumeDetails(tenant string, volume string) (block.Volu
 // then wrap them in keystone validation. It will then start the https
 // service.
 func (c *controller) startVolumeService() error {
-	config := block.APIConfig{Port: block.APIPort, VolService: c}
+	config := block.APIConfig{Port: volumeAPIPort, VolService: c}
 
 	r := block.Routes(config)
 	if r == nil {

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -64,6 +64,7 @@ const fullValidConf = `configure:
   storage:
     ceph_id: ciao
   controller:
+    volume_port: 8776
     compute_port: 8774
     compute_ca: /etc/pki/ciao/compute_ca.pem
     compute_cert: /etc/pki/ciao/compute_key.pem
@@ -112,6 +113,7 @@ func TestBlobCorrectPayload(t *testing.T) {
 func equalPayload(p1, p2 payloads.Configure) bool {
 	return (p1.Configure.Scheduler.ConfigStorageURI == p2.Configure.Scheduler.ConfigStorageURI &&
 
+		p1.Configure.Controller.VolumePort == p2.Configure.Controller.VolumePort &&
 		p1.Configure.Controller.ComputePort == p2.Configure.Controller.ComputePort &&
 		p1.Configure.Controller.HTTPSCACert == p2.Configure.Controller.HTTPSCACert &&
 		p1.Configure.Controller.HTTPSKey == p2.Configure.Controller.HTTPSKey &&
@@ -133,6 +135,7 @@ func equalPayload(p1, p2 payloads.Configure) bool {
 func emptyPayload(p payloads.Configure) bool {
 	return (p.Configure.Scheduler.ConfigStorageURI != "" &&
 
+		p.Configure.Controller.VolumePort != 0 &&
 		p.Configure.Controller.ComputePort != 0 &&
 		p.Configure.Controller.HTTPSCACert != "" &&
 		p.Configure.Controller.HTTPSKey != "" &&
@@ -207,7 +210,8 @@ func TestPayloadCorrectBlob(t *testing.T) {
 }
 
 func saneDefaults(conf *payloads.Configure) bool {
-	return (conf.Configure.Controller.ComputePort == 8774 &&
+	return (conf.Configure.Controller.VolumePort == 8776 &&
+		conf.Configure.Controller.ComputePort == 8774 &&
 		conf.Configure.ImageService.Type == payloads.Glance &&
 		conf.Configure.IdentityService.Type == payloads.Keystone &&
 		conf.Configure.Launcher.DiskLimit == true &&

--- a/payloads/configure.go
+++ b/payloads/configure.go
@@ -66,6 +66,7 @@ type ConfigureScheduler struct {
 // ConfigureController contains the unmarshalled configurations for the
 // controller service.
 type ConfigureController struct {
+	VolumePort       int    `yaml:"volume_port"`
 	ComputePort      int    `yaml:"compute_port"`
 	HTTPSCACert      string `yaml:"compute_ca"`
 	HTTPSKey         string `yaml:"compute_cert"`
@@ -114,6 +115,7 @@ type Configure struct {
 
 // InitDefaults initializes default vaulues for Configure structure.
 func (conf *Configure) InitDefaults() {
+	conf.Configure.Controller.VolumePort = 8776
 	conf.Configure.Controller.ComputePort = 8774
 	conf.Configure.ImageService.Type = Glance
 	conf.Configure.IdentityService.Type = Keystone

--- a/payloads/configure_test.go
+++ b/payloads/configure_test.go
@@ -54,7 +54,11 @@ func TestConfigureUnmarshal(t *testing.T) {
 		t.Errorf("Wrong launcher ceph id %v", cfg.Configure.Storage.CephID)
 	}
 
-	p, _ := strconv.Atoi(testutil.ComputePort)
+	p, _ := strconv.Atoi(testutil.VolumePort)
+	if cfg.Configure.Controller.VolumePort != p {
+		t.Errorf("Wrong controller volume port [%d]", cfg.Configure.Controller.VolumePort)
+	}
+	p, _ = strconv.Atoi(testutil.ComputePort)
 	if cfg.Configure.Controller.ComputePort != p {
 		t.Errorf("Wrong controller compute port [%d]", cfg.Configure.Controller.ComputePort)
 	}
@@ -74,7 +78,9 @@ func TestConfigureMarshal(t *testing.T) {
 	cfg.Configure.Launcher.DiskLimit = false
 	cfg.Configure.Launcher.MemoryLimit = false
 
-	p, _ := strconv.Atoi(testutil.ComputePort)
+	p, _ := strconv.Atoi(testutil.VolumePort)
+	cfg.Configure.Controller.VolumePort = p
+	p, _ = strconv.Atoi(testutil.ComputePort)
 	cfg.Configure.Controller.ComputePort = p
 	cfg.Configure.Controller.HTTPSCACert = testutil.HTTPSCACert
 	cfg.Configure.Controller.HTTPSKey = testutil.HTTPSKey

--- a/testutil/identity.go
+++ b/testutil/identity.go
@@ -27,8 +27,14 @@ import (
 // ComputeAPIPort is the compute service port the testutil identity service will use by default
 const ComputeAPIPort = "8774"
 
+// VolumeAPIPort is the volume service port the testutil identity service will use by default
+const VolumeAPIPort = "8776"
+
 // ComputeURL is the compute service URL the testutil identity service will use by default
 var ComputeURL = "https://localhost:" + ComputeAPIPort
+
+// VolumeURL is the volume service URL the testutil identity service will use by default
+var VolumeURL = "https://localhost:" + VolumeAPIPort
 
 // IdentityURL is the URL for the testutil identity service
 var IdentityURL string
@@ -37,6 +43,7 @@ var IdentityURL string
 var ComputeUser = "f452bbc7-5076-44d5-922c-3b9d2ce1503f"
 
 func authHandler(w http.ResponseWriter, r *http.Request) {
+	cinderv2URL := VolumeURL + "/v2/" + ComputeUser
 	token := `
 		{
 			"token": {
@@ -63,21 +70,21 @@ func authHandler(w http.ResponseWriter, r *http.Request) {
 						"endpoints": [
 							{
 								"region_id": "RegionOne",
-								"url": "%s/v3",
+								"url": "%[3]s/v3",
 								"region": "RegionOne",
 								"interface": "public",
 								"id": "068d1b359ee84b438266cb736d81de97"
 							},
 							{
 								"region_id": "RegionOne",
-								"url": "%s/v3",
+								"url": "%[3]s/v3",
 								"region": "RegionOne",
 								"interface": "admin",
 								"id": "8bfc846841ab441ca38471be6d164ced"
 							},
 							{
 								"region_id": "RegionOne",
-								"url": "%s/v3",
+								"url": "%[3]s/v3",
 								"region": "RegionOne",
 								"interface": "internal",
 								"id": "beb6d358c3654b4bada04d4663b640b9"
@@ -86,6 +93,34 @@ func authHandler(w http.ResponseWriter, r *http.Request) {
 						"type": "identity",
 						"id": "050726f278654128aba89757ae25950c",
 						"name": "keystone"
+					},
+					{
+						"endpoints": [
+							{
+								"region_id": "RegionOne",
+								"url": "%[4]s",
+								"region": "RegionOne",
+								"interface": "internal",
+								"id": "823c65e659d64733b86a609a96bcc48f"
+							},
+							{
+								"region_id": "RegionOne",
+								"url": "%[4]s",
+								"region": "RegionOne",
+								"id": "65796adae7b24663a2b9114fa34314c7",
+								"interface": "admin"
+							},
+							{
+								"region_id": "RegionOne",
+								"url": "%[4]s",
+								"region": "RegionOne",
+								"id": "0eddcb06eac24b9bae7d9db516a40fdb",
+								"interface": "public"
+							}
+						],
+						"id": "fbd0a99c-01c0-4fc2-96b9-c76e01def567",
+						"name": "cinderv2",
+						"type": "volumev2"
 					}
 				],
 			       "extras": {},
@@ -100,14 +135,13 @@ func authHandler(w http.ResponseWriter, r *http.Request) {
 			        "audit_ids": [
 				        "3T2dc1CGQxyJsHdDu1xkcw"
 			        ],
-			        "issued_at": "%s"
+			        "issued_at": "%[5]s"
 			}
 		}`
 
 	t := []byte(fmt.Sprintf(token,
 		time.Now().Add(1*time.Hour).Format(gophercloud.RFC3339Milli),
-		ComputeUser, IdentityURL, IdentityURL,
-		IdentityURL, time.Now().Format(gophercloud.RFC3339Milli)))
+		ComputeUser, IdentityURL, cinderv2URL, time.Now().Format(gophercloud.RFC3339Milli)))
 	w.Header().Set("X-Subject-Token", "imavalidtoken")
 	w.WriteHeader(http.StatusCreated)
 	w.Write(t)
@@ -150,21 +184,21 @@ func validateHandler(w http.ResponseWriter, r *http.Request) {
 					"endpoints": [
 						{
 							"region_id": "RegionOne",
-							"url": "%s/v3",
+							"url": "%[3]s/v3",
 							"region": "RegionOne",
 							"interface": "public",
 							"id": "068d1b359ee84b438266cb736d81de97"
 						},
 						{
 							"region_id": "RegionOne",
-							"url": "%s/v3",
+							"url": "%[3]s/v3",
 							"region": "RegionOne",
 							"interface": "admin",
 							"id": "8bfc846841ab441ca38471be6d164ced"
 						},
 						{
 							"region_id": "RegionOne",
-							"url": "%s/v3",
+							"url": "%[3]s/v3",
 							"region": "RegionOne",
 							"interface": "internal",
 							"id": "beb6d358c3654b4bada04d4663b640b9"
@@ -178,21 +212,21 @@ func validateHandler(w http.ResponseWriter, r *http.Request) {
 			                "endpoints": [
 					         {
 							"region_id": "RegionOne",
-							"url": "%s",
+							"url": "%[4]s",
 							"region": "RegionOne",
 							"interface": "admin",
 							"id": "2511589f262a407bb0071a814a480af4"
 						},
 						{
 							"region_id": "RegionOne",
-							"url": "%s",
+							"url": "%[4]s",
 							"region": "RegionOne",
 							"interface": "internal",
 							"id": "9cf9209ae4fc4673a7295611001cf0ae"
 						},
 						{
 							"region_id": "RegionOne",
-							"url": "%s",
+							"url": "%[4]s",
 							"region": "RegionOne",
 							"interface": "public",
 							"id": "d200b2509e1343e3887dcc465b4fa534"
@@ -206,15 +240,14 @@ func validateHandler(w http.ResponseWriter, r *http.Request) {
 			"audit_ids": [
 			        "mAjXQhiYRyKwkB4qygdLVg"
 			],
-			"issued_at": "%s"
+			"issued_at": "%[5]s"
 		}
 	}`
 
 	t := []byte(fmt.Sprintf(token,
 		time.Now().Add(1*time.Hour).Format(gophercloud.RFC3339Milli),
-		ComputeUser, IdentityURL, IdentityURL,
-		IdentityURL, tenantURL, tenantURL,
-		tenantURL, time.Now().Format(gophercloud.RFC3339Milli)))
+		ComputeUser, IdentityURL, tenantURL,
+		time.Now().Format(gophercloud.RFC3339Milli)))
 	w.WriteHeader(http.StatusOK)
 	w.Write(t)
 }
@@ -259,10 +292,11 @@ func IdentityHandlers() *mux.Router {
 	return r
 }
 
-// IdentityConfig contains the URL of the ciao compute service, and the TenantID of
-// the tenant you want tokens to be sent for.  The test Identity service only supports
-// authentication of a single tenant, and gives the token an admin role.
+// IdentityConfig contains the URL of the ciao compute and volume services, and the
+// TenantID of the tenant you want tokens to be sent for.  The test Identity service
+// only supports authentication of a single tenant, and gives the token an admin role.
 type IdentityConfig struct {
+	VolumeURL  string
 	ComputeURL string
 	ProjectID  string
 }
@@ -275,6 +309,9 @@ func StartIdentityServer(config IdentityConfig) *httptest.Server {
 		return nil
 	}
 
+	if config.VolumeURL != "" {
+		VolumeURL = config.VolumeURL
+	}
 	if config.ComputeURL != "" {
 		ComputeURL = config.ComputeURL
 	}

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -78,6 +78,9 @@ const IdentityUser = "controller"
 // IdentityPassword is a test password for the test identity server
 const IdentityPassword = "ciao"
 
+// VolumePort is a test port for the compute service
+const VolumePort = "446"
+
 // ComputePort is a test port for the compute service
 const ComputePort = "443"
 
@@ -341,6 +344,7 @@ const ConfigureYaml = `configure:
   storage:
     ceph_id: ` + ManagementID + `
   controller:
+    volume_port: ` + VolumePort + `
     compute_port: ` + ComputePort + `
     compute_ca: ` + HTTPSCACert + `
     compute_cert: ` + HTTPSKey + `


### PR DESCRIPTION
This commit does three things:

1. It adds the port of the volume service API to the ciao-configuration file.
2. It modifies controller so that it passes the cluster configured port number
   to the identity service.
3. It updates the identity service so that it advertises the volume service.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>