### PR TITLE
ciao-cli: Add more template examples to the README.md

### DIFF
--- a/ciao-cli/README.md
+++ b/ciao-cli/README.md
@@ -377,3 +377,210 @@ struct {
 	SSHPort int                                   // Instance SSH Port
 }
 ```
+
+### Template Cheat Sheet
+
+Let's look at a few more examples of how we can use templates to extract
+information from the ciao-cli command.  Looking at the help of the ciao-cli
+instance show command shown above we can see that ciao-cli passes a structure
+to the template passed to the -f option.  The members of this structure can be
+accessed inside template code by prefixing their name with '.'.  For example
+the following command prints out the ID of an instance.
+
+```
+# ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{.ID}}'
+80efbb0a-23ae-4d47-8e74-39fb18497c85 $
+```
+
+Note the command prints out the instance without a newline which can be a bit
+confusing.  We can fix this by including a newline character directly in the template.
+
+```
+# ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{.ID}}
+> '
+80efbb0a-23ae-4d47-8e74-39fb18497c85
+#
+```
+
+or by using the println function
+
+```
+# ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{println .ID}}'
+80efbb0a-23ae-4d47-8e74-39fb18497c85
+#
+```
+
+Here's a more elaborate example in which we output the id, the status and ssh connection details
+of the instance.
+
+```
+# ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{.ID}} ({{.Status}}) {{.SSHIP}}:{{.SSHPort}}{{println}}'
+80efbb0a-23ae-4d47-8e74-39fb18497c85 (active) 198.51.100.96:33002
+#
+```
+
+Now let's take a look at the Addresses field.  This field is a structure that
+contains a slice of structures.  We can gain access to this slice as follows
+.Addresses.Private.  Let's output the slice to see what happens.
+
+```
+# ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{println .Addresses.Private}}'
+[{172.16.0.2 02:00:ac:10:00:02  0}]
+#
+```
+
+We see what appears to be a slice of structures.  We can use the template range and index
+commands to access the elements of this slice.  For example to output the MAC addresses
+of each structure we would type:
+
+```
+# ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{range .Addresses.Private}}{{println .OSEXTIPSMACMacAddr}}{{end}}'
+02:00:ac:10:00:02
+#
+```
+
+Note that inside the {{range}}{{end}} tags the meaning of the . cursor changes.  Rather than
+referring to the entire structure passed to template it refers to an individual element
+of the .Addresses.Private slice.  If you want to access a field of the top level structure
+inside the range statement you need to use the $ operator.  For example, the following
+command prints the HostID of the instance before it prints each MAC address.
+
+
+```
+# ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{range .Addresses.Private}}{{$.HostID}} : {{println .OSEXTIPSMACMacAddr}}{{end}}'
+c483c178-2109-4a54-bf00-98cbf4bfa58b : 02:00:ac:10:00:02
+#
+```
+
+If we are only interested in the MAC address of a specific element of the slice
+we can access it directly.
+
+```
+# ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{println (index .Addresses.Private 0).OSEXTIPSMACMacAddr}}'
+02:00:ac:10:00:02
+#
+```
+
+If you find the expression (index .Addresses.Private 0).OSEXTIPSMACMacAddr a little confusing
+you can split things up by introducing a new variable.
+
+```
+# ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{$addr := index .Addresses.Private 0}}{{println $addr.OSEXTIPSMACMacAddr}}'
+02:00:ac:10:00:02
+#
+```
+
+Here the $addr variable becomes the first element of the slice.  $addr itself is a structure and
+so we can use the . operator to access its fields.
+
+However, there's a problem with this approach.  We don't know in advance how many entries
+are present in the .Addresses.Private slice.  If we try to index an element that doesn't
+exist we'll get an error.  For example,
+
+```
+# ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{$addr := index .Addresses.Private 1}}{{println $addr.OSEXTIPSMACMacAddr}}'
+F1117 10:54:29.246108    8776 template.go:30] ciao-cli FATAL: template: instance-show:1:11: executing "instance-show" at <index .Addresses.Pri...>: error calling index: index out of range: 1
+goroutine 1 [running]:
+```
+
+We can use the if statement to prevent us from accessing non-existing elements, e.g.,
+
+```
+# ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{if gt (len .Addresses.Private) 1}}{{$addr := index .Addresses.Private 1}}{{println $addr.OSEXTIPSMACMacAddr}}{{end}}'
+#
+```
+
+The command prints nothing as our if statement evaluates to false.  There's only one element in
+.Addresses.Private slice.
+
+Note in the previous example we use the rather unwieldy .Addresses.Private twice.  We can eliminate
+the repetition using the with statement, e.g.,
+
+```
+# ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{with .Addresses.Private}}{{if gt (len .) 1}}{{$addr := index . 1}}{{println $addr.OSEXTIPSMACMacAddr}}{{end}}{{end}}'
+#
+```
+
+Inside the with statement the . cursor takes on a new meaning.  It becomes assigned to the
+value of .Addresses.Private.
+
+The example above is getting a little big to fit onto one line.  We might find it easier to
+read if it were split onto multiple lines, e.g.,
+
+```
+# ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{with .Addresses.Private}}
+>   {{if gt (len .) 1}}
+>     {{$addr := index . 1}}{{println $addr.OSEXTIPSMACMacAddr}}
+>   {{end}}
+> {{end}}
+> '
+
+  
+
+
+#
+```
+
+This is easier to read but unfortunately the newlines in the template that we added to improve
+readability get copied to the output.  We can fix this by appending a '-' after the {{s and before
+the }}s, e.g.,
+
+```
+# ciao-cli instance show --instance 80efbb0a-23ae-4d47-8e74-39fb18497c85 --f '{{with .Addresses.Private}}
+  {{- if gt (len .) 1}}
+    {{- $addr := index . 1}}{{println $addr.OSEXTIPSMACMacAddr}}
+  {{- end}}
+{{- end -}}
+#
+'
+```
+
+The '-'s gobble up the white space that occurs before the {{- and after the -}}.
+
+Here's one final example.  Let's take a look at the help for the ciao-cli workload list
+command.
+
+```
+ciao-cli workload list --help
+usage: ciao-cli [options] workload list
+
+List all workloads
+
+  -f string
+    	Template used to format output
+
+The template passed to the -f option operates on a 
+
+[]struct {
+	OSFLVDISABLEDDisabled  bool    // Not used
+	Disk                   string  // Backing images associated with workload
+	OSFLVEXTDATAEphemeral  int     // Not currently used
+	OsFlavorAccessIsPublic bool    // Indicates whether the workload is available to all tenants
+	ID                     string  // ID of the workload
+	Links                  []Link  // Not currently used
+	Name                   string  // Name of the workload
+	RAM                    int     // Amount of RAM allocated to instances of this workload 
+	Swap                   string  // Not currently used
+	Vcpus                  int     // Number of Vcpus allocated to instances of this workload 
+}
+```
+
+The important thing to note here is that the template is passed a slice of structures.
+That means we need to use template function that can handle slices, e.g., len, index or range.
+So to determine the number of workloads available we would type.
+
+```
+# ciao-cli workload list -f '{{println (len .)'}}
+5
+```
+
+To output the names of each workload we might do
+
+```
+# ciao-cli workload list -f '{{range .}}{{println .Name}}{{end}}'
+Fedora 23 Cloud
+Clear Cloud
+Docker Debian latest
+Docker Iperf
+Boot Fedora23 from created volume based on image
+```


### PR DESCRIPTION
There's been some confusion about how to use the new -f parameter
recently added to the ciao-cli command that accepts a Go template.  This
commit updates the README.md file of ciao-cli to provide more
information about how templates are used with this tool.  Numerous
examples have also been added.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>