### PR TITLE
[DONOTMERGE] Add initial support for ciao external IPs API

### DIFF
--- a/ciao-cli/external-ips.go
+++ b/ciao-cli/external-ips.go
@@ -1,0 +1,826 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"text/tabwriter"
+
+	"github.com/01org/ciao/ciao-controller/api"
+	"github.com/01org/ciao/ciao-controller/types"
+)
+
+const (
+	poolTemplateDesc = `struct {
+	ID       string                               // ID of the pool
+	Name     string                               // Name of the pool
+	TotalIPs int                                  // Total IPs in pool
+	Free	 int                                  // Total Free IPs in pool
+}`
+	poolShowTemplateDesc = `struct {
+	ID	string					// ID of the pool
+	Name	string					// name of the pool
+	Free	*int					// Total free IPs in pool
+	TotalIPs *int					// Total IPs in pool
+	Subnets []ExternalSubnet			// Subnets in this pool
+	IPs	[]ExternalIP				// Individual IPs in this pool
+}`
+)
+
+func getCiaoExternalIPsResource() (string, string, error) {
+	url, err := getCiaoResource("external-ips", api.ExternalIPsV1)
+	return url, api.ExternalIPsV1, err
+}
+
+// TBD: in an ideal world, we'd modify the GET to take a query.
+func getExternalIPRef(address string) (string, error) {
+	var IPs []types.MappedIP
+
+	url, ver, err := getCiaoExternalIPsResource()
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("External IP list failed: %s", resp.Status)
+	}
+
+	err = unmarshalHTTPResponse(resp, &IPs)
+	if err != nil {
+		return "", err
+	}
+
+	for _, IP := range IPs {
+		if IP.ExternalIP == address {
+			url := getRef("self", IP.Links)
+			if url != "" {
+				return url, nil
+			}
+		}
+	}
+
+	return "", types.ErrAddressNotFound
+}
+
+var externalIPCommand = &command{
+	SubCommands: map[string]subCommand{
+		"map":   new(externalIPMapCommand),
+		"list":  new(externalIPListCommand),
+		"unmap": new(externalIPUnMapCommand),
+	},
+}
+
+type externalIPMapCommand struct {
+	Flag       flag.FlagSet
+	instanceID string
+	poolName   string
+}
+
+func (cmd *externalIPMapCommand) usage(...string) {
+	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] external-ip map [flags]
+
+Map an external IP from a given pool to an instance.
+
+The map flags are:
+
+`)
+	cmd.Flag.PrintDefaults()
+	os.Exit(2)
+}
+
+func (cmd *externalIPMapCommand) parseArgs(args []string) []string {
+	cmd.Flag.StringVar(&cmd.instanceID, "instance", "", "ID of the instance to map IP to.")
+	cmd.Flag.StringVar(&cmd.poolName, "pool", "", "Name of the pool to map from.")
+	cmd.Flag.Usage = func() { cmd.usage() }
+	cmd.Flag.Parse(args)
+	return cmd.Flag.Args()
+}
+
+func (cmd *externalIPMapCommand) run(args []string) error {
+	if cmd.instanceID == "" {
+		errorf("Missing required -instance parameter")
+		cmd.usage()
+	}
+
+	req := types.MapIPRequest{
+		InstanceID: cmd.instanceID,
+	}
+
+	if cmd.poolName != "" {
+		req.PoolName = &cmd.poolName
+	}
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	body := bytes.NewReader(b)
+
+	url, ver, err := getCiaoExternalIPsResource()
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	resp, err := sendCiaoRequest("POST", url, nil, body, &ver)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		fatalf("External IP map failed: %s", resp.Status)
+	}
+
+	fmt.Printf("Requested external IP for: %s\n", cmd.instanceID)
+
+	return nil
+}
+
+type externalIPListCommand struct {
+	Flag flag.FlagSet
+}
+
+func (cmd *externalIPListCommand) usage(...string) {
+	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] external-ip list [flags]
+
+List all mapped external IPs.
+
+The list flags are:
+
+`)
+	cmd.Flag.PrintDefaults()
+	os.Exit(2)
+}
+
+func (cmd *externalIPListCommand) parseArgs(args []string) []string {
+	cmd.Flag.Usage = func() { cmd.usage() }
+	cmd.Flag.Parse(args)
+	return cmd.Flag.Args()
+}
+
+func (cmd *externalIPListCommand) run(args []string) error {
+	var IPs []types.MappedIP
+
+	url, ver, err := getCiaoExternalIPsResource()
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		fatalf("External IP list failed: %s", resp.Status)
+	}
+
+	err = unmarshalHTTPResponse(resp, &IPs)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	w := new(tabwriter.Writer)
+	w.Init(os.Stdout, 0, 1, 1, ' ', 0)
+	fmt.Fprintf(w, "#\tExternalIP\tInternalIP")
+	if checkPrivilege() {
+		fmt.Fprintf(w, "\tInstanceID\tTenantID\tPoolName\n")
+	}
+
+	for i, IP := range IPs {
+		fmt.Fprintf(w, "%d", i+1)
+		fmt.Fprintf(w, "\t%s", IP.ExternalIP)
+		fmt.Fprintf(w, "\t%s", IP.InternalIP)
+		if IP.InstanceID != "" {
+			fmt.Fprintf(w, "\t%s", IP.InstanceID)
+		}
+
+		if IP.TenantID != "" {
+			fmt.Fprintf(w, "\t%s", IP.TenantID)
+		}
+
+		if IP.PoolName != "" {
+			fmt.Fprintf(w, "\t%s", IP.PoolName)
+		}
+
+		fmt.Fprintf(w, "\n")
+
+		w.Flush()
+	}
+	return nil
+}
+
+type externalIPUnMapCommand struct {
+	address string
+	Flag    flag.FlagSet
+}
+
+func (cmd *externalIPUnMapCommand) usage(...string) {
+	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] external-ip unmap [flags]
+
+Unmap a given external IP.
+
+The unmap flags are:
+
+`)
+	cmd.Flag.PrintDefaults()
+	os.Exit(2)
+}
+
+func (cmd *externalIPUnMapCommand) parseArgs(args []string) []string {
+	cmd.Flag.StringVar(&cmd.address, "address", "", "External IP to unmap.")
+	cmd.Flag.Usage = func() { cmd.usage() }
+	cmd.Flag.Parse(args)
+	return cmd.Flag.Args()
+}
+
+func (cmd *externalIPUnMapCommand) run(args []string) error {
+	if cmd.address == "" {
+		errorf("Missing required -instance parameter")
+		cmd.usage()
+	}
+
+	url, err := getExternalIPRef(cmd.address)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	ver := api.ExternalIPsV1
+
+	resp, err := sendCiaoRequest("DELETE", url, nil, nil, &ver)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		fatalf("Unmap of address failed: %s", resp.Status)
+	}
+
+	fmt.Printf("Requested unmap of: %s\n", cmd.address)
+
+	return nil
+}
+
+var poolCommand = &command{
+	SubCommands: map[string]subCommand{
+		"create": new(poolCreateCommand),
+		"list":   new(poolListCommand),
+		"show":   new(poolShowCommand),
+		"delete": new(poolDeleteCommand),
+		"add":    new(poolAddCommand),
+		"remove": new(poolRemoveCommand),
+	},
+}
+
+type poolCreateCommand struct {
+	Flag flag.FlagSet
+	name string
+}
+
+func getCiaoPoolsResource() (string, error) {
+	return getCiaoResource("pools", api.PoolsV1)
+}
+
+func getCiaoPoolRef(name string) (string, error) {
+	var pools types.ListPoolsResponse
+
+	query := queryValue{
+		name:  "name",
+		value: name,
+	}
+
+	url, err := getCiaoPoolsResource()
+	if err != nil {
+		return "", err
+	}
+
+	ver := api.PoolsV1
+
+	resp, err := sendCiaoRequest("GET", url, []queryValue{query}, nil, &ver)
+	if err != nil {
+		return "", err
+	}
+
+	err = unmarshalHTTPResponse(resp, &pools)
+	if err != nil {
+		return "", err
+	}
+
+	// we have now the pool ID
+	if len(pools.Pools) != 1 {
+		return "", errors.New("No pool by that name found")
+	}
+
+	links := pools.Pools[0].Links
+	url = getRef("self", links)
+	if url == "" {
+		return url, errors.New("Invalid Link returned from controller")
+	}
+
+	return url, nil
+}
+
+func getCiaoPool(name string) (types.Pool, error) {
+	var pool types.Pool
+
+	url, err := getCiaoPoolRef(name)
+	if err != nil {
+		return pool, nil
+	}
+
+	ver := api.PoolsV1
+
+	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	if err != nil {
+		return pool, err
+	}
+
+	err = unmarshalHTTPResponse(resp, &pool)
+	if err != nil {
+		return pool, err
+	}
+
+	return pool, nil
+}
+
+func (cmd *poolCreateCommand) usage(...string) {
+	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] pool create [flags]
+
+Creates a new external IP pool.
+
+The create flags are:
+
+`)
+	cmd.Flag.PrintDefaults()
+	os.Exit(2)
+}
+
+// TBD: add support for specifying a subnet or []ip addresses.
+func (cmd *poolCreateCommand) parseArgs(args []string) []string {
+	cmd.Flag.StringVar(&cmd.name, "name", "", "Name of pool")
+	cmd.Flag.Usage = func() { cmd.usage() }
+	cmd.Flag.Parse(args)
+	return cmd.Flag.Args()
+}
+
+func (cmd *poolCreateCommand) run(args []string) error {
+	if cmd.name == "" {
+		errorf("Missing required -name parameter")
+		cmd.usage()
+	}
+
+	req := types.NewPoolRequest{
+		Name: cmd.name,
+	}
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	body := bytes.NewReader(b)
+
+	url, err := getCiaoPoolsResource()
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	ver := api.PoolsV1
+
+	resp, err := sendCiaoRequest("POST", url, nil, body, &ver)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		fatalf("Pool creation failed: %s", resp.Status)
+	}
+
+	fmt.Printf("Created new pool: %s\n", cmd.name)
+
+	return nil
+}
+
+type poolListCommand struct {
+	Flag     flag.FlagSet
+	template string
+}
+
+func (cmd *poolListCommand) usage(...string) {
+	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] pool list [flags]
+
+List all ciao external IP pools.
+
+The list flags are:
+
+`)
+	cmd.Flag.PrintDefaults()
+	fmt.Fprintf(os.Stderr, `
+The template passed to the -f option operates on a
+
+[]%s
+`, poolTemplateDesc)
+
+	os.Exit(2)
+}
+
+func (cmd *poolListCommand) parseArgs(args []string) []string {
+	cmd.Flag.StringVar(&cmd.template, "f", "", "Template used to format output")
+	cmd.Flag.Usage = func() { cmd.usage() }
+	cmd.Flag.Parse(args)
+	return cmd.Flag.Args()
+}
+
+// change this command to return different output depending
+// on the privilege level of user. Check privilege, then
+// if not privileged, build non-priviledged URL.
+func (cmd *poolListCommand) run(args []string) error {
+	var pools types.ListPoolsResponse
+
+	url, err := getCiaoPoolsResource()
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	ver := api.PoolsV1
+
+	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	err = unmarshalHTTPResponse(resp, &pools)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	if cmd.template != "" {
+		return outputToTemplate("pool-list", cmd.template,
+			&pools)
+	}
+
+	w := new(tabwriter.Writer)
+	w.Init(os.Stdout, 0, 1, 1, ' ', 0)
+	fmt.Fprintf(w, "#\tName")
+	if checkPrivilege() {
+		fmt.Fprintf(w, "\tTotalIPs\tFreeIPs\n")
+	}
+
+	for i, pool := range pools.Pools {
+		fmt.Fprintf(w, "%d", i+1)
+		fmt.Fprintf(w, "\t%s", pool.Name)
+
+		if pool.TotalIPs != nil {
+			fmt.Fprintf(w, "\t%d", *pool.TotalIPs)
+		}
+
+		if pool.Free != nil {
+			fmt.Fprintf(w, "\t%d", *pool.Free)
+		}
+
+		fmt.Fprintf(w, "\n")
+
+		w.Flush()
+	}
+	return nil
+}
+
+type poolShowCommand struct {
+	Flag     flag.FlagSet
+	name     string
+	template string
+}
+
+func (cmd *poolShowCommand) usage(...string) {
+	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] pool show [flags]
+
+Show ciao external IP pool details.
+
+The show flags are:
+
+`)
+	cmd.Flag.PrintDefaults()
+	fmt.Fprintf(os.Stderr, `
+The template passed to the -f option operates on a
+
+[]%s
+`, poolShowTemplateDesc)
+
+	os.Exit(2)
+}
+
+func (cmd *poolShowCommand) parseArgs(args []string) []string {
+	cmd.Flag.StringVar(&cmd.name, "name", "", "Name of pool")
+	cmd.Flag.StringVar(&cmd.template, "f", "", "Template used to format output")
+	cmd.Flag.Usage = func() { cmd.usage() }
+	cmd.Flag.Parse(args)
+	return cmd.Flag.Args()
+}
+
+func dumpPool(pool types.Pool) {
+	fmt.Printf("\tUUID: %s\n", pool.ID)
+	fmt.Printf("\tName: %s\n", pool.Name)
+	fmt.Printf("\tFree IPs: %d\n", pool.Free)
+	fmt.Printf("\tTotal IPs: %d\n", pool.TotalIPs)
+
+	for _, sub := range pool.Subnets {
+		fmt.Printf("\tSubnet: %s\n", sub.CIDR)
+	}
+
+	for _, ip := range pool.IPs {
+		fmt.Printf("\tIP Address: %s\n", ip.Address)
+	}
+}
+
+func (cmd *poolShowCommand) run(args []string) error {
+	var pool types.Pool
+
+	if cmd.name == "" {
+		errorf("Missing required -name parameter")
+		cmd.usage()
+	}
+
+	pool, err := getCiaoPool(cmd.name)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	if cmd.template != "" {
+		return outputToTemplate("pool-show", cmd.template,
+			&pool)
+	}
+
+	dumpPool(pool)
+
+	return nil
+}
+
+type poolDeleteCommand struct {
+	Flag flag.FlagSet
+	name string
+}
+
+func (cmd *poolDeleteCommand) usage(...string) {
+	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] pool delete [flags]
+
+Delete an unused ciao external IP pool.
+
+The delete flags are:
+
+`)
+	cmd.Flag.PrintDefaults()
+	os.Exit(2)
+}
+
+func (cmd *poolDeleteCommand) parseArgs(args []string) []string {
+	cmd.Flag.StringVar(&cmd.name, "name", "", "Name of pool")
+	cmd.Flag.Usage = func() { cmd.usage() }
+	cmd.Flag.Parse(args)
+	return cmd.Flag.Args()
+}
+
+func (cmd *poolDeleteCommand) run(args []string) error {
+	if cmd.name == "" {
+		errorf("Missing required -name parameter")
+		cmd.usage()
+	}
+
+	url, err := getCiaoPoolRef(cmd.name)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	ver := api.PoolsV1
+
+	resp, err := sendCiaoRequest("DELETE", url, nil, nil, &ver)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		fatalf("Pool deletion failed: %s", resp.Status)
+	}
+
+	fmt.Printf("Deleted pool: %s\n", cmd.name)
+
+	return nil
+}
+
+type poolAddCommand struct {
+	Flag   flag.FlagSet
+	name   string
+	subnet string
+	ips    []string
+}
+
+func (cmd *poolAddCommand) usage(...string) {
+	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] pool add [flags] [ip1 ip2...]
+
+Add external IPs to a pool.
+
+The add flags are:
+
+`)
+	cmd.Flag.PrintDefaults()
+	os.Exit(2)
+}
+
+func (cmd *poolAddCommand) parseArgs(args []string) []string {
+	cmd.Flag.StringVar(&cmd.name, "name", "", "Name of pool")
+	cmd.Flag.StringVar(&cmd.subnet, "subnet", "", "Subnet in CIDR format")
+	cmd.Flag.Usage = func() { cmd.usage() }
+	cmd.Flag.Parse(args)
+	return cmd.Flag.Args()
+}
+
+func (cmd *poolAddCommand) run(args []string) error {
+	var req types.NewAddressRequest
+
+	if cmd.name == "" {
+		errorf("Missing required -name parameter")
+		cmd.usage()
+	}
+
+	url, err := getCiaoPoolRef(cmd.name)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	if cmd.subnet != "" {
+		// verify it's a good address.
+		_, _, err := net.ParseCIDR(cmd.subnet)
+		if err != nil {
+			fatalf(err.Error())
+		}
+
+		req.Subnet = &cmd.subnet
+	} else if len(args) < 1 {
+		errorf("Missing any addresses to add")
+		cmd.usage()
+	} else {
+		for _, addr := range args {
+			// verify it's a good address
+			IP := net.ParseIP(addr)
+			if IP == nil {
+				fatalf("Invalid IP address")
+			}
+
+			newAddr := types.NewIPAddressRequest{
+				IP: addr,
+			}
+
+			req.IPs = append(req.IPs, newAddr)
+		}
+	}
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	body := bytes.NewReader(b)
+
+	ver := api.PoolsV1
+
+	resp, err := sendCiaoRequest("POST", url, nil, body, &ver)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		fatalf("Adding address failed: %s", resp.Status)
+	}
+
+	fmt.Printf("Added new address to: %s\n", cmd.name)
+
+	return nil
+}
+
+type poolRemoveCommand struct {
+	Flag   flag.FlagSet
+	name   string
+	subnet string
+	ip     string
+}
+
+func (cmd *poolRemoveCommand) usage(...string) {
+	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] pool remove [flags]
+
+Remove unmapped external IPs from a pool.
+
+The remove flags are:
+
+`)
+	cmd.Flag.PrintDefaults()
+	os.Exit(2)
+}
+
+func (cmd *poolRemoveCommand) parseArgs(args []string) []string {
+	cmd.Flag.StringVar(&cmd.name, "name", "", "Name of pool")
+	cmd.Flag.StringVar(&cmd.subnet, "subnet", "", "Subnet in CIDR format")
+	cmd.Flag.StringVar(&cmd.ip, "ip", "", "IPv4 Address")
+	cmd.Flag.Usage = func() { cmd.usage() }
+	cmd.Flag.Parse(args)
+	return cmd.Flag.Args()
+}
+
+func getSubnetRef(pool types.Pool, cidr string) string {
+	for _, sub := range pool.Subnets {
+		if sub.CIDR == cidr {
+			return getRef("self", sub.Links)
+		}
+	}
+
+	return ""
+}
+
+func getIPRef(pool types.Pool, address string) string {
+	for _, ip := range pool.IPs {
+		if ip.Address == address {
+			return getRef("self", ip.Links)
+		}
+	}
+
+	return ""
+}
+
+func (cmd *poolRemoveCommand) run(args []string) error {
+	if cmd.name == "" {
+		errorf("Missing required -name parameter")
+		cmd.usage()
+	}
+
+	if cmd.subnet == "" && cmd.ip == "" {
+		errorf("You must specify subnet or ip address to remove")
+		cmd.usage()
+	}
+
+	if cmd.subnet != "" && cmd.ip != "" {
+		errorf("You can only remove one item at a time")
+	}
+
+	pool, err := getCiaoPool(cmd.name)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	var url string
+
+	if cmd.subnet != "" {
+		url = getSubnetRef(pool, cmd.subnet)
+	}
+
+	if cmd.ip != "" {
+		url = getIPRef(pool, cmd.ip)
+	}
+
+	if url == "" {
+		fatalf("Address not present")
+	}
+
+	ver := api.PoolsV1
+
+	resp, err := sendCiaoRequest("DELETE", url, nil, nil, &ver)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		fatalf("Address removal failed: %s", resp.Status)
+	}
+
+	fmt.Printf("Removed address from pool: %s\n", cmd.name)
+	return nil
+}

--- a/ciao-cli/identity.go
+++ b/ciao-cli/identity.go
@@ -181,7 +181,7 @@ func getUserProjects(username string, password string) ([]Project, error) {
 
 	identity := fmt.Sprintf("%s/v3/users/%s/projects", *identityURL, user)
 
-	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil)
+	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func getAllProjects(username string, password string) (*IdentityProjects, error)
 
 	identity := fmt.Sprintf("%s/v3/projects", *identityURL)
 
-	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil)
+	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/ciao-controller/api/api.go
+++ b/ciao-controller/api/api.go
@@ -1,0 +1,515 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/01org/ciao/ciao-controller/types"
+	"github.com/golang/glog"
+	"github.com/gorilla/mux"
+)
+
+// Port is the default port number for the ciao API.
+const Port = 8889
+
+const (
+	// PoolsV1 is the content-type string for v1 of our pools resource
+	PoolsV1 = "x.ciao.pools.v1"
+
+	// ExternalIPsV1 is the content-type string for v1 of our external-ips resource
+	ExternalIPsV1 = "x.ciao.external-ips.v1"
+)
+
+// HTTPErrorData represents the HTTP response body for
+// a compute API request error.
+type HTTPErrorData struct {
+	Code    int    `json:"code"`
+	Name    string `json:"name"`
+	Message string `json:"message"`
+}
+
+// HTTPReturnErrorCode represents the unmarshalled version for Return codes
+// when a API call is made and you need to return explicit data of
+// the call as OpenStack format
+// http://developer.openstack.org/api-guide/compute/faults.html
+type HTTPReturnErrorCode struct {
+	Error HTTPErrorData `json:"error"`
+}
+
+// Response contains the http status and any response struct to be marshalled.
+type Response struct {
+	status   int
+	response interface{}
+}
+
+func errorResponse(err error) Response {
+	switch err {
+	case types.ErrPoolNotFound,
+		types.ErrTenantNotFound,
+		types.ErrAddressNotFound,
+		types.ErrInstanceNotFound:
+		return Response{http.StatusNotFound, nil}
+
+	case types.ErrQuota,
+		types.ErrInstanceNotAssigned,
+		types.ErrDuplicateSubnet,
+		types.ErrDuplicateIP,
+		types.ErrInvalidIP,
+		types.ErrPoolNotEmpty,
+		types.ErrInvalidPoolAddress,
+		types.ErrBadRequest,
+		types.ErrPoolEmpty:
+		return Response{http.StatusForbidden, nil}
+
+	default:
+		return Response{http.StatusInternalServerError, nil}
+	}
+}
+
+// Handler is a custom handler for the compute APIs.
+// This custom handler allows us to more cleanly return an error and response,
+// and pass some package level context into the handler.
+type Handler struct {
+	*Context
+	Handler func(*Context, http.ResponseWriter, *http.Request) (Response, error)
+}
+
+func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// set the content type to whatever was requested.
+	contentType := r.Header.Get("Content-Type")
+
+	resp, err := h.Handler(h.Context, w, r)
+	if err != nil {
+		data := HTTPErrorData{
+			Code:    resp.status,
+			Name:    http.StatusText(resp.status),
+			Message: err.Error(),
+		}
+
+		code := HTTPReturnErrorCode{
+			Error: data,
+		}
+
+		b, err := json.Marshal(code)
+		if err != nil {
+			http.Error(w, http.StatusText(resp.status), resp.status)
+		}
+
+		http.Error(w, string(b), resp.status)
+	}
+
+	b, err := json.Marshal(resp.response)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError),
+			http.StatusInternalServerError)
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	w.WriteHeader(resp.status)
+	w.Write(b)
+}
+
+func listResources(c *Context, w http.ResponseWriter, r *http.Request) (Response, error) {
+	var links []types.APILink
+	vars := mux.Vars(r)
+	tenantID, ok := vars["tenant_id"]
+
+	// we support the "pools" resource.
+	link := types.APILink{
+		Rel:        "pools",
+		Version:    PoolsV1,
+		MinVersion: PoolsV1,
+	}
+
+	if !ok {
+		link.Href = fmt.Sprintf("%s/pools", c.URL)
+	} else {
+		link.Href = fmt.Sprintf("%s/%s/pools", c.URL, tenantID)
+	}
+
+	links = append(links, link)
+
+	// we support the "external-ips" resource
+	link = types.APILink{
+		Rel:        "external-ips",
+		Version:    ExternalIPsV1,
+		MinVersion: ExternalIPsV1,
+	}
+
+	if !ok {
+		link.Href = fmt.Sprintf("%s/external-ips", c.URL)
+	} else {
+		link.Href = fmt.Sprintf("%s/%s/external-ips", c.URL, tenantID)
+	}
+
+	links = append(links, link)
+
+	return Response{http.StatusOK, links}, nil
+}
+
+func dumpPool(pool types.Pool) {
+	glog.V(2).Info("Pool")
+	glog.V(2).Info("-----------------------")
+	glog.V(2).Infof("ID: %s\n", pool.ID)
+	glog.V(2).Infof("Name: %s\n", pool.Name)
+	glog.V(2).Infof("TotalIPs: %d\n", pool.TotalIPs)
+	glog.V(2).Infof("Free: %d\n", pool.Free)
+	glog.V(2).Infof("Links: %v\n", pool.Links)
+	glog.V(2).Infof("Subnets:\n")
+
+	for _, sub := range pool.Subnets {
+		glog.V(2).Infof("%v", sub)
+	}
+}
+
+func showPool(c *Context, w http.ResponseWriter, r *http.Request) (Response, error) {
+	vars := mux.Vars(r)
+	ID := vars["pool"]
+
+	pool, err := c.ShowPool(ID)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	dumpPool(pool)
+
+	return Response{http.StatusOK, pool}, nil
+}
+
+func listPools(c *Context, w http.ResponseWriter, r *http.Request) (Response, error) {
+	var resp types.ListPoolsResponse
+	vars := mux.Vars(r)
+	_, ok := vars["tenant_id"]
+
+	pools, err := c.ListPools()
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	queries := r.URL.Query()
+
+	names, returnNamedPool := queries["name"]
+
+	for i, p := range pools {
+		dumpPool(p)
+
+		var match bool
+
+		if returnNamedPool == true {
+			for _, name := range names {
+				if name == p.Name {
+					match = true
+				}
+			}
+		} else {
+			match = true
+		}
+
+		if match {
+			summary := types.PoolSummary{
+				ID:   p.ID,
+				Name: p.Name,
+			}
+
+			if !ok {
+				summary.TotalIPs = &pools[i].TotalIPs
+				summary.Free = &pools[i].Free
+				summary.Links = pools[i].Links
+			}
+
+			resp.Pools = append(resp.Pools, summary)
+		}
+	}
+
+	return Response{http.StatusOK, resp}, err
+}
+
+func addPool(c *Context, w http.ResponseWriter, r *http.Request) (Response, error) {
+	var req types.NewPoolRequest
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	err = json.Unmarshal(body, &req)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	var ips []string
+
+	for _, ip := range req.IPs {
+		ips = append(ips, ip.IP)
+	}
+
+	_, err = c.AddPool(req.Name, req.Subnet, ips)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	return Response{http.StatusNoContent, nil}, nil
+}
+
+func deletePool(c *Context, w http.ResponseWriter, r *http.Request) (Response, error) {
+	vars := mux.Vars(r)
+	ID := vars["pool"]
+
+	err := c.DeletePool(ID)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	return Response{http.StatusNoContent, nil}, nil
+}
+
+func addToPool(c *Context, w http.ResponseWriter, r *http.Request) (Response, error) {
+	vars := mux.Vars(r)
+	ID := vars["pool"]
+
+	var req types.NewAddressRequest
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	err = json.Unmarshal(body, &req)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	var ips []string
+
+	for _, ip := range req.IPs {
+		ips = append(ips, ip.IP)
+	}
+
+	err = c.AddAddress(ID, req.Subnet, ips)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	return Response{http.StatusNoContent, nil}, nil
+}
+
+func deleteSubnet(c *Context, w http.ResponseWriter, r *http.Request) (Response, error) {
+	vars := mux.Vars(r)
+	poolID := vars["pool"]
+	subnetID := vars["subnet"]
+
+	err := c.RemoveAddress(poolID, &subnetID, nil)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	return Response{http.StatusNoContent, nil}, nil
+}
+
+func deleteExternalIP(c *Context, w http.ResponseWriter, r *http.Request) (Response, error) {
+	vars := mux.Vars(r)
+	poolID := vars["pool"]
+	IPID := vars["ip_id"]
+
+	err := c.RemoveAddress(poolID, nil, &IPID)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	return Response{http.StatusNoContent, nil}, nil
+}
+
+func listMappedIPs(c *Context, w http.ResponseWriter, r *http.Request) (Response, error) {
+	vars := mux.Vars(r)
+	tenantID, ok := vars["tenant_id"]
+	var IPs []types.MappedIP
+	var short []types.MappedIPShort
+
+	if !ok {
+		IPs = c.ListMappedAddresses(nil)
+		return Response{http.StatusOK, IPs}, nil
+	}
+
+	IPs = c.ListMappedAddresses(&tenantID)
+	for _, IP := range IPs {
+		s := types.MappedIPShort{
+			ID:         IP.ID,
+			ExternalIP: IP.ExternalIP,
+			InternalIP: IP.InternalIP,
+			Links:      IP.Links,
+		}
+		short = append(short, s)
+	}
+
+	return Response{http.StatusOK, short}, nil
+}
+
+func mapExternalIP(c *Context, w http.ResponseWriter, r *http.Request) (Response, error) {
+	var req types.MapIPRequest
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	err = json.Unmarshal(body, &req)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	err = c.MapAddress(req.PoolName, req.InstanceID)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	return Response{http.StatusNoContent, nil}, nil
+}
+
+func unmapExternalIP(c *Context, w http.ResponseWriter, r *http.Request) (Response, error) {
+	vars := mux.Vars(r)
+	tenantID, ok := vars["tenant_id"]
+	mappingID := vars["mapping_id"]
+
+	var IPs []types.MappedIP
+
+	if !ok {
+		IPs = c.ListMappedAddresses(nil)
+	} else {
+		IPs = c.ListMappedAddresses(&tenantID)
+	}
+
+	for _, m := range IPs {
+		if m.ID == mappingID {
+			err := c.UnMapAddress(m.ExternalIP)
+			if err != nil {
+				return errorResponse(err), err
+			}
+
+			return Response{http.StatusAccepted, nil}, nil
+		}
+	}
+
+	return errorResponse(types.ErrAddressNotFound), types.ErrAddressNotFound
+}
+
+// Service is an interface which must be implemented by the ciao API context.
+type Service interface {
+	AddPool(name string, subnet *string, ips []string) (types.Pool, error)
+	ListPools() ([]types.Pool, error)
+	ShowPool(id string) (types.Pool, error)
+	DeletePool(id string) error
+	AddAddress(poolID string, subnet *string, IPs []string) error
+	RemoveAddress(poolID string, subnetID *string, IPID *string) error
+	ListMappedAddresses(tenantID *string) []types.MappedIP
+	MapAddress(poolName *string, instanceID string) error
+	UnMapAddress(ID string) error
+}
+
+// Context is used to provide the services and current URL to the handlers.
+type Context struct {
+	URL string
+	Service
+}
+
+// Config is used to setup the Context for the ciao API.
+type Config struct {
+	URL         string
+	CiaoService Service
+}
+
+// Routes returns the supported ciao API endpoints.
+// A plain application/json request will return v1 of the resource
+// since we only have one version of this api so far, that means
+// most routes will match both json as well as our custom
+// content type.
+func Routes(config Config) *mux.Router {
+	// make new Context
+	context := &Context{config.URL, config.CiaoService}
+
+	r := mux.NewRouter()
+
+	// external IP pools
+	route := r.Handle("/", Handler{context, listResources})
+	route.Methods("GET")
+
+	route = r.Handle("/{tenant_id:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8|9|aA|bB][a-f0-9]{3}-[a-f0-9]{12}}", Handler{context, listResources})
+	route.Methods("GET")
+
+	matchContent := fmt.Sprintf("application/(%s|json)", PoolsV1)
+
+	route = r.Handle("/pools", Handler{context, listPools})
+	route.Methods("GET")
+	route.HeadersRegexp("Content-Type", matchContent)
+
+	route = r.Handle("/{tenant_id:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8|9|aA|bB][a-f0-9]{3}-[a-f0-9]{12}}/pools", Handler{context, listPools})
+	route.Methods("GET")
+	route.HeadersRegexp("Content-Type", matchContent)
+
+	route = r.Handle("/pools", Handler{context, addPool})
+	route.Methods("POST")
+	route.HeadersRegexp("Content-Type", matchContent)
+
+	route = r.Handle("/pools/{pool:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8|9|aA|bB][a-f0-9]{3}-[a-f0-9]{12}}", Handler{context, showPool})
+	route.Methods("GET")
+	route.HeadersRegexp("Content-Type", matchContent)
+
+	route = r.Handle("/pools/{pool:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8|9|aA|bB][a-f0-9]{3}-[a-f0-9]{12}}", Handler{context, deletePool})
+	route.Methods("DELETE")
+	route.HeadersRegexp("Content-Type", matchContent)
+
+	route = r.Handle("/pools/{pool:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8|9|aA|bB][a-f0-9]{3}-[a-f0-9]{12}}", Handler{context, addToPool})
+	route.Methods("POST")
+	route.HeadersRegexp("Content-Type", matchContent)
+
+	route = r.Handle("/pools/{pool:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8|9|aA|bB][a-f0-9]{3}-[a-f0-9]{12}}/subnets/{subnet:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8|9|aA|bB][a-f0-9]{3}-[a-f0-9]{12}}", Handler{context, deleteSubnet})
+	route.Methods("DELETE")
+	route.HeadersRegexp("Content-Type", matchContent)
+
+	route = r.Handle("/pools/{pool:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8|9|aA|bB][a-f0-9]{3}-[a-f0-9]{12}}/external-ips/{ip_id:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8|9|aA|bB][a-f0-9]{3}-[a-f0-9]{12}}", Handler{context, deleteExternalIP})
+	route.Methods("DELETE")
+	route.HeadersRegexp("Content-Type", matchContent)
+
+	// mapped external IPs
+	matchContent = fmt.Sprintf("application/(%s|json)", ExternalIPsV1)
+
+	route = r.Handle("/external-ips", Handler{context, listMappedIPs})
+	route.Methods("GET")
+	route.HeadersRegexp("Content-Type", matchContent)
+
+	route = r.Handle("/{tenant_id:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8|9|aA|bB][a-f0-9]{3}-[a-f0-9]{12}}/external-ips", Handler{context, listMappedIPs})
+	route.Methods("GET")
+	route.HeadersRegexp("Content-Type", matchContent)
+
+	route = r.Handle("/external-ips", Handler{context, mapExternalIP})
+	route.Methods("POST")
+	route.HeadersRegexp("Content-Type", matchContent)
+
+	route = r.Handle("/{tenant_id:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8|9|aA|bB][a-f0-9]{3}-[a-f0-9]{12}}/external-ips", Handler{context, mapExternalIP})
+	route.Methods("POST")
+	route.HeadersRegexp("Content-Type", matchContent)
+
+	route = r.Handle("/external-ips/{mapping_id:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8|9|aA|bB][a-f0-9]{3}-[a-f0-9]{12}}", Handler{context, unmapExternalIP})
+	route.Methods("DELETE")
+	route.HeadersRegexp("Content-Type", matchContent)
+
+	route = r.Handle("/{tenant_id:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8|9|aA|bB][a-f0-9]{3}-[a-f0-9]{12}}/external-ips/{mapping_id:[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[8|9|aA|bB][a-f0-9]{3}-[a-f0-9]{12}}", Handler{context, unmapExternalIP})
+	route.Methods("DELETE")
+	route.HeadersRegexp("Content-Type", matchContent)
+	return r
+}

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -1,0 +1,285 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/01org/ciao/ciao-controller/types"
+)
+
+type test struct {
+	method           string
+	pattern          string
+	handler          func(*Context, http.ResponseWriter, *http.Request) (Response, error)
+	request          string
+	media            string
+	expectedStatus   int
+	expectedResponse string
+}
+
+func myHostname() string {
+	host, _ := os.Hostname()
+	return host
+}
+
+var tests = []test{
+	{
+		"GET",
+		"/",
+		listResources,
+		"",
+		"application/text",
+		http.StatusOK,
+		`[{"rel":"pools","href":"/pools","version":"x.ciao.pools.v1","minimum_version":"x.ciao.pools.v1"},{"rel":"external-ips","href":"/external-ips","version":"x.ciao.external-ips.v1","minimum_version":"x.ciao.external-ips.v1"}]`,
+	},
+	{
+		"GET",
+		"/pools",
+		listPools,
+		"",
+		"application/x.ciao.v1.pools",
+		http.StatusOK,
+		`{"pools":[{"id":"validID","name":"testpool","free":0,"total_ips":0,"links":[{"rel":"self","href":"/pools/validID"}]}]}`,
+	},
+	{
+		"GET",
+		"/pools?name=testpool",
+		listPools,
+		"",
+		"application/x.ciao.v1.pools",
+		http.StatusOK,
+		`{"pools":[{"id":"validID","name":"testpool","free":0,"total_ips":0,"links":[{"rel":"self","href":"/pools/validID"}]}]}`,
+	},
+	{
+		"POST",
+		"/pools",
+		addPool,
+		`{"name":"testpool"}`,
+		"application/x.ciao.v1.pools",
+		http.StatusNoContent,
+		"null",
+	},
+	{
+		"GET",
+		"/pools/validID",
+		showPool,
+		"",
+		"application/x.ciao.v1.pools",
+		http.StatusOK,
+		`{"id":"validID","name":"testpool","free":0,"total_ips":0,"links":[{"rel":"self","href":"/pools/validID"}],"subnets":[],"ips":[]}`,
+	},
+	{
+		"DELETE",
+		"/pools/validID",
+		deletePool,
+		"",
+		"application/x.ciao.v1.pools",
+		http.StatusNoContent,
+		"null",
+	},
+	{
+		"POST",
+		"/pools/validID",
+		addToPool,
+		`{"subnet":"192.168.0.0/24"}`,
+		"application/x.ciao.v1.pools",
+		http.StatusNoContent,
+		"null",
+	},
+	{
+		"DELETE",
+		"/pools/validID/subnets/validID",
+		deleteSubnet,
+		"",
+		"application/x.ciao.v1.pools",
+		http.StatusNoContent,
+		"null",
+	},
+	{
+		"DELETE",
+		"/pools/validID/external-ips/validID",
+		deleteExternalIP,
+		"",
+		"application/x.ciao.v1.pools",
+		http.StatusNoContent,
+		"null",
+	},
+	{
+		"GET",
+		"/external-ips",
+		listMappedIPs,
+		"",
+		ExternalIPsV1,
+		http.StatusOK,
+		`[{"mapping_id":"validID","external_ip":"192.168.0.1","internal_ip":"172.16.0.1","instance_id":"","tenant_id":"validtenant","pool_id":"validpool","pool_name":"mypool","links":[{"rel":"self","href":"/external-ips/validID"},{"rel":"pool","href":"/pools/validpool"}]}]`,
+	},
+	{
+		"POST",
+		"/validID/external-ips",
+		mapExternalIP,
+		`{"pool_name":"apool","instance_id":"validinstanceID"}`,
+		"application/x.ciao.v1.pools",
+		http.StatusNoContent,
+		"null",
+	},
+}
+
+type testCiaoService struct{}
+
+func (ts testCiaoService) ListPools() ([]types.Pool, error) {
+	self := types.Link{
+		Rel:  "self",
+		Href: "/pools/validID",
+	}
+
+	resp := types.Pool{
+		ID:       "validID",
+		Name:     "testpool",
+		Free:     0,
+		TotalIPs: 0,
+		Subnets:  []types.ExternalSubnet{},
+		IPs:      []types.ExternalIP{},
+		Links:    []types.Link{self},
+	}
+
+	return []types.Pool{resp}, nil
+}
+
+func (ts testCiaoService) AddPool(name string, subnet *string, ips []string) (types.Pool, error) {
+	return types.Pool{}, nil
+}
+
+func (ts testCiaoService) ShowPool(id string) (types.Pool, error) {
+	self := types.Link{
+		Rel:  "self",
+		Href: "/pools/validID",
+	}
+
+	resp := types.Pool{
+		ID:       "validID",
+		Name:     "testpool",
+		Free:     0,
+		TotalIPs: 0,
+		Subnets:  []types.ExternalSubnet{},
+		IPs:      []types.ExternalIP{},
+		Links:    []types.Link{self},
+	}
+
+	return resp, nil
+}
+
+func (ts testCiaoService) DeletePool(id string) error {
+	return nil
+}
+
+func (ts testCiaoService) AddAddress(poolID string, subnet *string, ips []string) error {
+	return nil
+}
+
+func (ts testCiaoService) RemoveAddress(poolID string, subnet *string, extIP *string) error {
+	return nil
+}
+
+func (ts testCiaoService) ListMappedAddresses(tenant *string) []types.MappedIP {
+	var ref string
+
+	m := types.MappedIP{
+		ID:         "validID",
+		ExternalIP: "192.168.0.1",
+		InternalIP: "172.16.0.1",
+		TenantID:   "validtenant",
+		PoolID:     "validpool",
+		PoolName:   "mypool",
+	}
+
+	if tenant != nil {
+		ref = fmt.Sprintf("%s/external-ips/%s", *tenant, m.ID)
+	} else {
+		ref = fmt.Sprintf("/external-ips/%s", m.ID)
+	}
+
+	link := types.Link{
+		Rel:  "self",
+		Href: ref,
+	}
+
+	m.Links = []types.Link{link}
+
+	if tenant == nil {
+		ref := fmt.Sprintf("/pools/%s", m.PoolID)
+
+		link := types.Link{
+			Rel:  "pool",
+			Href: ref,
+		}
+
+		m.Links = append(m.Links, link)
+	}
+
+	return []types.MappedIP{m}
+}
+
+func (ts testCiaoService) MapAddress(name *string, instanceID string) error {
+	return nil
+}
+
+func (ts testCiaoService) UnMapAddress(string) error {
+	return nil
+}
+
+func TestResponse(t *testing.T) {
+	var ts testCiaoService
+
+	context := &Context{"", ts}
+
+	for _, tt := range tests {
+		req, err := http.NewRequest(tt.method, tt.pattern, bytes.NewBuffer([]byte(tt.request)))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req.Header.Set("Content-Type", tt.media)
+
+		rr := httptest.NewRecorder()
+		handler := Handler{context, tt.handler}
+
+		handler.ServeHTTP(rr, req)
+
+		status := rr.Code
+		if status != tt.expectedStatus {
+			t.Errorf("got %v, expected %v", status, tt.expectedStatus)
+		}
+
+		if rr.Body.String() != tt.expectedResponse {
+			t.Errorf("%s: failed\ngot: %v\nexp: %v", tt.pattern, rr.Body.String(), tt.expectedResponse)
+		}
+	}
+}
+
+func TestRoutes(t *testing.T) {
+	var ts testCiaoService
+	config := Config{"", ts}
+
+	r := Routes(config)
+	if r == nil {
+		t.Fatalf("No routes returned")
+	}
+}

--- a/ciao-controller/external_ip.go
+++ b/ciao-controller/external_ip.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+
+	"github.com/01org/ciao/ciao-controller/types"
+)
+
+func (c *controller) AddPool(name string, subnet *string, ips []string) (types.Pool, error) {
+	return types.Pool{}, errors.New("Not Implemented Yet")
+}
+
+func (c *controller) ListPools() ([]types.Pool, error) {
+	return []types.Pool{}, errors.New("Not Implemented Yet")
+}
+
+func (c *controller) ShowPool(ID string) (types.Pool, error) {
+	return types.Pool{}, errors.New("Not Implemented Yet")
+}
+
+func (c *controller) AddAddress(poolID string, subnet *string, ips []string) error {
+	return errors.New("Not Implemented Yet")
+}
+
+func (c *controller) DeletePool(ID string) error {
+	return errors.New("Not Implemented Yet")
+}
+
+func (c *controller) RemoveAddress(poolID string, subnetID *string, IPID *string) error {
+	return errors.New("Not Implemented Yet")
+}
+
+func (c *controller) ListMappedAddresses(tenant *string) []types.MappedIP {
+	return []types.MappedIP{}
+}
+
+func (c *controller) MapAddress(poolName *string, instanceID string) error {
+	return errors.New("Not Implemented Yet")
+}
+
+func (c *controller) UnMapAddress(address string) error {
+	return errors.New("Not Implemented Yet")
+}

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -25,21 +25,27 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"sync"
 
+	"github.com/01org/ciao/ciao-controller/api"
 	datastore "github.com/01org/ciao/ciao-controller/internal/datastore"
 	image "github.com/01org/ciao/ciao-image/client"
 	storage "github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/openstack/block"
 	"github.com/01org/ciao/openstack/compute"
+	osIdentity "github.com/01org/ciao/openstack/identity"
 	osimage "github.com/01org/ciao/openstack/image"
 	"github.com/01org/ciao/osprepare"
 	"github.com/01org/ciao/ssntp"
 	"github.com/01org/ciao/testutil"
 	"github.com/golang/glog"
+	"github.com/gorilla/mux"
 )
 
 type controller struct {
@@ -49,6 +55,7 @@ type controller struct {
 	ds     *datastore.Datastore
 	id     *identity
 	image  image.Client
+	apiURL string
 }
 
 var singleMachine = flag.Bool("single", false, "Enable single machine test")
@@ -61,6 +68,7 @@ var servicePassword = ""
 var volumeAPIPort = block.APIPort
 var computeAPIPort = compute.APIPort
 var imageAPIPort = osimage.APIPort
+var controllerAPIPort = api.Port
 var httpsCAcert = "/etc/pki/ciao/ciao-controller-cacert.pem"
 var httpsKey = "/etc/pki/ciao/ciao-controller-key.pem"
 var tablesInitPath = flag.String("tables_init_path", "./tables", "path to csv files")
@@ -198,7 +206,61 @@ func main() {
 	wg.Add(1)
 	go ctl.startVolumeService()
 
+	host, _ := os.Hostname()
+	ctl.apiURL = fmt.Sprintf("https://%s:%d", host, controllerAPIPort)
+
+	wg.Add(1)
+	go ctl.startCiaoService()
+
 	wg.Wait()
 	ctl.ds.Exit()
 	ctl.client.Disconnect()
+}
+
+func (c *controller) startCiaoService() error {
+	config := api.Config{URL: c.apiURL, CiaoService: c}
+
+	r := api.Routes(config)
+	if r == nil {
+		return errors.New("Unable to start Ciao API Service")
+	}
+
+	// wrap each route in keystone validation.
+	validServices := []osIdentity.ValidService{
+		{ServiceType: "compute", ServiceName: "ciao"},
+		{ServiceType: "compute", ServiceName: "nova"},
+	}
+
+	validAdmins := []osIdentity.ValidAdmin{
+		{Project: "service", Role: "admin"},
+		{Project: "admin", Role: "admin"},
+	}
+
+	err := r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+		h := osIdentity.Handler{
+			Client:        c.id.scV3,
+			Next:          route.GetHandler(),
+			ValidServices: validServices,
+			ValidAdmins:   validAdmins,
+		}
+
+		route.Handler(h)
+
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	service := fmt.Sprintf(":%d", controllerAPIPort)
+
+	glog.Infof("Starting ciao API on port %d\n", controllerAPIPort)
+
+	err = http.ListenAndServeTLS(service, httpsCAcert, httpsKey, r)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	return nil
 }

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -511,4 +511,131 @@ var (
 
 	// ErrInstanceNotAssigned is returned when an instance is not assigned to a node.
 	ErrInstanceNotAssigned = errors.New("Cannot perform operation: instance not assigned to Node")
+
+	// ErrDuplicateSubnet is returned when a subnet already exists
+	ErrDuplicateSubnet = errors.New("Cannot add overlapping subnet")
+
+	// ErrDuplicateIP is returned when a duplicate external IP is added
+	ErrDuplicateIP = errors.New("Cannot add duplicated external IP")
+
+	// ErrInvalidIP is returned when an IP cannot be parsed
+	ErrInvalidIP = errors.New("The IP Address is not valid")
+
+	// ErrPoolNotFound is returned when an external IP pool is not found
+	ErrPoolNotFound = errors.New("Pool not found")
+
+	// ErrPoolNotEmpty is returned when a pool is still in use
+	ErrPoolNotEmpty = errors.New("Pool has mapped IPs")
+
+	// ErrAddressNotFound is returned when an address isn't found.
+	ErrAddressNotFound = errors.New("Address Not Found")
+
+	// ErrInvalidPoolAddress is returned when an address isn't part of a pool
+	ErrInvalidPoolAddress = errors.New("The Address is not found in this pool")
+
+	// ErrBadRequest is returned when we have a malformed request
+	ErrBadRequest = errors.New("Invalid Request")
+
+	// ErrPoolEmpty is returned when a pool has no free IPs
+	ErrPoolEmpty = errors.New("Pool has no Free IPs")
 )
+
+// Link provides a url and relationship for a resource.
+type Link struct {
+	Rel  string `json:"rel"`
+	Href string `json:"href"`
+}
+
+// APILink provides information and links about a supported resource.
+type APILink struct {
+	Rel        string `json:"rel"`
+	Href       string `json:"href"`
+	Version    string `json:"version"`
+	MinVersion string `json:"minimum_version"`
+}
+
+// ExternalSubnet represents a subnet for External IPs.
+type ExternalSubnet struct {
+	ID    string `json:"id"`
+	CIDR  string `json:"subnet"`
+	Links []Link `json:"links"`
+}
+
+// ExternalIP represents an External IP individual address.
+type ExternalIP struct {
+	ID      string `json:"id"`
+	Address string `json:"address"`
+	Links   []Link `json:"links"`
+}
+
+// Pool represents a pool of external IPs.
+type Pool struct {
+	ID       string           `json:"id"`
+	Name     string           `json:"name"`
+	Free     int              `json:"free"`
+	TotalIPs int              `json:"total_ips"`
+	Links    []Link           `json:"links"`
+	Subnets  []ExternalSubnet `json:"subnets"`
+	IPs      []ExternalIP     `json:"ips"`
+}
+
+// NewPoolRequest is used to create a new pool.
+type NewPoolRequest struct {
+	Name   string  `json:"name"`
+	Subnet *string `json:"subnet"`
+	IPs    []struct {
+		IP string `json:"ip"`
+	} `json:"ips"`
+}
+
+// PoolSummary is a short form of Pool.
+type PoolSummary struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Free     *int   `json:"free,omitempty"`
+	TotalIPs *int   `json:"total_ips,omitempty"`
+	Links    []Link `json:"links,omitempty"`
+}
+
+// ListPoolsResponse respresents a summary list of all pools.
+type ListPoolsResponse struct {
+	Pools []PoolSummary `json:"pools"`
+}
+
+// NewIPAddressRequest is used to add a new external IP to a pool.
+type NewIPAddressRequest struct {
+	IP string `json:"ip"`
+}
+
+// NewAddressRequest is used to add a new IP or new subnet to a pool.
+type NewAddressRequest struct {
+	Subnet *string               `json:"subnet"`
+	IPs    []NewIPAddressRequest `json:"ips"`
+}
+
+// MappedIP represents a mapping of external IP -> instance IP.
+type MappedIP struct {
+	ID         string `json:"mapping_id"`
+	ExternalIP string `json:"external_ip"`
+	InternalIP string `json:"internal_ip"`
+	InstanceID string `json:"instance_id"`
+	TenantID   string `json:"tenant_id"`
+	PoolID     string `json:"pool_id"`
+	PoolName   string `json:"pool_name"`
+	Links      []Link `json:"links"`
+}
+
+// MappedIPShort is a summary version of a MappedIP.
+type MappedIPShort struct {
+	ID         string `json:"mapping_id"`
+	ExternalIP string `json:"external_ip"`
+	InternalIP string `json:"internal_ip"`
+	Links      []Link `json:"links"`
+}
+
+// MapIPRequest is used to request that an external IP be assigned from a pool
+// to a particular instance.
+type MapIPRequest struct {
+	PoolName   *string `json:"pool_name"`
+	InstanceID string  `json:"instance_id"`
+}


### PR DESCRIPTION
Modify ciao-controller to add a stubbed out api for external IPs and pools. Modify ciao-cli to use the API to allow the user to interact with the pools and external IPs resources.