### PR TITLE
Single VM: Bug fix. Ensure local cache directory exists

### DIFF
--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -19,6 +19,9 @@ fedora_cloud_url="https://download.fedoraproject.org/pub/fedora/linux/releases/2
 download=0
 hosts_file_backup="/etc/hosts.orig.$RANDOM"
 
+#Ensure that the local cache exists
+mkdir -p "$ciao_bin"
+
 # Copy the cleanup scripts
 cp "$ciao_scripts"/cleanup.sh "$ciao_bin"
 


### PR DESCRIPTION
Ensure that the $HOME/local directory used to cache the
images and scripts is always created if it does not already
exist

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>