### PR TITLE
[WIP] Experiment with volume images

### DIFF
--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -497,7 +497,7 @@ func TestDetachVolume(t *testing.T) {
 }
 
 func addTestBlockDevice(t *testing.T, tenantID string) types.BlockData {
-	bd, err := ctl.CreateBlockDevice(nil, 0)
+	bd, err := ctl.CreateBlockDevice("", nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -25,6 +25,7 @@ import (
 	"github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/openstack/block"
 	osIdentity "github.com/01org/ciao/openstack/identity"
+	"github.com/01org/ciao/ssntp/uuid"
 	"github.com/golang/glog"
 	"github.com/gorilla/mux"
 )
@@ -51,13 +52,13 @@ func (c *controller) CreateVolume(tenant string, req block.RequestedVolume) (blo
 	// no limits checking for now.
 	if req.ImageRef != nil {
 		// create bootable volume
-		bd, err = c.CreateBlockDevice(req.ImageRef, req.Size)
+		bd, err = getImageBlockDevice(c, tenant, *req.ImageRef)
 	} else if req.SourceVolID != nil {
 		// copy existing volume
 		bd, err = c.CopyBlockDevice(*req.SourceVolID)
 	} else {
 		// create empty volume
-		bd, err = c.CreateBlockDevice(nil, req.Size)
+		bd, err = c.CreateBlockDevice(uuid.Generate().String(), nil, req.Size)
 	}
 
 	if err != nil {

--- a/ciao-launcher/docker_test.go
+++ b/ciao-launcher/docker_test.go
@@ -55,8 +55,16 @@ func (s dockerTestStorage) MapVolumeToNode(volumeUUID string) (string, error) {
 	return "", nil
 }
 
-func (s dockerTestStorage) CreateBlockDevice(image *string, sizeGB int) (storage.BlockDevice, error) {
+func (s dockerTestStorage) CreateBlockDevice(volumeUUID string, image *string, sizeGB int) (storage.BlockDevice, error) {
 	return storage.BlockDevice{}, nil
+}
+
+func (s dockerTestStorage) CreateBlockDeviceFromSnapshot(volumeUUID string, snapshotID string) (storage.BlockDevice, error) {
+	return storage.BlockDevice{}, nil
+}
+
+func (s dockerTestStorage) CreateBlockDeviceSnapshot(volumeUUID string, snapshotID string) error {
+	return nil
 }
 
 func (s dockerTestStorage) DeleteBlockDevice(string) error {

--- a/ciao-storage/block.go
+++ b/ciao-storage/block.go
@@ -25,7 +25,9 @@ var (
 
 // BlockDriver is the interface that all block drivers must implement.
 type BlockDriver interface {
-	CreateBlockDevice(image *string, sizeGB int) (BlockDevice, error)
+	CreateBlockDevice(volumeUUID string, image *string, sizeGB int) (BlockDevice, error)
+	CreateBlockDeviceFromSnapshot(volumeUUID string, snapshotID string) (BlockDevice, error)
+	CreateBlockDeviceSnapshot(volumeUUID string, snapshotID string) error
 	DeleteBlockDevice(string) error
 	MapVolumeToNode(volumeUUID string) (string, error)
 	UnmapVolumeFromNode(volumeUUID string) error

--- a/ciao-storage/ceph.go
+++ b/ciao-storage/ceph.go
@@ -51,7 +51,7 @@ func (d CephDriver) CreateBlockDevice(imagePath *string, size int) (BlockDevice,
 
 	err := cmd.Run()
 	if err != nil {
-		return BlockDevice{}, err
+		return BlockDevice{}, fmt.Errorf("Error when running: %v: %v", cmd.Args, err)
 	}
 
 	return BlockDevice{ID: ID}, nil
@@ -67,7 +67,7 @@ func (d CephDriver) CopyBlockDevice(volumeUUID string) (BlockDevice, error) {
 
 	err := cmd.Run()
 	if err != nil {
-		return BlockDevice{}, err
+		return BlockDevice{}, fmt.Errorf("Error when running: %v: %v", cmd.Args, err)
 	}
 
 	return BlockDevice{ID: ID}, nil

--- a/ciao-storage/ceph.go
+++ b/ciao-storage/ceph.go
@@ -32,10 +32,7 @@ type CephDriver struct {
 }
 
 // CreateBlockDevice will create a rbd image in the ceph cluster.
-func (d CephDriver) CreateBlockDevice(imagePath *string, size int) (BlockDevice, error) {
-	// generate a UUID to use for this image.
-	ID := uuid.Generate().String()
-
+func (d CephDriver) CreateBlockDevice(ID string, imagePath *string, size int) (BlockDevice, error) {
 	var cmd *exec.Cmd
 
 	// imageFeatures holds the image features to use when creating a ceph rbd image format 2
@@ -71,6 +68,41 @@ func (d CephDriver) CopyBlockDevice(volumeUUID string) (BlockDevice, error) {
 	}
 
 	return BlockDevice{ID: ID}, nil
+}
+
+// CreateBlockDeviceFromSnapshot will create a block device derived from the previously created snapshot.
+func (d CephDriver) CreateBlockDeviceFromSnapshot(volumeUUID string, snapshotID string) (BlockDevice, error) {
+	ID := uuid.Generate().String()
+
+	var cmd *exec.Cmd
+
+	cmd = exec.Command("rbd", "--id", d.ID, "clone", volumeUUID+"@"+snapshotID, ID)
+
+	err := cmd.Run()
+	if err != nil {
+		return BlockDevice{}, fmt.Errorf("Error when running: %v: %v", cmd.Args, err)
+	}
+
+	return BlockDevice{ID: ID}, nil
+}
+
+// CreateBlockDeviceSnapshot creates and protects the snapshot with the provided name
+func (d CephDriver) CreateBlockDeviceSnapshot(volumeUUID string, snapshotID string) error {
+	var cmd *exec.Cmd
+	cmd = exec.Command("rbd", "--id", d.ID, "snap", "create", volumeUUID+"@"+snapshotID)
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Error when running: %v: %v", cmd.Args, err)
+	}
+
+	cmd = exec.Command("rbd", "--id", d.ID, "snap", "protect", volumeUUID+"@"+snapshotID)
+
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Error when running: %v: %v", cmd.Args, err)
+	}
+	return nil
 }
 
 // DeleteBlockDevice will remove a rbd image from the ceph cluster.

--- a/ciao-storage/ceph_test.go
+++ b/ciao-storage/ceph_test.go
@@ -26,7 +26,7 @@ var driver = CephDriver{
 var imagePath = "/var/lib/ciao/images/73a86d7e-93c0-480e-9c41-ab42f69b7799"
 
 func TestCreateBlockDevice(t *testing.T) {
-	device, err := driver.CreateBlockDevice(&imagePath, 0)
+	device, err := driver.CreateBlockDevice(uuid.Generate().String(), &imagePath, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-storage/noop.go
+++ b/ciao-storage/noop.go
@@ -27,8 +27,18 @@ type NoopDriver struct {
 }
 
 // CreateBlockDevice pretends to create a block device.
-func (d *NoopDriver) CreateBlockDevice(image *string, size int) (BlockDevice, error) {
+func (d *NoopDriver) CreateBlockDevice(ID string, image *string, size int) (BlockDevice, error) {
+	return BlockDevice{ID: ID}, nil
+}
+
+// CreateBlockDeviceFromSnapshot pretends to create a block device from snapshot
+func (d *NoopDriver) CreateBlockDeviceFromSnapshot(string, string) (BlockDevice, error) {
 	return BlockDevice{ID: uuid.Generate().String()}, nil
+}
+
+// CreateBlockDeviceSnapshot pretends to create a snapshot on the block device
+func (d *NoopDriver) CreateBlockDeviceSnapshot(volumeUUID string, snapshotID string) error {
+	return nil
 }
 
 // CopyBlockDevice pretends to copy an existing block device


### PR DESCRIPTION
With this code the first time an image is used it will get uploaded to a volume. Subsequent will runs use the volume instead. The volumes are COWed before booting via rbd clone.

```
rob@ciao-singlevm:~/go/src/github.com/01org/ciao$ time ciao-cli instance add -workload 79034317-3beb-447e-987d-4e310a8cf410
Created new instance: b8461b07-1a99-42b3-b279-b8bf9952e713

real    1m35.642s
user    0m0.036s
sys     0m0.016s

rob@ciao-singlevm:~/go/src/github.com/01org/ciao$ time ciao-cli instance add -workload 79034317-3beb-447e-987d-4e310a8cf410
Created new instance: dd4f5f2a-7497-418d-a19e-5c75187573e3

real    0m0.355s
user    0m0.036s
sys     0m0.048s

rob@ciao-singlevm:~/go/src/github.com/01org/ciao$ time ciao-cli instance add -workload 79034317-3beb-447e-987d-4e310a8cf410
Created new instance: fc01d08b-8f8e-4f80-a4e2-e281c5b86cae

real    0m0.321s
user    0m0.052s
sys     0m0.032s

rob@ciao-singlevm:~/go/src/github.com/01org/ciao$ ciao-cli volume list
Volume #1
        Name             [Volume for image: 73a86d7e-93c0-480e-9c41-ab42f69b7799]
        Size             [0 GB]
        UUID             [73a86d7e-93c0-480e-9c41-ab42f69b7799]
        Status           []
        Description      []

Volume #2
        Name             []
        Size             [0 GB]
        UUID             [37efc42b-8f71-4d14-aeac-69eacb1bb3cb]
        Status           [in-use]
        Description      []

Volume #3
        Name             []
        Size             [0 GB]
        UUID             [e9b6884f-980b-4a81-b517-7d01c561a715]
        Status           [in-use]
        Description      []

Volume #4
        Name             []
        Size             [0 GB]
        UUID             [0885b1aa-03c1-4542-9fd1-85c6b1fc5f08]
        Status           [in-use]
        Description      []

```

Obviously needs quite a lot of tweaking and unit tests.