### PR TITLE
send volume attachments with server info

### DIFF
--- a/ciao-cli/instance.go
+++ b/ciao-cli/instance.go
@@ -54,6 +54,7 @@ const (
 	}
 	SSHIP   string                                // Instance SSH IP address
 	SSHPort int                                   // Instance SSH Port
+	OsExtendedVolumesVolumesAttached []string     // list of attached volumes
 }`
 )
 
@@ -505,6 +506,10 @@ func dumpInstance(server *compute.ServerDetails) {
 	if server.SSHIP != "" {
 		fmt.Printf("\tSSH IP: %s\n", server.SSHIP)
 		fmt.Printf("\tSSH Port: %d\n", server.SSHPort)
+	}
+
+	for _, vol := range server.OsExtendedVolumesVolumesAttached {
+		fmt.Printf("\tVolume: %s\n", vol)
 	}
 }
 

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -33,6 +33,17 @@ func instanceToServer(ctl *controller, instance *types.Instance) (compute.Server
 		return compute.ServerDetails{}, err
 	}
 
+	var volumes []string
+
+	instance.Attachments, err = ctl.ds.GetStorageAttachments(instance.ID)
+	if err != nil {
+		return compute.ServerDetails{}, err
+	}
+
+	for _, vol := range instance.Attachments {
+		volumes = append(volumes, vol.BlockID)
+	}
+
 	imageID := workload.ImageID
 
 	server := compute.ServerDetails{
@@ -54,6 +65,7 @@ func instanceToServer(ctl *controller, instance *types.Instance) (compute.Server
 				},
 			},
 		},
+		OsExtendedVolumesVolumesAttached: volumes,
 		SSHIP:   instance.SSHIP,
 		SSHPort: instance.SSHPort,
 		Created: instance.CreateTime,


### PR DESCRIPTION
Allow ciao-cli to report the attached volumes when displaying instance details.

Fixes #654 