### PR TITLE
single-vm: move creation of ciao_bin directory

### DIFF
--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -19,8 +19,15 @@ fedora_cloud_url="https://download.fedoraproject.org/pub/fedora/linux/releases/2
 download=0
 hosts_file_backup="/etc/hosts.orig.$RANDOM"
 
-#Ensure that the local cache exists
+#Create a directory where all the certificates, binaries and other
+#dependencies are placed
 mkdir -p "$ciao_bin"
+
+if [ ! -d  "$ciao_bin" ]
+then
+	echo "FATAL ERROR: Unable to create $ciao_bin"
+	exit 1
+fi
 
 # Copy the cleanup scripts
 cp "$ciao_scripts"/cleanup.sh "$ciao_bin"
@@ -93,16 +100,6 @@ sudo mv /etc/hosts $hosts_file_backup
 echo "$ciao_ip $ciao_host" > hosts
 sudo mv hosts /etc/hosts
 sudo rm -rf /var/lib/ciao/instances
-
-#Create a directory where all the certificates, binaries and other
-#dependencies are placed
-mkdir "$ciao_bin"
-
-if [ ! -d  "$ciao_bin" ]
-then
-	echo "FATAL ERROR: Unable to create $ciao_bin"
-	exit 1
-fi
 
 cd "$ciao_bin"
 


### PR DESCRIPTION
Don't duplicate the mkdir of the ciao_bin directory, and instead
move the call to make the directory to the top of the script.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>