### PR TITLE
BAT testing for ceph storage backend

### DIFF
--- a/_release/bat/README.md
+++ b/_release/bat/README.md
@@ -6,8 +6,9 @@ the following sub folders.
 
 ```
 .
-├── base_bat   - Basic tests that verify that the cluster is functional
-├── image_bat  - BAT tests for the image service
+├── base_bat     - Basic tests that verify that the cluster is functional
+├── image_bat    - BAT tests for the image service
+├── storage_bat  - Storage related BAT tests
 ```
 
 The tests are implemented using the go testing framework.  This is convenient

--- a/_release/bat/image_bat/image_bat_test.go
+++ b/_release/bat/image_bat/image_bat_test.go
@@ -18,9 +18,7 @@ package image_bat
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -31,34 +29,8 @@ import (
 
 const standardTimeout = time.Second * 300
 
-func createRandomFile(sizeMB int) (path string, err error) {
-	var f *os.File
-	f, err = ioutil.TempFile("/tmp", "image-")
-	if err != nil {
-		return
-	}
-	defer func() {
-		err1 := f.Close()
-		if err1 != nil && err == nil {
-			err = err1
-		}
-	}()
-
-	b := make([]byte, sizeMB*1000000)
-	_, err = rand.Read(b)
-	if err != nil {
-		return
-	}
-	_, err = f.Write(b)
-	if err == nil {
-		path = f.Name()
-	}
-
-	return
-}
-
 func addRandomImage(ctx context.Context, tenant string, size int, options *bat.ImageOptions) (*bat.Image, error) {
-	path, err := createRandomFile(size)
+	path, err := bat.CreateRandomFile(size)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to create random file : %v", err)
 	}

--- a/_release/bat/storage_bat/ceph_test.go
+++ b/_release/bat/storage_bat/ceph_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage_bat
+
+import (
+	"os"
+	"testing"
+
+	"github.com/01org/ciao/bat"
+	"github.com/01org/ciao/ciao-storage"
+)
+
+var driver = storage.CephDriver{
+	ID: "ciao",
+}
+
+// Check creating a ceph backed block device works
+//
+// TestCreateBlockDevice creates a block device containing some random data,
+// checks for errors and then deletes it.
+func TestCreateBlockDevice(t *testing.T) {
+	path, err := bat.CreateRandomFile(20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+
+	device, err := driver.CreateBlockDevice(&path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = driver.DeleteBlockDevice(device.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Check copying a ceph backed block device works
+//
+// TestCopyBlockDevice creates a block device containing some random data,
+// checks for errors and then copies it. The created volumes are then
+// deleted.
+func TestCopyBlockDevice(t *testing.T) {
+	path, err := bat.CreateRandomFile(20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+
+	device, err := driver.CreateBlockDevice(&path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	copy, err := driver.CopyBlockDevice(device.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = driver.DeleteBlockDevice(copy.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = driver.DeleteBlockDevice(device.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/_release/bat/storage_bat/storage_bat.go
+++ b/_release/bat/storage_bat/storage_bat.go
@@ -1,3 +1,4 @@
+//
 // Copyright (c) 2016 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,32 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
-package storage
-
-import (
-	"fmt"
-	"testing"
-)
-
-var driver = CephDriver{
-	ID: "kristen",
-}
-
-var imagePath = "/var/lib/ciao/images/73a86d7e-93c0-480e-9c41-ab42f69b7799"
-
-func TestCreateBlockDevice(t *testing.T) {
-	device, err := driver.CreateBlockDevice(&imagePath, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	fmt.Println(device.ID)
-}
-
-func TestDeleteBlockDevice(t *testing.T) {
-	err := driver.DeleteBlockDevice(imagePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
+// storage_bat is a placeholder package for storage related BAT tests.
+package storage_bat

--- a/bat/bat.go
+++ b/bat/bat.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -723,4 +724,32 @@ func UploadImage(ctx context.Context, tenant, ID, path string) error {
 	args := []string{"image", "upload", "-image", ID, "-file", path}
 	_, err := RunCIAOCLIAsAdmin(ctx, tenant, args)
 	return err
+}
+
+// CreateRandomFile creates a file of the desired size with random data
+// returning the path.
+func CreateRandomFile(sizeMB int) (path string, err error) {
+	var f *os.File
+	f, err = ioutil.TempFile("/tmp", "ciao-random-")
+	if err != nil {
+		return
+	}
+	defer func() {
+		err1 := f.Close()
+		if err1 != nil && err == nil {
+			err = err1
+		}
+	}()
+
+	b := make([]byte, sizeMB*1000000)
+	_, err = rand.Read(b)
+	if err != nil {
+		return
+	}
+	_, err = f.Write(b)
+	if err == nil {
+		path = f.Name()
+	}
+
+	return
 }


### PR DESCRIPTION
Migrate ceph_test.go from ciao-storage to the BAT tests as this test requires a working ceph setup in order to be able to function.

More tests will be added when the ceph driver changes for images as volumes are added.