### PR TITLE
ciao-controller: api: Set 'limit' value properly for instances

### DIFF
--- a/openstack/compute/api.go
+++ b/openstack/compute/api.go
@@ -288,12 +288,22 @@ func pagerQueryParse(r *http.Request) (int, int, string) {
 	// we only support marker and offset for now.
 	if values["marker"] != nil {
 		marker = values["marker"][0]
-	} else if values["offset"] != nil {
-		o, err := strconv.ParseInt(values["offset"][0], 10, 32)
-		if err != nil {
-			offset = 0
-		} else {
-			offset = (int)(o)
+	} else {
+		if values["offset"] != nil {
+			o, err := strconv.ParseInt(values["offset"][0], 10, 32)
+			if err != nil {
+				offset = 0
+			} else {
+				offset = (int)(o)
+			}
+		}
+		if values["limit"] != nil {
+			l, err := strconv.ParseInt(values["limit"][0], 10, 32)
+			if err != nil {
+				limit = 0
+			} else {
+				limit = (int)(l)
+			}
 		}
 	}
 

--- a/openstack/compute/api_test.go
+++ b/openstack/compute/api_test.go
@@ -47,6 +47,14 @@ var tests = []test{
 	},
 	{
 		"GET",
+		"/v2.1/{tenant}/servers/detail?limit=1&offset=1",
+		ListServersDetails,
+		"",
+		http.StatusOK,
+		`{"total_servers":1,"servers":[]}`,
+	},
+	{
+		"GET",
 		"/v2.1/{tenant}/servers/detail",
 		ListServersDetails,
 		"",
@@ -272,5 +280,20 @@ func TestRoutes(t *testing.T) {
 	r := Routes(config)
 	if r == nil {
 		t.Fatalf("No routes returned")
+	}
+}
+
+func TestPager(t *testing.T) {
+	req, err := http.NewRequest("GET", "/v2.1/{tenant}/servers/detail?limit=2&offset=2", bytes.NewBuffer([]byte("")))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	limit, offset, _ := pagerQueryParse(req)
+	if limit != 2 {
+		t.Fatalf("Invalid limit registered")
+	}
+	if offset != 2 {
+		t.Fatalf("Invalid offset registered")
 	}
 }


### PR DESCRIPTION
Fixes #698 Set limit value when a pager is being used on servers/detail endpoint.
Returns correct number of instances in order for the pager feature to work on
ciao-webui.

Signed-off-by: Jorge Villalobos <jorge.villalobos.gutierrez@intel.com>