### PR TITLE
Add ciao-cli image show and templates to ciao-cli image add

### DIFF
--- a/ciao-cli/image.go
+++ b/ciao-cli/image.go
@@ -109,6 +109,7 @@ type imageAddCommand struct {
 	protected       bool
 	tags            string
 	file            string
+	template        string
 }
 
 func (cmd *imageAddCommand) usage(...string) {
@@ -120,6 +121,11 @@ The add flags are:
 
 `)
 	cmd.Flag.PrintDefaults()
+	fmt.Fprintf(os.Stderr, `
+The template passed to the -f option operates on a 
+
+%s
+`, imageTemplateDesc)
 	os.Exit(2)
 }
 
@@ -136,6 +142,7 @@ func (cmd *imageAddCommand) parseArgs(args []string) []string {
 	cmd.Flag.BoolVar(&cmd.protected, "protected", false, "Prevent an image from being deleted")
 	cmd.Flag.StringVar(&cmd.tags, "tags", "", "Image tags separated by comma")
 	cmd.Flag.StringVar(&cmd.file, "file", "", "Image file to upload")
+	cmd.Flag.StringVar(&cmd.template, "f", "", "Template used to format output")
 	cmd.Flag.Usage = func() { cmd.usage() }
 	cmd.Flag.Parse(args)
 	return cmd.Flag.Args()
@@ -183,6 +190,10 @@ func (cmd *imageAddCommand) run(args []string) error {
 		if err != nil {
 			fatalf("Could not retrieve new created image [%s]\n", err)
 		}
+	}
+
+	if cmd.template != "" {
+		return outputToTemplate("image-add", cmd.template, image)
 	}
 
 	fmt.Printf("Created image:\n")

--- a/ciao-image/service/service.go
+++ b/ciao-image/service/service.go
@@ -149,12 +149,16 @@ func (is ImageService) DeleteImage(imageID string) (image.NoContentImageResponse
 func (is ImageService) GetImage(imageID string) (image.DefaultResponse, error) {
 	var response image.DefaultResponse
 
-	image, err := is.ds.GetImage(imageID)
+	img, err := is.ds.GetImage(imageID)
 	if err != nil {
 		return response, err
 	}
 
-	response, _ = createImageResponse(image)
+	if (img == datastore.Image{}) {
+		return response, image.ErrNoImage
+	}
+
+	response, _ = createImageResponse(img)
 	return response, nil
 }
 


### PR DESCRIPTION
This PR adds the missing ciao-cli image show command.  The functionality was already supported by the image service but there was no corresponding ciao-cli command.  Now there is.  In adding this command, a small problem with the image service was also fixed, in which an empty image was returned, instead of an error, the ID of a requested image did not exist.

The second commit adds a -f option to the ciao-cli image add command.  This will allow one to easily determine the IDs of newly created images.

Fixes #794 