### PR TITLE
Single VM: Switch the container test image to debian from ubuntu

### DIFF
--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -16,4 +16,4 @@ sudo rm -rf /var/lib/ciao/ciao-image
 sudo rm /var/lib/ciao/images/4e16e743-265a-4bf2-9fd1-57ada0b28904
 sudo rm /var/lib/ciao/images/df3768da-31f5-4ba6-82f0-127a1a705169
 sudo rm /var/lib/ciao/images/73a86d7e-93c0-480e-9c41-ab42f69b7799
-
+sudo docker network rm $(sudo docker network ls --filter driver=ciao -q)

--- a/testutil/singlevm/tables/workload_template.csv
+++ b/testutil/singlevm/tables/workload_template.csv
@@ -1,5 +1,5 @@
 79034317-3beb-447e-987d-4e310a8cf410,Fedora 23 Cloud,test.yaml,legacy,qemu,"","", 0
 e35ed972-c46c-4aad-a1e7-ef103ae079a2,Clear Cloud,test.yaml,efi,qemu,"","", 0
 eba04826-62a5-48bd-876f-9119667b1487,CNCI,test.yaml,efi,qemu,"","", 1
-ca957444-fa46-11e5-94f9-38607786d9ec,Docker Ubuntu latest,docker-ubuntu.yaml,"",docker,fa7d86d8-fa46-11e5-8493-38607786d9ec,"ubuntu:latest",0
+ca957444-fa46-11e5-94f9-38607786d9ec,Docker Debian latest,docker-debian.yaml,"",docker,fa7d86d8-fa46-11e5-8493-38607786d9ec,"debian:latest",0
 ab68111c-03a6-11e6-87de-001320fb6e31,Docker Iperf,docker-iperf.yaml,"",docker,b5e696b8-03a6-11e6-a424-001320fb6e31,"mcastelino/iperf:latest",0


### PR DESCRIPTION
The ubuntu container image on dockerhub has been slimmed down.
This break the automated tests as the network tools required for
testing are no longer found within the image.

Switching the test image to debian which has the required tools.

This fixes issue #844

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>