### PR TITLE
ciao-cli: Fix instance list template ordering

### DIFF
--- a/ciao-cli/instance.go
+++ b/ciao-cli/instance.go
@@ -395,9 +395,15 @@ func (cmd *instanceListCommand) run(args []string) error {
 		fatalf(err.Error())
 	}
 
+	sortedServers := []compute.ServerDetails{}
+	for _, v := range servers.Servers {
+		sortedServers = append(sortedServers, v)
+	}
+	sort.Sort(byCreated(sortedServers))
+
 	if cmd.template != "" {
 		return outputToTemplate("instance-list", cmd.template,
-			&servers.Servers)
+			&sortedServers)
 	}
 
 	w := new(tabwriter.Writer)
@@ -405,12 +411,6 @@ func (cmd *instanceListCommand) run(args []string) error {
 		w.Init(os.Stdout, 0, 1, 1, ' ', 0)
 		fmt.Fprintln(w, "#\tUUID\tStatus\tPrivate IP\tSSH IP\tSSH PORT")
 	}
-
-	sortedServers := []compute.ServerDetails{}
-	for _, v := range servers.Servers {
-		sortedServers = append(sortedServers, v)
-	}
-	sort.Sort(byCreated(sortedServers))
 
 	for i, server := range sortedServers {
 		if !cmd.detail {


### PR DESCRIPTION
The commits that sorted the result of the instance list command and
added template support for this command conflicted.  The automerge
done by github was insufficient and resulted in an unsorted slice
being passed to the user supplied template.  This commit simply
re-arranges the code a little bit to ensure that the instances processed
by the user template are sorted.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>