### PR TITLE
Single VM: Enable the image service

### DIFF
--- a/ciao-cli/image.go
+++ b/ciao-cli/image.go
@@ -79,6 +79,7 @@ var imageCommand = &command{
 type imageAddCommand struct {
 	Flag            flag.FlagSet
 	name            string
+	id              string
 	containerFormat imageContainerFormat
 	diskFormat      imageDiskFormat
 	minDiskSize     int
@@ -105,6 +106,7 @@ func (cmd *imageAddCommand) parseArgs(args []string) []string {
 	cmd.containerFormat = "bare"
 	cmd.diskFormat = "qcow2"
 	cmd.Flag.StringVar(&cmd.name, "name", "", "Image Name")
+	cmd.Flag.StringVar(&cmd.id, "id", "", "Image UUID")
 	cmd.Flag.Var(&cmd.containerFormat, "container-format", "Image Container Format (ami, ari, aki, bare, ovf, ova, docker")
 	cmd.Flag.Var(&cmd.diskFormat, "disk-format", "Image Disk Format (ami, ari, aki, vhd, vmdk, raw, qcow2, vdi, iso")
 	cmd.Flag.IntVar(&cmd.minDiskSize, "min-disk-size", 0, "Minimum disk size in GB")
@@ -139,6 +141,7 @@ func (cmd *imageAddCommand) run(args []string) error {
 
 	opts := images.CreateOpts{
 		Name:             cmd.name,
+		ID:               cmd.id,
 		ContainerFormat:  cmd.containerFormat.String(),
 		DiskFormat:       cmd.diskFormat.String(),
 		MinDiskGigabytes: cmd.minDiskSize,

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -35,6 +35,7 @@ import (
 	storage "github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/openstack/block"
 	"github.com/01org/ciao/openstack/compute"
+	osimage "github.com/01org/ciao/openstack/image"
 	"github.com/01org/ciao/osprepare"
 	"github.com/01org/ciao/ssntp"
 	"github.com/01org/ciao/testutil"
@@ -59,6 +60,7 @@ var serviceUser = "csr"
 var servicePassword = ""
 var volumeAPIPort = block.APIPort
 var computeAPIPort = compute.APIPort
+var imageAPIPort = osimage.APIPort
 var httpsCAcert = "/etc/pki/ciao/ciao-controller-cacert.pem"
 var httpsKey = "/etc/pki/ciao/ciao-controller-key.pem"
 var tablesInitPath = flag.String("tables_init_path", "./tables", "path to csv files")
@@ -151,9 +153,11 @@ func main() {
 	if *singleMachine {
 		hostname, _ := os.Hostname()
 		volumeURL := "https://" + hostname + ":" + strconv.Itoa(volumeAPIPort)
+		imageURL := "https://" + hostname + ":" + strconv.Itoa(imageAPIPort)
 		computeURL := "https://" + hostname + ":" + strconv.Itoa(computeAPIPort)
 		testIdentityConfig := testutil.IdentityConfig{
 			VolumeURL:  volumeURL,
+			ImageURL:   imageURL,
 			ComputeURL: computeURL,
 			ProjectID:  "f452bbc7-5076-44d5-922c-3b9d2ce1503f",
 		}

--- a/ciao-image/service/service.go
+++ b/ciao-image/service/service.go
@@ -39,8 +39,21 @@ type ImageService struct {
 func (is ImageService) CreateImage(req image.CreateImageRequest) (image.DefaultResponse, error) {
 	// create an ImageInfo struct and store it in our image
 	// datastore.
+	id := req.ID
+	if id == "" {
+		id = uuid.Generate().String()
+	} else {
+		if _, err := uuid.Parse(id); err != nil {
+			return image.DefaultResponse{}, image.ErrBadUUID
+		}
+
+		if _, err := is.ds.GetImage(id); err == nil {
+			return image.DefaultResponse{}, image.ErrAlreadyExists
+		}
+	}
+
 	i := datastore.Image{
-		ID:         uuid.Generate().String(),
+		ID:         id,
 		State:      datastore.Created,
 		Name:       req.Name,
 		CreateTime: time.Now(),

--- a/openstack/image/api.go
+++ b/openstack/image/api.go
@@ -142,6 +142,13 @@ var (
 
 	// ErrImageSaving is returned when an image is being uploaded.
 	ErrImageSaving = errors.New("Image being uploaded")
+
+	// ErrBadUUID is returned when an invalid UUID is specified
+	ErrBadUUID = errors.New("Bad UUID")
+
+	// ErrAlreadyExists is returned when an attempt is made to add
+	// an image with a UUID that already exists.
+	ErrAlreadyExists = errors.New("Already Exists")
 )
 
 // CreateImageRequest contains information for a create image request.
@@ -269,6 +276,10 @@ func errorResponse(err error) APIResponse {
 	switch err {
 	case ErrNoImage:
 		return APIResponse{http.StatusNotFound, nil}
+	case ErrBadUUID:
+		return APIResponse{http.StatusBadRequest, nil}
+	case ErrAlreadyExists:
+		return APIResponse{http.StatusConflict, nil}
 	default:
 		return APIResponse{http.StatusInternalServerError, nil}
 	}

--- a/testutil/identity.go
+++ b/testutil/identity.go
@@ -30,11 +30,17 @@ const ComputeAPIPort = "8774"
 // VolumeAPIPort is the volume service port the testutil identity service will use by default
 const VolumeAPIPort = "8776"
 
+// ImageAPIPort is the image service port the testutil identity service will use by default
+const ImageAPIPort = "9292"
+
 // ComputeURL is the compute service URL the testutil identity service will use by default
 var ComputeURL = "https://localhost:" + ComputeAPIPort
 
 // VolumeURL is the volume service URL the testutil identity service will use by default
 var VolumeURL = "https://localhost:" + VolumeAPIPort
+
+// ImageURL is the image service URL the testutil identity service will use by default
+var ImageURL = "https://localhost:" + ImageAPIPort
 
 // IdentityURL is the URL for the testutil identity service
 var IdentityURL string
@@ -121,6 +127,34 @@ func authHandler(w http.ResponseWriter, r *http.Request) {
 						"id": "fbd0a99c-01c0-4fc2-96b9-c76e01def567",
 						"name": "cinderv2",
 						"type": "volumev2"
+					},
+					{
+						"endpoints": [
+							{
+								"region_id": "RegionOne",
+								"url": "%[5]s",
+								"region": "RegionOne",
+								"id": "a4989bcbc54a4b4ca47f91ffb8adf5f7",
+								"interface": "internal"
+							},
+							{
+								"region_id": "RegionOne",
+								"url": "%[5]s",
+								"region": "RegionOne",
+								"id": "025515ea9f664368a26eeefd56f5cab5",
+								"interface": "admin"
+							},
+							{
+								"region_id": "RegionOne",
+								"url": "%[5]s",
+								"region": "RegionOne",
+								"id": "dd9cdb516d5745d9a8d7215bc712543a",
+								"interface": "public"
+							}
+						],
+						"id": "ecbff61f-92d9-48b6-bbb5-73153e7bfe26",
+						"name": "glance",
+						"type": "image"
 					}
 				],
 			       "extras": {},
@@ -135,13 +169,14 @@ func authHandler(w http.ResponseWriter, r *http.Request) {
 			        "audit_ids": [
 				        "3T2dc1CGQxyJsHdDu1xkcw"
 			        ],
-			        "issued_at": "%[5]s"
+			        "issued_at": "%[6]s"
 			}
 		}`
 
 	t := []byte(fmt.Sprintf(token,
 		time.Now().Add(1*time.Hour).Format(gophercloud.RFC3339Milli),
-		ComputeUser, IdentityURL, cinderv2URL, time.Now().Format(gophercloud.RFC3339Milli)))
+		ComputeUser, IdentityURL, cinderv2URL, ImageURL,
+		time.Now().Format(gophercloud.RFC3339Milli)))
 	w.Header().Set("X-Subject-Token", "imavalidtoken")
 	w.WriteHeader(http.StatusCreated)
 	w.Write(t)
@@ -297,6 +332,7 @@ func IdentityHandlers() *mux.Router {
 // only supports authentication of a single tenant, and gives the token an admin role.
 type IdentityConfig struct {
 	VolumeURL  string
+	ImageURL   string
 	ComputeURL string
 	ProjectID  string
 }
@@ -311,6 +347,9 @@ func StartIdentityServer(config IdentityConfig) *httptest.Server {
 
 	if config.VolumeURL != "" {
 		VolumeURL = config.VolumeURL
+	}
+	if config.ImageURL != "" {
+		ImageURL = config.ImageURL
 	}
 	if config.ComputeURL != "" {
 		ComputeURL = config.ComputeURL

--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -10,6 +10,7 @@ fi
 ciao_gobin="$GOPATH"/bin
 sudo killall ciao-scheduler
 sudo killall ciao-controller
+sudo killall ciao-image
 sudo killall ciao-launcher
 sleep 2
 sudo "$ciao_gobin"/ciao-launcher --alsologtostderr -v 3 --hard-reset
@@ -18,3 +19,6 @@ sudo pkill -F /tmp/dnsmasq.macvlan0.pid
 sudo mv $hosts_file_backup /etc/hosts
 sudo docker rm -v -f ceph-demo
 sudo rm /etc/ceph/*
+sudo rm /etc/pki/ciao/controller_key.pem /etc/pki/ciao/ciao-image-key.pem
+sudo rm /etc/pki/ciao/controller_cert.pem /etc/pki/ciao/ciao-image-cacert.pem
+

--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -21,4 +21,7 @@ sudo docker rm -v -f ceph-demo
 sudo rm /etc/ceph/*
 sudo rm /etc/pki/ciao/controller_key.pem /etc/pki/ciao/ciao-image-key.pem
 sudo rm /etc/pki/ciao/controller_cert.pem /etc/pki/ciao/ciao-image-cacert.pem
+sudo rm /var/lib/ciao/images/4e16e743-265a-4bf2-9fd1-57ada0b28904
+sudo rm /var/lib/ciao/images/df3768da-31f5-4ba6-82f0-127a1a705169
+sudo rm /var/lib/ciao/images/73a86d7e-93c0-480e-9c41-ab42f69b7799
 

--- a/testutil/singlevm/run_image.sh
+++ b/testutil/singlevm/run_image.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ ! -z $1 ]; then
+    sudo "$GOPATH"/bin/ciao-image --identity $1 &
+else
+    sudo "$GOPATH"/bin/ciao-image &
+fi
+

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -94,6 +94,7 @@ sudo cp -f "$ciao_scripts"/configuration.yaml /etc/ciao
 sudo killall ciao-scheduler
 sudo killall ciao-controller
 sudo killall ciao-launcher
+sudo killall ciao-image
 sudo killall qemu-system-x86_64
 echo "Original /etc/hosts is temporarily move to $hosts_file_backup"
 sudo mv /etc/hosts $hosts_file_backup
@@ -146,6 +147,8 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout controller_key.pem -
 #Copy the certs
 sudo cp -f controller_key.pem /etc/pki/ciao
 sudo cp -f controller_cert.pem /etc/pki/ciao
+sudo ln -s /etc/pki/ciao/controller_key.pem /etc/pki/ciao/ciao-image-key.pem
+sudo ln -s /etc/pki/ciao/controller_cert.pem /etc/pki/ciao/ciao-image-cacert.pem
 
 
 #Copy the configuration
@@ -162,6 +165,7 @@ cp -f "$ciao_scripts"/tables/* "$ciao_bin"/tables
 cp "$ciao_scripts"/run_scheduler.sh "$ciao_bin"
 cp "$ciao_scripts"/run_controller.sh "$ciao_bin"
 cp "$ciao_scripts"/run_launcher.sh "$ciao_bin"
+cp "$ciao_scripts"/run_image.sh "$ciao_bin"
 cp "$ciao_scripts"/verify.sh "$ciao_bin"
 
 #Download the firmware
@@ -295,6 +299,11 @@ echo "export CIAO_CA_CERT_FILE=/etc/pki/ciao/controller_cert.pem" >> "$ciao_env"
 sleep 5
 identity=$(grep CIAO_IDENTITY $ciao_ctl_log | sed 's/^.*export/export/')
 echo "$identity" >> "$ciao_env"
+
+# Run the image service
+
+identity_url=$(echo $identity | sed 's/^.*=//')
+"$ciao_bin"/run_image.sh $identity_url &> /dev/null
 
 echo "---------------------------------------------------------------------------------------"
 echo ""

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -209,9 +209,6 @@ then
 fi
 
 qemu-img convert -f raw -O qcow2 "$ciao_cnci_image" "$ciao_cnci_image".qcow
-sudo cp -f "$ciao_cnci_image".qcow /var/lib/ciao/images
-cd /var/lib/ciao/images
-sudo ln -sf "$ciao_cnci_image".qcow 4e16e743-265a-4bf2-9fd1-57ada0b28904
 
 #Clear
 cd "$ciao_bin"
@@ -232,10 +229,6 @@ then
 	exit 1
 fi
 
-sudo cp -f clear-"${LATEST}"-cloud.img /var/lib/ciao/images
-cd /var/lib/ciao/images
-sudo ln -sf clear-"${LATEST}"-cloud.img df3768da-31f5-4ba6-82f0-127a1a705169
-
 #Fedora, needed for BAT tests
 cd "$ciao_bin"
 if [ $download -eq 1 ] || [ ! -f $fedora_cloud_image ]
@@ -249,10 +242,6 @@ then
 	echo "FATAL ERROR: unable to download fedora cloud Image"
 	exit 1
 fi
-
-sudo cp -f $fedora_cloud_image /var/lib/ciao/images
-cd /var/lib/ciao/images
-sudo ln -sf $fedora_cloud_image 73a86d7e-93c0-480e-9c41-ab42f69b7799
 
 # Install ceph
 
@@ -304,6 +293,25 @@ echo "$identity" >> "$ciao_env"
 
 identity_url=$(echo $identity | sed 's/^.*=//')
 "$ciao_bin"/run_image.sh $identity_url &> /dev/null
+
+sleep 1
+
+. ~/local/demo.sh
+
+echo ""
+echo "Uploading test images to image service"
+echo "---------------------------------------------------------------------------------------"
+if [ -f "$ciao_cnci_image".qcow ]; then
+    ciao-cli image add --file "$ciao_cnci_image".qcow --name "ciao CNCI image" --id 4e16e743-265a-4bf2-9fd1-57ada0b28904
+fi
+
+if [ -f clear-"${LATEST}"-cloud.img ]; then
+    ciao-cli image add --file clear-"${LATEST}"-cloud.img --name "Clear Linux ${LATEST}" --id df3768da-31f5-4ba6-82f0-127a1a705169
+fi
+
+if [ -f $fedora_cloud_image ]; then
+    ciao-cli image add --file $fedora_cloud_image --name "Fedorda Cloud Base 24-1.2" --id 73a86d7e-93c0-480e-9c41-ab42f69b7799
+fi
 
 echo "---------------------------------------------------------------------------------------"
 echo ""


### PR DESCRIPTION
This commit enables the image service in Single VM.  It also modifies Single VM to use the image service to manages the example images that it downloads.  Changes to the fake identity service, ciao-cli and the image service itself were required to enable this.