### PR TITLE
ansible: Install docker-py on fedora from docker role

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/roles/docker/tasks/install_fedora.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/docker/tasks/install_fedora.yml
@@ -24,4 +24,7 @@
       gpgcheck: yes
 
   - name: Install docker (Fedora)
-    dnf: name=docker-engine state=present
+    dnf: name={{ item }} state=present
+    with_items:
+      - docker-engine
+      - python-docker-py


### PR DESCRIPTION
docker-py is required to interact with docker from python.
Ubuntu installs the package as dependency of docker-engine
but fedora doesn't

This change installs docker-py on fedora from the docker role.

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>