### PR TITLE
ciao-controller: Change persistent data paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,10 @@ script:
    - go list ./... | grep -v github.com/01org/ciao/vendor | xargs go list -f '{{.Dir}}' | xargs -L 1 ineffassign
    - go list ./... | grep -v github.com/01org/ciao/vendor | xargs go list -f '{{.Dir}}' | xargs gofmt -s -l | wc -l | xargs -I % bash -c "test % -eq 0"
    - sudo mkdir -p /var/lib/ciao/instances
-   - sudo chmod 0777 /var/lib/ciao/instances
+   - sudo mkdir -p /var/lib/ciao/data/controller/{workloads,tables}
+   - sudo chmod 0777 -R /var/lib/ciao
+   - cp $GOPATH/src/github.com/01org/ciao/ciao-controller/workloads/* /var/lib/ciao/data/controller/workloads/
+   - cp $GOPATH/src/github.com/01org/ciao/ciao-controller/tables/* /var/lib/ciao/data/controller/tables/
    - test-cases -v -timeout 9 -coverprofile /tmp/cover.out -short github.com/01org/ciao/ciao-controller/...
    - test-cases -v -timeout 9 -coverprofile /tmp/cover.out -append-profile -short github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/payloads github.com/01org/ciao/configuration github.com/01org/ciao/testutil github.com/01org/ciao/ssntp/uuid github.com/01org/ciao/qemu github.com/01org/ciao/openstack/... github.com/01org/ciao/bat  github.com/01org/ciao/ciao-image/... github.com/01org/ciao/database/...
    - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/ssntp

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/main.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/main.yml
@@ -34,6 +34,15 @@
     changed_when: "ciao_build_wait.stderr is defined and 'github.com/01org/ciao/' in ciao_build_wait.stderr"
     when: ciao_dev
 
+  - name: Create directories required by ciao-controller
+    file: path={{ item }} state=directory owner=ciao group=ciao
+    with_items:
+      - /var/lib/ciao/data
+      - /var/lib/ciao/data/controller
+      - /var/lib/ciao/data/controller/workloads
+      - /var/lib/ciao/data/controller/tables
+      - /var/lib/ciao/data/image
+
   - include: install.yml
 
   - include: certificates.yml

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/startservices.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/startservices.yml
@@ -26,13 +26,13 @@
       - restart controller
 
   - name: Copy tables/workload files
-    copy: dest=/var/lib/ciao src={{ item }} owner=ciao group=ciao
+    copy: dest=/var/lib/ciao/data/controller src={{ item }} owner=ciao group=ciao
     with_items:
       - tables
       - workloads
 
   - name: Copy test.yaml file
-    template: dest=/var/lib/ciao/workloads/test.yaml src=workloads/test.yaml.j2 owner=ciao group=ciao
+    template: dest=/var/lib/ciao/data/controller/workloads/test.yaml src=workloads/test.yaml.j2 owner=ciao group=ciao
 
   - name: Create /etc/ciao config dir
     file: path=/etc/ciao state=directory owner=ciao group=ciao

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/templates/ciao-controller.service.j2
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/templates/ciao-controller.service.j2
@@ -6,10 +6,6 @@ After=network.target
 Type=simple
 ExecStart={{ bindir }}/ciao-controller --cacert=/etc/pki/ciao/CAcert-{{ ciao_controller_fqdn }}.pem \
                                    --cert=/etc/pki/ciao/cert-Controller-localhost.pem \
-                                   --tables_init_path=/var/lib/ciao/tables \
-                                   --workloads_path=/var/lib/ciao/workloads \
-                                   --database_path=/var/lib/ciao/datastore/ciao-controller.db \
-                                   --stats_path=/var/lib/ciao/datastore/ciao-controller-stats.db \
                                    --logtostderr -v 2
 Restart=always
 

--- a/ciao-controller/README.md
+++ b/ciao-controller/README.md
@@ -101,7 +101,9 @@ Usage of ciao-controller/ciao-controller:
   -cert string
     	Client certificate (default "/etc/pki/ciao/cert-client-localhost.pem")
   -database_path string
-    	path to persistent database (default "./ciao-controller.db")
+        path to persistent database (default "/var/lib/ciao/data/controller/ciao-controller.db")
+  -image_database_path string
+        path to image persistent database (default "/var/lib/ciao/data/image/ciao-image.db")
   -log_backtrace_at value
     	when logging hits line file:N, emit a stack trace (default :0)
   -log_dir string
@@ -111,11 +113,11 @@ Usage of ciao-controller/ciao-controller:
   -nonetwork
     	Debug with no networking
   -stats_path string
-    	path to stats database (default "/tmp/ciao-controller-stats.db")
+    	path to stats database (default "/var/lib/ciao/data/controller/ciao-controller-stats.db")
   -stderrthreshold value
     	logs at or above this threshold go to stderr
   -tables_init_path string
-	path to csv files (default "./tables")
+	path to csv files (default "/var/lib/ciao/data/controller/tables")
   -url string
     	Server URL (default "localhost")
   -v value
@@ -123,7 +125,7 @@ Usage of ciao-controller/ciao-controller:
   -vmodule value
     	comma-separated list of pattern=N settings for file-filtered logging
   -workloads_path string
-	path to yaml files (default "./workloads")
+	path to yaml files (default "/var/lib/ciao/data/controller/workloads")
 ```
 
 ### Example

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -606,6 +607,12 @@ func (ds *sqliteDB) getTableDB(name string) *sql.DB {
 func getPersistentStore(config Config) (persistentStore, error) {
 	var ds = &sqliteDB{}
 
+	dbDir := filepath.Dir(config.PersistentURI)
+	if err := os.MkdirAll(dbDir, 0755); err != nil && dbDir != "." {
+		fmt.Println(err)
+		return nil, fmt.Errorf("Unable to create db directory (%s) %v", dbDir, err)
+	}
+
 	err := ds.Connect(config.PersistentURI, config.TransientURI)
 	if err != nil {
 		return nil, err
@@ -634,7 +641,18 @@ func getPersistentStore(config Config) (persistentStore, error) {
 	}
 
 	ds.tableInitPath = config.InitTablesPath
+	if ds.tableInitPath != "" {
+		if err := os.MkdirAll(ds.tableInitPath, 0755); err != nil {
+			return nil, fmt.Errorf("Unable to create db directory (%s) %v", dbDir, err)
+		}
+	}
+
 	ds.workloadsPath = config.InitWorkloadsPath
+	if ds.workloadsPath != "" {
+		if err := os.MkdirAll(ds.workloadsPath, 0755); err != nil {
+			return nil, fmt.Errorf("Unable to create db directory (%s) %v", dbDir, err)
+		}
+	}
 
 	for _, table := range ds.tables {
 		err = table.Init()

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -63,11 +63,11 @@ var computeAPIPort = compute.APIPort
 var imageAPIPort = osimage.APIPort
 var httpsCAcert = "/etc/pki/ciao/ciao-controller-cacert.pem"
 var httpsKey = "/etc/pki/ciao/ciao-controller-key.pem"
-var tablesInitPath = flag.String("tables_init_path", "./tables", "path to csv files")
-var workloadsPath = flag.String("workloads_path", "./workloads", "path to yaml files")
+var tablesInitPath = flag.String("tables_init_path", "/var/lib/ciao/data/controller/tables", "path to csv files")
+var workloadsPath = flag.String("workloads_path", "/var/lib/ciao/data/controller/workloads", "path to yaml files")
 var noNetwork = flag.Bool("nonetwork", false, "Debug with no networking")
-var persistentDatastoreLocation = flag.String("database_path", "./ciao-controller.db", "path to persistent database")
-var imageDatastoreLocation = flag.String("image_database_path", "./ciao-image.db", "path to image persistent database")
+var persistentDatastoreLocation = flag.String("database_path", "/var/lib/ciao/data/controller/ciao-controller.db", "path to persistent database")
+var imageDatastoreLocation = flag.String("image_database_path", "/var/lib/ciao/data/image/ciao-image.db", "path to image persistent database")
 var transientDatastoreLocation = flag.String("stats_path", "/tmp/ciao-controller-stats.db", "path to stats database")
 var logDir = "/var/lib/ciao/logs/controller"
 


### PR DESCRIPTION
In favor of cleaner deployment, we're changing default paths
for persistent data file of ciao-controller and ``ciao-image`` to
``/var/lib/ciao/data`` directory.

It will create the directories in case that they don't exists.
In case of a diferent path is desired, ``ciao-controller`` command
will require the proper parameters to configure the paths.

Signed-off-by: Obed N Munoz <obed.n.munoz@intel.com>