### PR TITLE
ciao-cli: Make ciao-cli scriptable

### DIFF
--- a/ciao-cli/template.go
+++ b/ciao-cli/template.go
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"os"
+	"text/template"
+)
+
+func outputToTemplate(name, tmplSrc string, obj interface{}) error {
+	t, err := template.New(name).Parse(tmplSrc)
+	if err != nil {
+		fatalf(err.Error())
+	}
+	if err = t.Execute(os.Stdout, obj); err != nil {
+		fatalf(err.Error())
+	}
+	return nil
+}
+
+func createTemplate(name, tmplSrc string) *template.Template {
+	var t *template.Template
+	if tmplSrc == "" {
+		return nil
+	}
+
+	t, err := template.New("node-list").Parse(tmplSrc)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	return t
+}


### PR DESCRIPTION
This commit adds a -f parameter that accepts a go template to the following
commands:

- event list
- image list
- tenant list
- instance list
- instance show
- node list
- node show
- tenant list
- tenant show
- volume list
- volume show
- workload list

As an example, to print the name of the workload with an ID of
ca957444-fa46-11e5-94f9-38607786d9ec on might type

ciao-cli workload list -f '
{{- range .}}
  {{- if eq .ID "ca957444-fa46-11e5-94f9-38607786d9ec" }}
    {{- .Name | printf -}}
  {{end -}}
{{end }}
'

The output would be

Docker Debian latest

Fixes: #690

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>