### PR TITLE
Provide a generic database implementation.

### DIFF
--- a/networking/libsnnet/database.go
+++ b/networking/libsnnet/database.go
@@ -44,13 +44,13 @@ type DbTable interface {
 	Add(k string, v interface{}) error
 }
 
-// A TableDBProvider represents a persistent data base provider
+// A TableDBProvider represents a persistent database provider
 // that can be used to store map, arrays or any other type of
 // tables into a database
 type TableDBProvider interface {
 	//Initializes the Database
 	DbInit(dir string, file string) error
-	//Populates the DockerPlugin cache from the database
+	//Populates the in-memory table from the database
 	DbTableRebuild(table DbTable) error
 	//Closes the database
 	DbClose() error

--- a/networking/libsnnet/docker_database.go
+++ b/networking/libsnnet/docker_database.go
@@ -28,30 +28,62 @@ import (
 	"github.com/golang/glog"
 )
 
-const (
-	dbFile = "docker_plugin.db"
-)
+//DbTable interface that needs to be supported
+//for the table to be handled by the database
+type DbTable interface {
+	// Creates the backing map
+	NewTable()
 
-type dockerBoltDB struct {
+	// Name of the table as stored in the database
+	Name() string
+
+	// Allocates and returns a single value in the table
+	NewElement() interface{}
+
+	// Add an value to the in memory table
+	Add(k string, v interface{}) error
+}
+
+// A TableDBProvider represents a persistent data base provider
+// that can be used to store map, arrays or any other type of
+// tables into a database
+type TableDBProvider interface {
+	//Initializes the Database
+	DbInit(dir string, file string) error
+	//Populates the DockerPlugin cache from the database
+	DbTableRebuild(table DbTable) error
+	//Closes the database
+	DbClose() error
+	//Creates the tables if the tables do not already exist in the database
+	DbTableInit(tables []string) error
+	//Adds the key value pair to the table
+	DbAdd(table string, key string, value interface{}) error
+	//Adds the key value pair to the table
+	DbDelete(table string, key string) error
+	//Retrives the value corresponding to the key from the table
+	DbGet(table string, key string) (interface{}, error)
+}
+
+type tableBoltDB struct {
 	Name string
 	DB   *bolt.DB
 }
 
-func newDockerBoltDb() *dockerBoltDB {
-	return &dockerBoltDB{
-		Name: "docker_bolt.DB",
+func newTableBoltDb() *tableBoltDB {
+	return &tableBoltDB{
+		Name: "tableBolt.DB",
 	}
 }
 
-type dbProvider dockerBoltDB
+type dbProvider tableBoltDB
 
-//NewDockerBoltDBProvider returns a bolt based database that conforms
-//to the DockerDBProvider interface
-func NewDockerBoltDBProvider() DockerDBProvider {
-	return (*dbProvider)(newDockerBoltDb())
+//NewTableBoltDBProvider returns a bolt based database that conforms
+//to the tableDBProvider interface
+func NewTableBoltDBProvider() TableDBProvider {
+	return (*dbProvider)(newTableBoltDb())
 }
 
-func (db *dbProvider) DbInit(dbDir string) error {
+func (db *dbProvider) DbInit(dbDir string, dbFile string) error {
 
 	if err := os.MkdirAll(dbDir, 0755); err != nil {
 		return fmt.Errorf("Unable to create db directory (%s) %v", dbDir, err)


### PR DESCRIPTION
Make the networking database implementation generic so that it can be used to store data for any component in Ciao. This database implementation can be used to persist any table map, array, slice to a database backed by boltDB+gob.

We may want to consider moving this to a generic util package for ciao.

    **Note: As the table name internally has changed, this will break
    any in place update of the CN launcher. For a proper update
    of the CN, it has to be hard reset to remove all instances
    and the database cleaned up.**

