### PR TITLE
ssntp: Remove the trailing "-" from ouput from the Stringer

### DIFF
--- a/ciao-cert/main.go
+++ b/ciao-cert/main.go
@@ -135,7 +135,7 @@ func createCertificates(role ssntp.Role) {
 
 	firstHost := getFirstHost()
 	CAcertName := fmt.Sprintf("%s/CAcert-%s.pem", *installDir, firstHost)
-	certName := fmt.Sprintf("%s/cert-%s%s.pem", *installDir, role.String(), firstHost)
+	certName := fmt.Sprintf("%s/cert-%s-%s.pem", *installDir, role.String(), firstHost)
 	if *isServer == true {
 		CAcertOut, err := os.Create(CAcertName)
 		if err != nil {

--- a/ssntp/ssntp.go
+++ b/ssntp/ssntp.go
@@ -705,33 +705,33 @@ func (role *Role) IsCNCIAgent() bool {
 }
 
 func (role *Role) String() string {
-	roleString := ""
+	roleStrings := []string{}
 
 	if role.IsServer() {
-		roleString += "Server-"
+		roleStrings = append(roleStrings, "Server")
 	}
 
 	if role.IsController() {
-		roleString += "Controller-"
+		roleStrings = append(roleStrings, "Controller")
 	}
 
 	if role.IsAgent() {
-		roleString += "CNAgent-"
+		roleStrings = append(roleStrings, "CNAgent")
 	}
 
 	if role.IsScheduler() {
-		roleString += "Scheduler-"
+		roleStrings = append(roleStrings, "Scheduler")
 	}
 
 	if role.IsNetAgent() {
-		roleString += "NetworkingAgent-"
+		roleStrings = append(roleStrings, "NetworkingAgent")
 	}
 
 	if role.IsCNCIAgent() {
-		roleString += "CNCIAgent-"
+		roleStrings = append(roleStrings, "CNCIAgent")
 	}
 
-	return roleString
+	return strings.Join(roleStrings, "-")
 }
 
 // DefaultCACert is the default name for the SSNTP CA certificate


### PR DESCRIPTION
This should improve the readability of logging and error reporting. This
change also updates all the places which expected the trailing "-" and
adds it explicitly.

Fixes: #671

Signed-off-by: Rob Bradford <robert.bradford@intel.com>