### PR TITLE
contributing: Add an exception for commit message summaries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,9 @@ For example:
 	Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>
 ```
 
+Under exceptional circumstances, if the patch is fixing a typo in a comment for
+instance, it is acceptable to omit the detailed explanation.
+
 ## Pull requests
 
 We accept github pull requests.


### PR DESCRIPTION
I have a couple of trivial commits (eg. fixing a typo in a commit) that
don't really need a summary. Not even sure what I'd say!

    ciao-vendor: Fix depdenency typo

    Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>

And currently that's preventing a PR to be merged.

So, proposing to be a bit more precise in CONTRIBUTING.md.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>