### PR TITLE
ciao-cli: Improve template functionality

### DIFF
--- a/ciao-cli/event.go
+++ b/ciao-cli/event.go
@@ -58,6 +58,7 @@ The template passed to the -f option operates on a
 	Message   string    // Event message
 }
 `)
+	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
 

--- a/ciao-cli/image.go
+++ b/ciao-cli/image.go
@@ -126,6 +126,7 @@ The template passed to the -f option operates on a
 
 %s
 `, imageTemplateDesc)
+	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
 
@@ -220,6 +221,7 @@ The template passed to the -f option operates on a
 
 %s
 `, imageTemplateDesc)
+	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
 
@@ -275,6 +277,7 @@ As images are retrieved in pages, the template may be applied multiple
 times.  You can not therefore rely on the length of the slice passed
 to the template to determine the total number of images.
 `, imageTemplateDesc)
+	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
 
@@ -293,11 +296,7 @@ func (cmd *imageListCommand) run(args []string) error {
 
 	var t *template.Template
 	if cmd.template != "" {
-		var err error
-		t, err = template.New("image-list").Parse(cmd.template)
-		if err != nil {
-			fatalf(err.Error())
-		}
+		t = createTemplate("image-list", cmd.template)
 	}
 
 	pager := images.List(client, images.ListOpts{})

--- a/ciao-cli/instance.go
+++ b/ciao-cli/instance.go
@@ -322,7 +322,7 @@ The template passed to the -f option operates on a
 
 []%s
 `, instanceTemplateDesc)
-
+	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
 
@@ -456,7 +456,7 @@ The template passed to the -f option operates on a
 
 %s
 `, instanceTemplateDesc)
-
+	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
 

--- a/ciao-cli/node.go
+++ b/ciao-cli/node.go
@@ -88,6 +88,7 @@ The template passed to the -f option operates on one of the following types:
 
 []%s
 `, cnciTemplateDesc, computeTemplateDesc)
+	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
 
@@ -207,7 +208,7 @@ struct {
 	TotalNodesMaintenance int
 }
 `)
-
+	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
 
