### PR TITLE
ciao-cert: Add -dump parameter

### DIFF
--- a/ciao-cert/README.md
+++ b/ciao-cert/README.md
@@ -12,37 +12,41 @@ and private keys for all SSNTP roles.
 ```shell
 Usage of ciao-cert:
   -alsologtostderr
-    	log to standard error as well as files
+        log to standard error as well as files
+  -directory string
+        Installation directory (default ".")
+  -dump string
+        Print details about provided certificate
   -elliptic-key
-    	Use elliptic curve algorithms
+        Use elliptic curve algorithms
   -email string
-    	Certificate email address (default "ciao-devel@lists.clearlinux.org")
+        Certificate email address (default "ciao-devel@lists.clearlinux.org")
   -host string
-    	Comma-separated hostnames to generate a certificate for
+        Comma-separated hostnames to generate a certificate for
   -ip string
-    	Comma-separated IPs to generate a certificate for
+        Comma-separated IPs to generate a certificate for
   -log_backtrace_at value
-    	when logging hits line file:N, emit a stack trace (default :0)
+        when logging hits line file:N, emit a stack trace
   -log_dir string
-    	If non-empty, write log files in this directory
+        If non-empty, write log files in this directory
   -logtostderr
-    	log to standard error instead of files
+        log to standard error instead of files
   -organization string
-    	Certificates organization
+        Certificates organization
   -role value
-    	SSNTP role [agent, scheduler, controller, netagent, server, cnciagent] (default Unknown)
+        Comma separated list of SSNTP role [agent, scheduler, controller, netagent, server, cnciagent]
   -server
-    	Whether this cert should be a server one
+        Whether this cert should be a server one
   -server-cert string
-    	Server certificate for signing a client one
+        Server certificate for signing a client one
   -stderrthreshold value
-    	logs at or above this threshold go to stderr
+        logs at or above this threshold go to stderr
   -v value
-    	log level for V logs
+        log level for V logs
   -verify
-    	Verify client certificate
+        Verify client certificate
   -vmodule value
-    	comma-separated list of pattern=N settings for file-filtered logging
+        comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 ## Example
@@ -96,3 +100,21 @@ comma separated list of roles to ciao-cert.
 For example launcher may want to expose both the CN and NN agent roles:
 
 ```$GOBIN/ciao-cert -role agent,netagent -server-cert cert-Scheduler-ciao-ctl.intel.com.pem -email=ciao-devel@lists.clearlinux.org -organization=Intel -host=localhost -verify```
+
+## Inspecting certificates
+
+It is possible to have `ciao-cert` provide some information about the generated
+certificates; this is done by using the `-dump` command line flag. Here is some
+sample output from the scheduler certificate generated above:
+
+```
+$GOBIN/ciao-cert -dump ./cert-Scheduler-ciao-ctl.intel.com.pem
+Certificate:    ./cert-Scheduler-ciao-ctl.intel.com.pem
+Organization:   Intel
+Is CA:          true
+Validity:       2016-10-12 15:19:39 +0000 UTC to 2017-10-12 15:19:39 +0000 UTC
+For role:       Scheduler-
+For host:       ciao-ctl.intel.com
+For IP:         192.168.1.118
+Private key:    RSA PRIVATE KEY
+```


### PR DESCRIPTION
This PR adds a -dump to ciao-cert for obtaining useful details from the certificate

Fixes: #255