### PR TITLE
ciao-cli: expect NoContent from instance delete

### DIFF
--- a/ciao-cli/instance.go
+++ b/ciao-cli/instance.go
@@ -189,7 +189,7 @@ func (cmd *instanceDeleteCommand) run(args []string) error {
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusAccepted {
+	if resp.StatusCode != http.StatusNoContent {
 		fatalf("Instance deletion failed: %s", resp.Status)
 	}
 


### PR DESCRIPTION
The api for deleting a server response with 204 in the case
of success, not 200.

Fixes: #652

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>