### PR TITLE
qemu: Support creating multiple QMP sockets

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -695,8 +695,8 @@ type Config struct {
 	// Machine
 	Machine Machine
 
-	// QMPSocket is the QMP socket description.
-	QMPSocket QMPSocket
+	// QMPSockets is a slice of QMP socket description.
+	QMPSockets []QMPSocket
 
 	// Devices is a list of devices for qemu to create and drive.
 	Devices []Device
@@ -777,24 +777,24 @@ func (config *Config) appendCPUModel() {
 	}
 }
 
-func (config *Config) appendQMPSocket() {
-	if config.QMPSocket.Valid() == false {
-		return
-	}
-
-	var qmpParams []string
-
-	qmpParams = append(qmpParams, fmt.Sprintf("%s:", config.QMPSocket.Type))
-	qmpParams = append(qmpParams, fmt.Sprintf("%s", config.QMPSocket.Name))
-	if config.QMPSocket.Server == true {
-		qmpParams = append(qmpParams, ",server")
-		if config.QMPSocket.NoWait == true {
-			qmpParams = append(qmpParams, ",nowait")
+func (config *Config) appendQMPSockets() {
+	for _, q := range config.QMPSockets {
+		if q.Valid() == false {
+			continue
 		}
-	}
 
-	config.qemuParams = append(config.qemuParams, "-qmp")
-	config.qemuParams = append(config.qemuParams, strings.Join(qmpParams, ""))
+		qmpParams := append([]string{}, fmt.Sprintf("%s:", q.Type))
+		qmpParams = append(qmpParams, fmt.Sprintf("%s", q.Name))
+		if q.Server == true {
+			qmpParams = append(qmpParams, ",server")
+			if q.NoWait == true {
+				qmpParams = append(qmpParams, ",nowait")
+			}
+		}
+
+		config.qemuParams = append(config.qemuParams, "-qmp")
+		config.qemuParams = append(config.qemuParams, strings.Join(qmpParams, ""))
+	}
 }
 
 func (config *Config) appendDevices() {
@@ -935,7 +935,7 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	config.appendUUID()
 	config.appendMachine()
 	config.appendCPUModel()
-	config.appendQMPSocket()
+	config.appendQMPSockets()
 	config.appendMemory()
 	config.appendCPUs()
 	config.appendDevices()

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -54,8 +54,12 @@ func testAppend(structure interface{}, expected string, t *testing.T) {
 		config.appendCPUs()
 
 	case QMPSocket:
-		config.QMPSocket = s
-		config.appendQMPSocket()
+		config.QMPSockets = []QMPSocket{s}
+		config.appendQMPSockets()
+
+	case []QMPSocket:
+		config.QMPSockets = s
+		config.appendQMPSockets()
 
 	case RTC:
 		config.RTC = s
@@ -232,10 +236,10 @@ func TestAppendCPUs(t *testing.T) {
 	testAppend(smp, cpusString, t)
 }
 
-var qmpSocketServerString = "-qmp unix:cc-qmp,server,nowait"
-var qmpSocketString = "-qmp unix:cc-qmp"
+var qmpSingleSocketServerString = "-qmp unix:cc-qmp,server,nowait"
+var qmpSingleSocketString = "-qmp unix:cc-qmp"
 
-func TestAppendQMPSocketServer(t *testing.T) {
+func TestAppendSingleQMPSocketServer(t *testing.T) {
 	qmp := QMPSocket{
 		Type:   "unix",
 		Name:   "cc-qmp",
@@ -243,17 +247,38 @@ func TestAppendQMPSocketServer(t *testing.T) {
 		NoWait: true,
 	}
 
-	testAppend(qmp, qmpSocketServerString, t)
+	testAppend(qmp, qmpSingleSocketServerString, t)
 }
 
-func TestAppendQMPSocket(t *testing.T) {
+func TestAppendSingleQMPSocket(t *testing.T) {
 	qmp := QMPSocket{
 		Type:   Unix,
 		Name:   "cc-qmp",
 		Server: false,
 	}
 
-	testAppend(qmp, qmpSocketString, t)
+	testAppend(qmp, qmpSingleSocketString, t)
+}
+
+var qmpSocketServerString = "-qmp unix:cc-qmp-1,server,nowait -qmp unix:cc-qmp-2,server,nowait"
+
+func TestAppendQMPSocketServer(t *testing.T) {
+	qmp := []QMPSocket{
+		{
+			Type:   "unix",
+			Name:   "cc-qmp-1",
+			Server: true,
+			NoWait: true,
+		},
+		{
+			Type:   "unix",
+			Name:   "cc-qmp-2",
+			Server: true,
+			NoWait: true,
+		},
+	}
+
+	testAppend(qmp, qmpSocketServerString, t)
 }
 
 var qemuString = "-name cc-qemu -cpu host -uuid " + testutil.AgentUUID


### PR DESCRIPTION
The QMP socket implementation does not support multiple clients sending
and receiving QMP commands. As a consequence we need to be able to
create multiple QMP sockets from the qemu package, so that at least we
can support a fixed number of QMP clients.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>