### PR TITLE
ansible: Optionally skip ceph configuration on ciao nodes

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/doc/development.md
+++ b/_DeploymentAndDistroPackaging/ansible/doc/development.md
@@ -1,8 +1,16 @@
 # Development Mode
-This playbooks installs ciao from the latest ciao packaged for your distro.
+By default, these playbooks install ciao on production environments from
+the latest packages available for each supported distro.
 
-If you want to try the latest features, there is a way to use this playbook to
-deploy ciao from github.com/01org/ciao master branch source code.
+However, there are some options that can be specified when running the playbooks
+to alter this default behaviour. These options are useful during development and
+are described in more detail below:
 
-Set `ciao_dev = True` in [group_vars/all](../group_vars/all) file or pass the
+## Deploy from source code
+In order to deploy ciao from the master branch in github set `ciao_dev = True` in [group_vars/all](../group_vars/all) file or pass the
 command line argument `--extra-vars "ciao_dev=true"`
+
+## Skip ceph configuration
+If you plan to manually setup ceph in your ciao nodes set `skip_ceph = True`
+in [group_vars/all](../group_vars/all) file or pass the command line argument
+`--extra-vars "skip_ceph=true"`

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/README.md
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/README.md
@@ -10,6 +10,7 @@ The following variables are available for all ciao roles
 Variable  | Default Value | Description
 --------  | ------------- | -----------
 cephx_user | admin | cephx user to login into the ceph cluster
+skip_ceph | False | When set to true, ansible will not configure ceph on Ciao nodes
 ciao_dev | False | Set to True to install from source, otherwise install form OS packages
 gopath | /tmp/go | golang GOPATH
 ciao_controller_fqdn | `{{ ansible_fqdn }}` | FQDN for CIAO controller node

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/defaults/main.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/defaults/main.yml
@@ -44,5 +44,8 @@ clear_cloud_image_url: https://download.clearlinux.org/releases/10820/clear/clea
 # Clearlinux cloud image file name
 clear_cloud_image: "{{ clear_cloud_image_url.split('/') | last | regex_replace('(.*).xz', '\\1') }}"
 
+# Set to true to skip ceph configuration in ciao nodes
+skip_ceph: False
+
 # cephx user
 cephx_user: admin

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/tasks/main.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/tasks/main.yml
@@ -52,3 +52,4 @@
     when: not ciao_dev
 
   - include: ceph.yml
+    when: not skip_ceph


### PR DESCRIPTION
Ciao requires a ceph cluster to be available for all ciao nodes.

The deployment playbook requires that the systadmin provides ceph
configuration and secret files in order to configure ceph on all
ciao nodes.

This changes introduces `skip_ceph` variable which allows the deployment
to skip ceph configuration and leave that step to be performed manually
by the sysadmin.

Fixes #782

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>