### PR TITLE
ciao-controller: datastore: update attachments when deleting instance

### DIFF
--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -1042,6 +1042,8 @@ func (ds *Datastore) deleteInstance(instanceID string) error {
 		glog.V(2).Info("deleteInstance: ", err)
 	}
 
+	ds.updateStorageAttachments(instanceID, nil)
+
 	return err
 }
 


### PR DESCRIPTION
When we delete an instance, we should update the attachments list
to make sure any attachments are deleted and the volume state
is reset to available.

Possibly Fixes: #645