### PR TITLE
ciao-controller: return error if getStorage fails

### DIFF
--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -245,9 +245,7 @@ func newConfig(ctl *controller, wl *types.Workload, instanceID string, tenantID 
 		if wl.Storage != nil {
 			storage, err = getStorage(ctl, wl, tenantID)
 			if err != nil {
-				glog.Warning(err)
-				// we should really clean up and return here,
-				// but just keep going for now.
+				return config, err
 			}
 		}
 	} else {


### PR DESCRIPTION
Rather than continuing on as if nothing had happened, let newConfig
fail when we fail to get storage information for the requested
workload.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>