### PR TITLE
ansible: Retry Create custom projects task

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/roles/keystone/tasks/access.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/keystone/tasks/access.yml
@@ -41,6 +41,14 @@
       login_project_name: "admin"
       insecure: yes
     with_items: "{{ keystone_projects | default([]) }}"
+    # TODO: Remove the following workaround
+    # There is an issue with clearcontainers where it says the port is open
+    # even when it is not ready yet.
+    # https://github.com/01org/cc-oci-runtime/issues/349
+    register: result
+    until: result.failed == false or result.failed is undefined
+    retries: 10
+    delay: 1
 
   - name: Create custom roles
     keystone:


### PR DESCRIPTION
The keystone role has a task to wait for port 5000 to be open before
trying to send request to create services, projects, etc. But there
is an issue with clearcontainers [1] where the port is reported to be
open even if the application has not been started inside the container.

This change adds a workaround to retry the Create custom project task
to avoid the scripts from failing when running in clearlinux with
clearcontainers.

[1] https://github.com/01org/cc-oci-runtime/issues/349

Fixes #788

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>