### PR TITLE
test-cases, travis: Add support for TAP reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,10 +58,10 @@ script:
    - go list ./... | grep -v github.com/01org/ciao/vendor | xargs go list -f '{{.Dir}}' | xargs gofmt -s -l | wc -l | xargs -I % bash -c "test % -eq 0"
    - sudo mkdir -p /var/lib/ciao/instances
    - sudo chmod 0777 /var/lib/ciao/instances
-   - test-cases -v -timeout 9 -text -coverprofile /tmp/cover.out -short github.com/01org/ciao/ciao-controller/...
-   - test-cases -v -timeout 9 -text -coverprofile /tmp/cover.out -append-profile -short github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/payloads github.com/01org/ciao/configuration github.com/01org/ciao/testutil github.com/01org/ciao/ssntp/uuid github.com/01org/ciao/qemu github.com/01org/ciao/openstack/...
-   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -text -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/ssntp
-   - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -text -short -tags travis -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/networking/libsnnet
+   - test-cases -v -timeout 9 -coverprofile /tmp/cover.out -short github.com/01org/ciao/ciao-controller/...
+   - test-cases -v -timeout 9 -coverprofile /tmp/cover.out -append-profile -short github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/payloads github.com/01org/ciao/configuration github.com/01org/ciao/testutil github.com/01org/ciao/ssntp/uuid github.com/01org/ciao/qemu github.com/01org/ciao/openstack/...
+   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/ssntp
+   - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -short -tags travis -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/networking/libsnnet
    # API Documentation is automated by swagger, every PR will verify the documentation can be generated
    # verify ciao-controller api documentation can be generated with swagger
    - go get github.com/yvasiyarov/swagger

--- a/openstack/image/api.go
+++ b/openstack/image/api.go
@@ -367,8 +367,6 @@ func getImage(context *Context, w http.ResponseWriter, r *http.Request) (APIResp
 	vars := mux.Vars(r)
 	imageID := vars["image_id"]
 
-	defer r.Body.Close()
-
 	resp, err := context.GetImage(imageID)
 	if err != nil {
 		return errorResponse(err), err
@@ -380,8 +378,6 @@ func uploadImage(context *Context, w http.ResponseWriter, r *http.Request) (APIR
 	vars := mux.Vars(r)
 	imageID := vars["image_id"]
 
-	defer r.Body.Close()
-
 	_, err := context.UploadImage(imageID, r.Body)
 	if err != nil {
 		return errorResponse(err), err
@@ -392,8 +388,6 @@ func uploadImage(context *Context, w http.ResponseWriter, r *http.Request) (APIR
 func deleteImage(context *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	vars := mux.Vars(r)
 	imageID := vars["image_id"]
-
-	defer r.Body.Close()
 
 	_, err := context.DeleteImage(imageID)
 	if err != nil {


### PR DESCRIPTION
This commit adds test-cases support for the generation of TAP reports. It also takes
the oppurtunity to rationalize the options for specifying the output format.  There
is now one format option, --format, which accepts a number of different values;
html, tap, colour-text and text.  The default is colour-text.

This change requires a modification to the travis script that executes test-cases,
as the old formatting option used by travis.yml no longer exists.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>