### PR TITLE
ciao-controller: datastore: do not make fake volumes for every workload

### DIFF
--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -788,14 +788,7 @@ func (ds *sqliteDB) getWorkloadDefaults(ID string) ([]payloads.RequestedResource
 }
 
 func (ds *sqliteDB) getWorkloadStorage(ID string) (*types.StorageResource, error) {
-	// fake this for now. We are going to always request a
-	// new bootable image which will persist.
-	return &types.StorageResource{
-		ID:         "",
-		Bootable:   true,
-		Persistent: true,
-		SourceType: types.ImageService,
-	}, nil
+	return nil, nil
 }
 
 func (ds *sqliteDB) addLimit(tenantID string, resourceID int, limit int) error {


### PR DESCRIPTION
The sqlite3 datastore currently makes fake storage requests for
every workload. this causes us to create a volume on every workload
start and impacts performance for workloads that did not want
a volume.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>