### PR TITLE
qemu: Add support for serial port addition

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -70,6 +70,9 @@ const (
 
 	// Console is the console device driver.
 	Console = "virtconsole"
+
+	// VirtioSerialPort is the serial port device driver.
+	VirtioSerialPort = "virtserialport"
 )
 
 // ObjectType is a string representing a qemu object type.
@@ -265,6 +268,7 @@ type CharDevice struct {
 
 	ID   string
 	Path string
+	Name string
 }
 
 // Valid returns true if the CharDevice structure is valid and complete.
@@ -285,6 +289,9 @@ func (cdev CharDevice) QemuParams(config *Config) []string {
 	deviceParams = append(deviceParams, fmt.Sprintf("%s", cdev.Driver))
 	deviceParams = append(deviceParams, fmt.Sprintf(",chardev=%s", cdev.ID))
 	deviceParams = append(deviceParams, fmt.Sprintf(",id=%s", cdev.DeviceID))
+	if cdev.Name != "" {
+		deviceParams = append(deviceParams, fmt.Sprintf(",name=%s", cdev.Name))
+	}
 
 	cdevParams = append(cdevParams, string(cdev.Backend))
 	cdevParams = append(cdevParams, fmt.Sprintf(",id=%s", cdev.ID))

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -154,6 +154,21 @@ func TestAppendDeviceSerial(t *testing.T) {
 	testAppend(sdev, deviceSerialString, t)
 }
 
+var deviceSerialPortString = "-device virtserialport,chardev=char0,id=channel0,name=channel.0 -chardev socket,id=char0,path=/tmp/char.sock,server,nowait"
+
+func TestAppendDeviceSerialPort(t *testing.T) {
+	chardev := CharDevice{
+		Driver:   VirtioSerialPort,
+		Backend:  Socket,
+		ID:       "char0",
+		DeviceID: "channel0",
+		Path:     "/tmp/char.sock",
+		Name:     "channel.0",
+	}
+
+	testAppend(chardev, deviceSerialPortString, t)
+}
+
 var deviceBlockString = "-device virtio-blk,drive=hd0,scsi=off,config-wce=off -drive id=hd0,file=/var/lib/ciao.img,aio=threads,format=qcow2,if=none"
 
 func TestAppendDeviceBlock(t *testing.T) {


### PR DESCRIPTION
We add a new device driver, and also a name to the CharDev structure
this is needed for qemu to actually create the serial port on
the guest.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>