### PR TITLE
Single VM: Fix a ceph related disk space leak

### DIFF
--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -16,5 +16,5 @@ sudo "$ciao_gobin"/ciao-launcher --alsologtostderr -v 3 --hard-reset
 sudo ip link del eth10
 sudo pkill -F /tmp/dnsmasq.macvlan0.pid
 sudo mv $hosts_file_backup /etc/hosts
-sudo docker rm -f ceph-demo
+sudo docker rm -v -f ceph-demo
 sudo rm /etc/ceph/*


### PR DESCRIPTION
The ceph-demo docker container creates a new volume each time the container
is started.  This volume needs to be explicitly deleted.  It does not get
deleted when the container is deleted.  Overtime, this can lead to a
substantial waste of disk space.  This commit tells docker to delete the
volume created by the ceph-demo container when it itself is deleted.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>