### PR TITLE
ciao-deployment: Fix ownership of /etc/systemd/system

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/tasks/main.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/tasks/main.yml
@@ -32,7 +32,9 @@
       - /etc/pki
       - /etc/pki/ciao
       - /etc/pki/keystone
-      - /etc/systemd/system
+
+  - name: Create /etc/systemd/system if it does not exists
+    file: path=/etc/systemd/system state=directory owner=root group=root
 
   - name: Set bindir location
     set_fact: bindir={{ '/usr/local/bin' if ciao_dev else '/usr/bin' }}


### PR DESCRIPTION
Add a separate task in order to create the /etc/systemd/system
directory and make sure it belongs to root.

Fixes https://github.com/01org/ciao/issues/820