### PR TITLE
[RFC] ciao-controller: Change persistent data paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 # We need to create and install SSNTP certs for the SSNTP and controller tests
 before_script:
    - sudo mkdir -p /etc/pki/ciao/
-   - sudo mkdir -p /var/lib/ciao/logs/scheduler
+   - sudo mkdir -p /var/lib/ciao/logs/{controller,scheduler}
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server -role scheduler
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role agent
    - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role agent,netagent

--- a/ciao-controller/README.md
+++ b/ciao-controller/README.md
@@ -101,7 +101,9 @@ Usage of ciao-controller/ciao-controller:
   -cert string
     	Client certificate (default "/etc/pki/ciao/cert-client-localhost.pem")
   -database_path string
-    	path to persistent database (default "./ciao-controller.db")
+        path to persistent database (default "/var/lib/ciao/data/controller/ciao-controller.db")
+  -image_database_path string
+        path to image persistent database (default "/var/lib/ciao/data/image/ciao-image.db")
   -log_backtrace_at value
     	when logging hits line file:N, emit a stack trace (default :0)
   -log_dir string
@@ -111,11 +113,11 @@ Usage of ciao-controller/ciao-controller:
   -nonetwork
     	Debug with no networking
   -stats_path string
-    	path to stats database (default "/tmp/ciao-controller-stats.db")
+    	path to stats database (default "/var/lib/ciao/data/controller/ciao-controller-stats.db")
   -stderrthreshold value
     	logs at or above this threshold go to stderr
   -tables_init_path string
-	path to csv files (default "./tables")
+	path to csv files (default "/var/lib/ciao/data/controller/tables")
   -url string
     	Server URL (default "localhost")
   -v value
@@ -123,7 +125,7 @@ Usage of ciao-controller/ciao-controller:
   -vmodule value
     	comma-separated list of pattern=N settings for file-filtered logging
   -workloads_path string
