### PR TITLE
ciao-cli: Parse the subcommand before identifying with keystone

### DIFF
--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -51,6 +51,7 @@ func (c *command) run(args []string) error {
 		c.usage(cmdName)
 	}
 	args = subCmd.parseArgs(args[2:])
+	prepareForCommand()
 	return subCmd.run(args)
 }
 
@@ -341,21 +342,8 @@ func checkCompulsoryOptions() {
 	}
 }
 
-func main() {
+func prepareForCommand() {
 	var err error
-
-	flag.Usage = usage
-	flag.Parse()
-
-	getCiaoEnvVariables()
-	checkCompulsoryOptions()
-
-	// Print usage if no arguments are given
-	args := flag.Args()
-	if len(args) < 1 {
-		usage()
-	}
-
 	/* Load CA file if necessary */
 	if *caCertFile != "" {
 		caCert, err := ioutil.ReadFile(*caCertFile)
@@ -381,6 +369,22 @@ func main() {
 	scopedToken, *tenantID, _, err = getScopedToken(*identityUser, *identityPassword, *tenantName)
 	if err != nil {
 		fatalf(err.Error())
+	}
+}
+
+func main() {
+	var err error
+
+	flag.Usage = usage
+	flag.Parse()
+
+	getCiaoEnvVariables()
+	checkCompulsoryOptions()
+
+	// Print usage if no arguments are given
+	args := flag.Args()
+	if len(args) < 1 {
+		usage()
 	}
 
 	// Find command in cmdline args


### PR DESCRIPTION
This change moves the execution of common code that talks to keystone
and validates the tenant setup to after the subcommand arguments are
parsed but before the command itself is run.

This means you can get instant feedback of command line parsing errors
without any network induced delay.

Fixes: #747