### PR TITLE
ciao-networking: simplify cnci image preparation mount

### DIFF
--- a/networking/ciao-cnci-agent/scripts/generate_cnci_cloud_image.sh
+++ b/networking/ciao-cnci-agent/scripts/generate_cnci_cloud_image.sh
@@ -64,21 +64,13 @@ fi
 echo -e "\nMounting image: $image"
 tmpdir=$(mktemp -d)
 
-#it can take some time for the device to get created
-retry=0
-loop=''
-until [ $retry -ge 3 ]
-do
-    if [ "$loop" == "" ]; then
-	loop=`sudo losetup -f --show -P $image`
-    fi
-    sudo mount ${loop}p$partition "$tmpdir" && break
-    let retry=retry+1
-    echo "Mount failed, retrying $retry"
-done
+loop=`sudo losetup -f --show -P $image`
+sudo udevadm settle
+sudo mount ${loop}p$partition "$tmpdir"
 
-if [ $retry -ge 3 ]
-then
+# simplistic sanity check...most any linux image rootfs successfully mounted
+# will have a /usr directory
+if [ ! -e $tmpdir/usr ]; then
 	echo "Unable to mount CNCI Image"
 	return 1
 fi


### PR DESCRIPTION
We have a race potentially between losetup and partition existance.  This
probably is what the retry loop managed to kind of work around in the past.
The udevadm settle was in the wrong location previously.  It needs to come
after creation and before use.  It would have coincidentally in the past,
IF you were retrying.

We can simplify by not looping and rather create, wait, use as a simple
series of commands.

If we find subsequent issues that need more logic in this flow, I suggest
we remove the losetup and udevadm settle, and instead do "kpartx -sav
$img" followed by the mount.  Then also on exit do "kpartx -sdv $img".

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>