-	path to yaml files (default "./workloads")
+	path to yaml files (default "/var/lib/ciao/data/controller/workloads")
 ```
 
 ### Example

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -63,12 +63,12 @@ var computeAPIPort = compute.APIPort
 var imageAPIPort = osimage.APIPort
 var httpsCAcert = "/etc/pki/ciao/ciao-controller-cacert.pem"
 var httpsKey = "/etc/pki/ciao/ciao-controller-key.pem"
-var tablesInitPath = flag.String("tables_init_path", "./tables", "path to csv files")
-var workloadsPath = flag.String("workloads_path", "./workloads", "path to yaml files")
+var tablesInitPath = flag.String("tables_init_path", "/var/lib/ciao/data/controller/tables", "path to csv files")
+var workloadsPath = flag.String("workloads_path", "/var/lib/ciao/data/controller/workloads", "path to yaml files")
 var noNetwork = flag.Bool("nonetwork", false, "Debug with no networking")
-var persistentDatastoreLocation = flag.String("database_path", "./ciao-controller.db", "path to persistent database")
-var imageDatastoreLocation = flag.String("image_database_path", "./ciao-image.db", "path to image persistent database")
-var transientDatastoreLocation = flag.String("stats_path", "/tmp/ciao-controller-stats.db", "path to stats database")
+var persistentDatastoreLocation = flag.String("database_path", "/var/lib/ciao/data/controller/ciao-controller.db", "path to persistent database")
+var imageDatastoreLocation = flag.String("image_database_path", "/var/lib/ciao/data/image/ciao-image.db", "path to image persistent database")
+var transientDatastoreLocation = flag.String("stats_path", "/var/lib/ciao/data/controller/ciao-controller-stats.db", "path to stats database")
 var logDir = "/var/lib/ciao/logs/controller"
 
 var imagesPath = flag.String("images_path", "/var/lib/ciao/images", "path to ciao images")

--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -3,6 +3,7 @@
 . ~/local/demo.sh
 
 ciao_gobin="$GOPATH"/bin
+ciao_data="$HOME/local/data"
 sudo killall ciao-scheduler
 sudo killall ciao-controller
 sudo killall ciao-launcher
@@ -13,6 +14,7 @@ sudo pkill -F /tmp/dnsmasq.ciaovlan.pid
 sudo docker rm -v -f ceph-demo
 sudo rm /etc/ceph/*
 sudo rm -rf /var/lib/ciao/ciao-image
+sudo rm -rf "$ciao_data"/*
 sudo rm /var/lib/ciao/images/4e16e743-265a-4bf2-9fd1-57ada0b28904
 sudo rm /var/lib/ciao/images/df3768da-31f5-4ba6-82f0-127a1a705169
 sudo rm /var/lib/ciao/images/73a86d7e-93c0-480e-9c41-ab42f69b7799

--- a/testutil/singlevm/run_controller.sh
+++ b/testutil/singlevm/run_controller.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 ciao_host=$(hostname)
+ciao_data="$HOME/local/data"
 
-sudo rm ciao-controller.db-shm ciao-controller.db-wal ciao-controller.db /tmp/ciao-controller-stats.db
+sudo rm $ciao_data/*
 
-sudo "$GOPATH"/bin/ciao-controller --cacert=./CAcert-"$ciao_host".pem --cert=./cert-Controller-"$ciao_host".pem --single --v 3 &
+sudo "$GOPATH"/bin/ciao-controller --cacert=./CAcert-"$ciao_host".pem --cert=./cert-Controller-"$ciao_host".pem \
+     --tables_init_path=$ciao_data --workloads_path=$ciao_data --database_path=$ciao_data/ciao-controller.db \
+     --image_database_path=$ciao_data/ciao-image.db --stats_path=$ciao_data/ciao-controller-stats.db --single --v 3 &

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -17,6 +17,7 @@ ciao_env="$ciao_bin/demo.sh"
 ciao_ctl_log="/var/lib/ciao/logs/controller/ciao-controller.ERROR"
 ciao_cnci_image="clear-8260-ciao-networking.img"
 ciao_cnci_url="https://download.clearlinux.org/demos/ciao"
+ciao_data=$ciao_bin"/data"
 fedora_cloud_image="Fedora-Cloud-Base-24-1.2.x86_64.qcow2"
 fedora_cloud_url="https://download.fedoraproject.org/pub/fedora/linux/releases/24/CloudImages/x86_64/images/Fedora-Cloud-Base-24-1.2.x86_64.qcow2"
 download=0
@@ -26,6 +27,7 @@ echo "Subnet =" $ciao_subnet
 #Create a directory where all the certificates, binaries and other
 #dependencies are placed
 mkdir -p "$ciao_bin"
+mkdir -p "$ciao_data"
 
 if [ ! -d  "$ciao_bin" ]
 then
@@ -113,13 +115,7 @@ cd "$ciao_bin"
 
 #Cleanup any old artifacts
 rm -f "$ciao_bin"/*.pem
-sudo rm -f "$ciao_bin"/ciao-controller.db-shm
-sudo rm -f "$ciao_bin"/ciao-controller.db-wal
-sudo rm -f "$ciao_bin"/ciao-controller.db
-sudo rm -f /tmp/ciao-controller-stats.db
-sudo rm -f "$ciao_bin"/ciao-image.db
-rm -rf "$ciao_bin"/tables
-rm -rf "$ciao_bin"/workloads
+sudo rm -f "$ciao_data"/*
 
 #Build ciao
 rm -f "$ciao_gobin"/ciao*
@@ -158,12 +154,12 @@ sudo cp -f controller_cert.pem /etc/pki/ciao
 
 #Copy the configuration
 cd "$ciao_bin"
-cp -a "$ciao_src"/ciao-controller/tables "$ciao_bin"
-cp -a "$ciao_src"/ciao-controller/workloads "$ciao_bin"
+cp -a "$ciao_src"/ciao-controller/tables "$ciao_data"
+cp -a "$ciao_src"/ciao-controller/workloads "$ciao_data"
 
 #Over ride the configuration with test specific defaults
-cp -f "$ciao_scripts"/workloads/* "$ciao_bin"/workloads
-cp -f "$ciao_scripts"/tables/* "$ciao_bin"/tables
+cp -f "$ciao_scripts"/workloads/* "$ciao_data"/workloads
+cp -f "$ciao_scripts"/tables/* "$ciao_data"/tables
 
 
 #Copy the launch scripts


### PR DESCRIPTION
In favor of cleaner deployment, we're changing default paths
for persistent data file of ``ciao-controller`` and ``ciao-image`` to
``/var/lib/ciao/data`` directory.

It will create the directories in case that they don't exist.
In case of a diferent path is desired, ``ciao-controller`` command
will require the proper parameters to configure the paths.

Signed-off-by: Obed N Munoz <obed.n.munoz@intel.com>