### PR TITLE
ansible: Install docker on compute nodes

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/ciao_computes.yml
+++ b/_DeploymentAndDistroPackaging/ansible/ciao_computes.yml
@@ -16,4 +16,5 @@
   - hosts: computes
     become: yes
     roles:
+      - docker
       - ciao-compute


### PR DESCRIPTION
While osprepare tells the compute node to install docker-engine, it does
not setup the docker repository.

This change runs the docker role on compute nodes to install docker properly
from the docker repository.

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>