### PR TITLE
ciao-controller: Fix duplicated json identifier in NodeStats

### DIFF
--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -144,7 +144,7 @@ type NodeStats struct {
 	Load            int       `json:"load"`
 	MemTotalMB      int       `json:"mem_total_mb"`
 	MemAvailableMB  int       `json:"mem_available_mb"`
-	DiskTotalMB     int       `json:"mem_total_mb"`
+	DiskTotalMB     int       `json:"disk_total_mb"`
 	DiskAvailableMB int       `json:"disk_available_mb"`
 	CpusOnline      int       `json:"cpus_online"`
 }


### PR DESCRIPTION
This issue was identified by a new version of "go vet":
https://github.com/golang/go/commit/4940a8379096

Signed-off-by: Rob Bradford <robert.bradford@intel.com>