### PR TITLE
ciao-controller: Store correct tenant ID for instance deleted events

### DIFF
--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -993,7 +993,7 @@ func (ds *Datastore) DetachVolumeFailure(instanceID string, volumeID string, rea
 	ds.db.logEvent(i.TenantID, string(userError), msg)
 }
 
-func (ds *Datastore) deleteInstance(instanceID string) error {
+func (ds *Datastore) deleteInstance(instanceID string) (string, error) {
 	ds.instanceLastStatLock.Lock()
 	delete(ds.instanceLastStat, instanceID)
 	ds.instanceLastStatLock.Unlock()
@@ -1044,18 +1044,18 @@ func (ds *Datastore) deleteInstance(instanceID string) error {
 
 	ds.updateStorageAttachments(instanceID, nil)
 
-	return err
+	return i.TenantID, err
 }
 
 // DeleteInstance removes an instance from the datastore.
 func (ds *Datastore) DeleteInstance(instanceID string) error {
-	err := ds.deleteInstance(instanceID)
+	tenantID, err := ds.deleteInstance(instanceID)
 	if err != nil {
 		return err
 	}
 
 	msg := fmt.Sprintf("Deleted Instance %s", instanceID)
-	ds.db.logEvent(instanceID, string(userInfo), msg)
+	ds.db.logEvent(tenantID, string(userInfo), msg)
 
 	return nil
 }


### PR DESCRIPTION
The controller was incorrectly storing the instance ID in the tenant ID
field of the log table for instance deleted events.  This meant that it
was not possible for the user to view these events using ciao-cli event
list as events are filtered by tenant ID, and the IDs stored did not
correspond to any tenants.

Fixes #776

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>