### PR TITLE
ciao-storage: do not use rbd import

### DIFF
--- a/ciao-storage/ceph.go
+++ b/ciao-storage/ceph.go
@@ -42,7 +42,8 @@ func (d CephDriver) CreateBlockDevice(imagePath *string, size int) (BlockDevice,
 	// Currently the kernel rdb client only supports layering but in the future more feaures
 	// should be added as they are enabled in the kernel.
 	if imagePath != nil {
-		cmd = exec.Command("rbd", "--id", d.ID, "--image-feature", "layering", "import", *imagePath, ID)
+		rbdStr := fmt.Sprintf("rbd:rbd/%s:id=%s", ID, d.ID)
+		cmd = exec.Command("qemu-img", "convert", "-O", "rbd", *imagePath, rbdStr)
 	} else {
 		// create an empty volume
 		cmd = exec.Command("rbd", "--id", d.ID, "--image-feature", "layering", "create", "--size", strconv.Itoa(size)+"G", ID)


### PR DESCRIPTION
Instead of using rbd import to create volumes from images,
use qemu-img convert.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>