@@ -268,7 +269,7 @@ The template passed to the -f option operates on one of the following types:
 
 %s
 `, cnciTemplateDesc)
-
+	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
 

--- a/ciao-cli/template.go
+++ b/ciao-cli/template.go
@@ -17,12 +17,124 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
 	"os"
+	"reflect"
+	"strings"
 	"text/template"
 )
 
+const templateFunctionHelp = `
+ciao-cli adds three new functions to Go's template language
+
+- tojson outputs the specified object in json format, e.g., {{tojson .}}
+- filter operates on an slice or array of structures.  It allows the caller
+  to filter the input array based on the value of a single field.
+  The function returns a slice containing only the objects that satisfy the
+  filter, e.g.
+    
+  ciao-cli image list -f '{{$x := filter . "Protected" "true"}}{{len $x}}'
+   
+  outputs the number of protected images maintained by the image service.
+- select operates on a slice of structs.  It outputs the value of a specified
+  field for each struct on a new line , e.g.,
+
+  {{select . "Name"}}
+`
+
+var funcMap = template.FuncMap{
+	"filter": filterByField,
+	"tojson": toJSON,
+	"select": selectField,
+}
+
+func findField(fieldPath []string, v reflect.Value) reflect.Value {
+	f := v
+	for _, seg := range fieldPath {
+		f = f.FieldByName(seg)
+		if f.Kind() == reflect.Ptr {
+			f = reflect.Indirect(f)
+		}
+	}
+	return f
+}
+
+func filterByField(obj interface{}, field, val string) (retval interface{}) {
+	defer func() {
+		err := recover()
+		if err != nil {
+			fatalf("Invalid use of filter: %v", err)
+		}
+	}()
+
+	list := reflect.ValueOf(obj)
+	if list.Kind() == reflect.Ptr {
+		list = reflect.Indirect(list)
+	}
+	filtered := reflect.MakeSlice(list.Type(), 0, list.Len())
+
+	fieldPath := strings.Split(field, ".")
+
+	for i := 0; i < list.Len(); i++ {
+		v := list.Index(i)
+		if v.Kind() == reflect.Ptr {
+			v = reflect.Indirect(v)
+		}
+
+		f := findField(fieldPath, v)
+
+		strVal := fmt.Sprintf("%v", f.Interface())
+		if strVal == val {
+			filtered = reflect.Append(filtered, list.Index(i))
+		}
+	}
+
+	retval = filtered.Interface()
+	return
+}
+
+func selectField(obj interface{}, field string) string {
+	defer func() {
+		err := recover()
+		if err != nil {
+			fatalf("Invalid use of select: %v", err)
+		}
+	}()
+
+	var b bytes.Buffer
+	list := reflect.ValueOf(obj)
+	if list.Kind() == reflect.Ptr {
+		list = reflect.Indirect(list)
+	}
+
+	fieldPath := strings.Split(field, ".")
+
+	for i := 0; i < list.Len(); i++ {
+		v := list.Index(i)
+		if v.Kind() == reflect.Ptr {
+			v = reflect.Indirect(v)
+		}
+
+		f := findField(fieldPath, v)
+
+		fmt.Fprintf(&b, "%v\n", f.Interface())
+	}
+
+	return string(b.Bytes())
+}
+
+func toJSON(obj interface{}) string {
+	b, err := json.MarshalIndent(obj, "", "\t")
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
 func outputToTemplate(name, tmplSrc string, obj interface{}) error {
-	t, err := template.New(name).Parse(tmplSrc)
+	t, err := template.New(name).Funcs(funcMap).Parse(tmplSrc)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -38,7 +150,7 @@ func createTemplate(name, tmplSrc string) *template.Template {
 		return nil
 	}
 
-	t, err := template.New("node-list").Parse(tmplSrc)
+	t, err := template.New(name).Funcs(funcMap).Parse(tmplSrc)
 	if err != nil {
 		fatalf(err.Error())
 	}

--- a/ciao-cli/tenant.go
+++ b/ciao-cli/tenant.go
@@ -97,6 +97,7 @@ struct {
 	Timestamp time.Time  // Time resource snapshot was taken
 }
 `)
+	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
 

--- a/ciao-cli/trace.go
+++ b/ciao-cli/trace.go
@@ -51,6 +51,7 @@ The template passed to the -f option operates on
 	Instances int    // Number of instances created with this label
 }
 `)
+	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
 
@@ -119,6 +120,7 @@ struct {
 	VarianceScheduler        float64 // Scheduler start time variance
 }
 `)
+	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
 

--- a/ciao-cli/volume.go
+++ b/ciao-cli/volume.go
@@ -132,7 +132,7 @@ As volumes are retrieved in pages, the template may be applied multiple
 times.  You can not therefore rely on the length of the slice passed
 to the template to determine the total number of volumes.
 `, volumeTemplateDesc)
-
+	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
 
@@ -211,6 +211,7 @@ The template passed to the -f option operates on a
 
 %s
 `, volumeTemplateDesc)
+	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
 

--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -58,7 +58,7 @@ The template passed to the -f option operates on a
 	Vcpus                  int     // Number of Vcpus allocated to instances of this workload 
 }
 `)
-
+	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
 


### PR DESCRIPTION
This PR adds two new functions to the template language understood
by ciao-cli:

- tojson outputs the specified object in json format, e.g., {{tojson .}}
- filter operates on an slice or array of structures.  It allows the caller
  to filter the input array based on the value of a single field.
  The function returns a slice containing only the objects that satisfy the
  filter, e.g.
- select operates on a slice of structs.  It outputs the value of a specified
  field for each struct on a new line , e.g.,
  {{select . "Name"}}

  ciao-cli image list -f '{{$x := filter . "Protected" "true"}}{{len $x}}'

  outputs the number of protected images maintained by the image service.

The image list command was also modified to called the template utility
functions in template.go.  This was necessary to ensure that our new
functions are available to the image list command.

Finally, a the createTemplate function was using the wrong name for the
templates it created.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>