### PR TITLE
ansible: `ciao_guest_key` var to contain workload pubkey

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/README.md
+++ b/_DeploymentAndDistroPackaging/ansible/README.md
@@ -47,7 +47,8 @@ compute2.example.com
 compute3.example.com
 ```
 
-Optionally edit [group_vars/all](group_vars/all) file to change default passwords and other settings
+It's also encouraged to edit [group_vars/all](group_vars/all) file
+to change default passwords and other settings.
 
 ### Gather ceph config files
 Ciao storage is implemented to use ceph as its storage backend. For this reason all ciao nodes
@@ -88,6 +89,12 @@ in the CNCI image by using the `losetup` command. Because we need to access
 `/dev/loop*` devices, we also need to mount `/dev/` into the container.
 To learn more about the Docker options used, please refer to the
 [Docker documentation](https://docs.docker.com/engine/reference/commandline/run/).
+
+### Default guest ssh public key
+the `group_vars/all` file contains a default public ssh-key which is used
+to access the guest VMs ciao launches. We strongly encourage the user to
+change the content of the `ciao_guest_key` variable for a known ssh-key,
+otherwise the guests won't be accessible using the default value.
 
 ### A note on docker hostname resolution
 This playbook uses docker containers to start the [identity service](https://hub.docker.com/r/clearlinux/keystone/) and [ciao-webui](https://hub.docker.com/r/clearlinux/ciao-webui/).

--- a/_DeploymentAndDistroPackaging/ansible/group_vars/all
+++ b/_DeploymentAndDistroPackaging/ansible/group_vars/all
@@ -14,7 +14,7 @@ ciao_controller_fqdn: "{{ controller_fqdn }}"
 ciao_service_user: ciao
 ciao_service_password: ciaoUserPassword
 ciao_guest_user: demouser
-ciao_guest_key: ~/.ssh/id_rsa.pub
+ciao_guest_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDB34XG8nbwKyrTiB83kqe2I25P9A8aNU2iTd4AsvnQgM9QbjE9tzndggeOLkz5Ea/IJegOJWfsiDu4ExJ3qXNYqfEFiam8FTdeOVLXkHu6MKpO1pQgmAiJTOO2NMeNqGPFCMAj0ogcKL2/Hl5JAdh+4aK1tLZHdqKTpJGwLp6jP1wo3w5lu0V/oBEPN4qwpzj+S+/6Z6P/cB9rwfTGCbhTyMGdkpj8SIFwhIBTKWYzjxYQMRpbpijXNDSeOekd6L2+QTPRdnEm2+Nh3MFrz5enDZrCGdP7f5nrO3fepz00wtTKcn5rg+0tyuZUNpUwsi40alVvJ6syfPSCRcbGpEDB demouser@localhost
 
 # Create a demo project and a demo user for ciao
 keystone_projects:

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/README.md
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/README.md
@@ -24,7 +24,7 @@ ciao_service_password | ciaoUserPassword | Password for `ciao_service_user`
 ciao_admin_email | admin@example.com | CIAO administrator email address
 ciao_cert_organization | Example Inc. | Name of the organization running the CIAO cluster
 ciao_guest_user | demouser | CIAO virtual machines can be accessed with this username and it's public key
-ciao_guest_key | ~/.ssh/id_rsa.pub | A path to an SSH public authentication key for `ciao_guest_user`
+ciao_guest_key | default ssh public key | SSH public authentication key for `ciao_guest_user`
 ceph_id | admin | Cephx user to authenticate
 secret_path | /etc/ceph/ceph.client.admin.keyring| Path to ceph user keyring
 

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/defaults/main.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/defaults/main.yml
@@ -39,11 +39,8 @@ ciao_cert_organization: Example Inc.
 # CIAO virtual machines can be accessed with this username and it's public key
 ciao_guest_user: demouser
 
-# A path to an SSH public authentication key for `ciao_guest_user`
-ciao_guest_key: ~/.ssh/id_rsa.pub
-
-# The contents of ciao_guest_key file
-ciao_ssh_public_key: "{{ lookup('file', ciao_guest_key) }}"
+# SSH public authentication key for `ciao_guest_user`
+ciao_guest_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDB34XG8nbwKyrTiB83kqe2I25P9A8aNU2iTd4AsvnQgM9QbjE9tzndggeOLkz5Ea/IJegOJWfsiDu4ExJ3qXNYqfEFiam8FTdeOVLXkHu6MKpO1pQgmAiJTOO2NMeNqGPFCMAj0ogcKL2/Hl5JAdh+4aK1tLZHdqKTpJGwLp6jP1wo3w5lu0V/oBEPN4qwpzj+S+/6Z6P/cB9rwfTGCbhTyMGdkpj8SIFwhIBTKWYzjxYQMRpbpijXNDSeOekd6L2+QTPRdnEm2+Nh3MFrz5enDZrCGdP7f5nrO3fepz00wtTKcn5rg+0tyuZUNpUwsi40alVvJ6syfPSCRcbGpEDB demouser@localhost
 
 # CIAO Services to create in Keystone
 ciao_openstack_services:

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/templates/workloads/test.yaml.j2
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/templates/workloads/test.yaml.j2
@@ -6,5 +6,5 @@ users:
     lock-passwd: false
     passwd: $6$rounds=4096$w9I3hR4g/hu$AnYjaC2DfznbPSG3vxsgtgAS4mJwWBkcR74Y/KHNB5OsfAlA4gpU5j6CHWMOkkt9j.9d7OYJXJ4icXHzKXTAO.
     sudo: ALL=(ALL) NOPASSWD:ALL
-    ssh-authorized-keys: {{ ciao_ssh_public_key }}
+    ssh-authorized-keys: {{ ciao_guest_key }}
 ...


### PR DESCRIPTION
`ciao_guest_key` variable in
`_DeploymentAndDistroPackaging/ansible/group_vars/all`
points to a public ssh key file (default is ~/.id_rsa.pub)
which is used to access the VMs that ciao creates.

This commit changes the content of `ciao_guest_key` var
to actually contain the public ssh key instead of the key
path.

Fixes: #814

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>