### PR TITLE
Ephemeral boot from volume

### DIFF
--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -1113,7 +1113,7 @@ func TestGetStorage(t *testing.T) {
 		Storage: s,
 	}
 
-	pl, err := getStorage(ctl, wl, tenant.ID)
+	pl, err := getStorage(ctl, wl, tenant.ID, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -1084,7 +1084,49 @@ func testStartWorkloadLaunchCNCI(t *testing.T, num int) (*testutil.SsntpTestClie
 	return netClient, instances
 }
 
-func TestGetStorage(t *testing.T) {
+func TestGetStorageForVolume(t *testing.T) {
+	tenant, err := addTestTenant()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sourceVolume := addTestBlockDevice(t, tenant.ID)
+	defer ctl.DeleteBlockDevice(sourceVolume.ID)
+
+	// a temporary in memory filesystem?
+	s := &types.StorageResource{
+		ID:         "",
+		Bootable:   true,
+		Persistent: true,
+		SourceType: types.VolumeService,
+		SourceID:   sourceVolume.ID,
+	}
+
+	wl := &types.Workload{
+		ID:      "validID",
+		ImageID: uuid.Generate().String(),
+		Storage: s,
+	}
+
+	pl, err := getStorage(ctl, wl, tenant.ID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pl.ID == "" {
+		t.Errorf("storage ID does not exist")
+	}
+
+	if pl.Bootable != true {
+		t.Errorf("bootable flag not correct")
+	}
+
+	if pl.Ephemeral != false {
+		t.Errorf("ephemeral flag not correct")
+	}
+}
+
+func TestGetStorageForImage(t *testing.T) {
 	tenant, err := addTestTenant()
 	if err != nil {
 		t.Fatal(err)
@@ -1124,6 +1166,10 @@ func TestGetStorage(t *testing.T) {
 
 	if pl.Bootable != true {
 		t.Errorf("bootable flag not correct")
+	}
+
+	if pl.Ephemeral != true {
+		t.Errorf("ephemeral flag not correct")
 	}
 }
 

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -1124,6 +1124,16 @@ func TestGetStorageForVolume(t *testing.T) {
 	if pl.Ephemeral != false {
 		t.Errorf("ephemeral flag not correct")
 	}
+
+	createdVolume, err := ctl.ds.GetBlockDevice(pl.ID)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(createdVolume.Name) == 0 {
+		t.Errorf("block device name not set")
+	}
 }
 
 func TestGetStorageForImage(t *testing.T) {
@@ -1170,6 +1180,16 @@ func TestGetStorageForImage(t *testing.T) {
 
 	if pl.Ephemeral != true {
 		t.Errorf("ephemeral flag not correct")
+	}
+
+	createdVolume, err := ctl.ds.GetBlockDevice(pl.ID)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(createdVolume.Name) == 0 {
+		t.Errorf("block device name not set")
 	}
 }
 

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -146,7 +146,7 @@ func (c *config) GetResources() map[string]int {
 	return resources
 }
 
-func getStorage(c *controller, wl *types.Workload, tenant string) (payloads.StorageResources, error) {
+func getStorage(c *controller, wl *types.Workload, tenant string, instanceID string) (payloads.StorageResources, error) {
 	s := wl.Storage
 
 	// storage already exists, use preexisting definition.
@@ -199,6 +199,7 @@ func getStorage(c *controller, wl *types.Workload, tenant string) (payloads.Stor
 			Size:        s.Size,
 			CreateTime:  time.Now(),
 			TenantID:    tenant,
+			Name:        fmt.Sprintf("Storage for instance: %s", instanceID),
 		}
 
 		err = c.ds.AddBlockDevice(data)
@@ -221,6 +222,7 @@ func getStorage(c *controller, wl *types.Workload, tenant string) (payloads.Stor
 			Size:        s.Size,
 			CreateTime:  time.Now(),
 			TenantID:    tenant,
+			Name:        fmt.Sprintf("Storage for instance: %s", instanceID),
 		}
 
 		err = c.ds.AddBlockDevice(data)
@@ -244,6 +246,7 @@ func getStorage(c *controller, wl *types.Workload, tenant string) (payloads.Stor
 			Size:        s.Size,
 			CreateTime:  time.Now(),
 			TenantID:    tenant,
+			Name:        fmt.Sprintf("Storage for instance: %s", instanceID),
 		}
 
 		err = c.ds.AddBlockDevice(data)
@@ -316,7 +319,7 @@ func newConfig(ctl *controller, wl *types.Workload, instanceID string, tenantID 
 
 		// handle storage resources
 		if wl.Storage != nil {
-			storage, err = getStorage(ctl, wl, tenantID)
+			storage, err = getStorage(ctl, wl, tenantID, instanceID)
 			if err != nil {
 				return config, err
 			}

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -90,6 +90,13 @@ func (i *instance) Add() error {
 	if i.CNCI == false {
 		ds := i.ctl.ds
 		ds.AddInstance(&i.Instance)
+		storage := i.newConfig.sc.Start.Storage
+		if (storage != payloads.StorageResources{}) {
+			_, err := ds.CreateStorageAttachment(i.Instance.ID, storage.ID, storage.Ephemeral)
+			if err != nil {
+				glog.Error(err)
+			}
+		}
 	} else {
 		i.ctl.ds.AddTenantCNCI(i.TenantID, i.ID, i.MACAddress)
 	}
@@ -208,7 +215,7 @@ func getStorage(c *controller, wl *types.Workload, tenant string, instanceID str
 			return payloads.StorageResources{}, err
 		}
 
-		return payloads.StorageResources{ID: data.ID, Bootable: s.Bootable}, nil
+		return payloads.StorageResources{ID: data.ID, Bootable: s.Bootable, Ephemeral: true}, nil
 	case types.VolumeService:
 		device, err := c.CopyBlockDevice(s.SourceID)
 		if err != nil {

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -1488,7 +1488,9 @@ func (ds *Datastore) UpdateBlockDevice(data types.BlockData) error {
 	return ds.AddBlockDevice(data)
 }
 
-func (ds *Datastore) createStorageAttachment(instanceID string, blockID string) (types.StorageAttachment, error) {
+// CreateStorageAttachment will associate an instance with a block device in
+// the datastore
+func (ds *Datastore) CreateStorageAttachment(instanceID string, blockID string, ephemeral bool) (types.StorageAttachment, error) {
 	link := attachment{
 		instanceID: instanceID,
 		volumeID:   blockID,
@@ -1498,6 +1500,7 @@ func (ds *Datastore) createStorageAttachment(instanceID string, blockID string) 
 		InstanceID: instanceID,
 		ID:         uuid.Generate().String(),
 		BlockID:    blockID,
+		Ephemeral:  ephemeral,
 	}
 
 	// add it to our links map
@@ -1639,7 +1642,9 @@ func (ds *Datastore) getStorageAttachment(instanceID string, volumeID string) (t
 	return a, nil
 }
 
-func (ds *Datastore) deleteStorageAttachment(ID string) error {
+// DeleteStorageAttachment will delete the attachment with the associated ID
+// from the datastore.
+func (ds *Datastore) DeleteStorageAttachment(ID string) error {
 	ds.attachLock.Lock()
 	a, ok := ds.attachments[ID]
 	if ok {

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -1818,7 +1818,7 @@ func TestCreateStorageAttachment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ds.createStorageAttachment(instance.ID, data.ID)
+	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1875,7 +1875,7 @@ func TestUpdateStorageAttachmentExisting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ds.createStorageAttachment(instance.ID, data.ID)
+	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1982,7 +1982,7 @@ func TestUpdateStorageAttachmentDeleted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ds.createStorageAttachment(instance.ID, data.ID)
+	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2032,7 +2032,7 @@ func TestGetStorageAttachment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ds.createStorageAttachment(instance.ID, data.ID)
+	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2127,7 +2127,7 @@ func TestDeleteStorageAttachment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ds.createStorageAttachment(instance.ID, data.ID)
+	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2141,7 +2141,7 @@ func TestDeleteStorageAttachment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ds.deleteStorageAttachment(a.ID)
+	err = ds.DeleteStorageAttachment(a.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2189,7 +2189,7 @@ func TestDeleteStorageAttachmentError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ds.createStorageAttachment(instance.ID, data.ID)
+	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2203,7 +2203,7 @@ func TestDeleteStorageAttachmentError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ds.deleteStorageAttachment(a.ID)
+	err = ds.DeleteStorageAttachment(a.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2213,7 +2213,7 @@ func TestDeleteStorageAttachmentError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ds.deleteStorageAttachment(a.ID)
+	err = ds.DeleteStorageAttachment(a.ID)
 	if err != ErrNoStorageAttachment {
 		t.Fatal(err)
 	}
@@ -2256,7 +2256,7 @@ func TestGetVolumeAttachments(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ds.createStorageAttachment(instance.ID, data.ID)
+	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -241,6 +241,7 @@ func TestGetAllStorageAttachments(t *testing.T) {
 		ID:         uuid.Generate().String(),
 		InstanceID: uuid.Generate().String(),
 		BlockID:    uuid.Generate().String(),
+		Ephemeral:  false,
 	}
 
 	err = db.createStorageAttachment(a)
@@ -257,5 +258,51 @@ func TestGetAllStorageAttachments(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	alpha := attachments[a.ID]
+
+	if alpha != a {
+		t.Fatal("Attachment from DB doesn't match original attachment")
+	}
+
+	b := types.StorageAttachment{
+		ID:         uuid.Generate().String(),
+		InstanceID: uuid.Generate().String(),
+		BlockID:    uuid.Generate().String(),
+		Ephemeral:  true,
+	}
+
+	err = db.createStorageAttachment(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	attachments, err = db.getAllStorageAttachments()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(attachments) != 2 {
+		t.Fatal(err)
+	}
+
+	err = db.deleteStorageAttachment(a.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	attachments, err = db.getAllStorageAttachments()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(attachments) != 1 {
+		t.Fatal(err)
+	}
+
+	beta := attachments[b.ID]
+
+	if beta != b {
+		t.Fatal("Attachment from DB doesn't match original attachment")
+	}
 	db.disconnect()
 }

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -251,6 +251,7 @@ type StorageAttachment struct {
 	ID         string // a uuid
 	InstanceID string // the instance this volume is attached to
 	BlockID    string // the ID of the block device
+	Ephemeral  bool   // whether the storage should be deleted on Cleanup
 }
 
 // CiaoComputeTenants represents the unmarshalled version of the contents of a

--- a/payloads/start.go
+++ b/payloads/start.go
@@ -93,6 +93,10 @@ type StorageResources struct {
 
 	// Bootable indicates that this is a bootable storage device.
 	Bootable bool `yaml:"boot"`
+
+	// Ephemeral indicates whether this storage should only last as long as
+	// the instance
+	Ephemeral bool `yaml:"ephemeral"`
 }
 
 // RequestedResource is used to specify an individual resource contained within


### PR DESCRIPTION
This is some early enabling work for the "Images as Volumes" project. With this change volumes created from an image specified in a storage workload will be deleted when the instance itself is deleted.