### PR TITLE
ciao-cert: Rename signer flag for clarity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,13 @@ before_install:
 before_script:
    - sudo mkdir -p /etc/pki/ciao/
    - sudo mkdir -p /var/lib/ciao/logs/scheduler
-   - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server -role scheduler
-   - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role agent
-   - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role agent,netagent
-   - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role controller
-   - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role cnciagent
-   - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role netagent
-   - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -server-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role server
+   - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -anchor -role scheduler
+   - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -anchor-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role agent
+   - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -anchor-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role agent,netagent
+   - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -anchor-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role controller
+   - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -anchor-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role cnciagent
+   - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -anchor-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role netagent
+   - sudo -E $GOPATH/bin/ciao-cert -directory /etc/pki/ciao -host localhost -anchor-cert /etc/pki/ciao/cert-Scheduler-localhost.pem -role server
    - sudo cp /etc/pki/ciao/CAcert-localhost.pem /etc/pki/ciao/ca_cert.crt
    - sudo cp /etc/pki/ciao/CAcert-localhost.pem /etc/pki/ciao/CAcert-server-localhost.pem
    - sudo cp /etc/pki/ciao/cert-Scheduler-localhost.pem /etc/pki/ciao/server.pem

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/certificates.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/certificates.yml
@@ -25,7 +25,7 @@
     become: no
     connection: local
     command: >
-      {{ ciao_cert }} -server -role scheduler
+      {{ ciao_cert }} -anchor -role scheduler
       -email={{ ciao_admin_email }} -organization="{{ ciao_cert_organization }}"
       -ip={{ ciao_controller_ip }} -host={{ ciao_controller_fqdn }} -verify
     args:
@@ -36,7 +36,7 @@
     become: no
     connection: local
     command: >
-      {{ ciao_cert }} -role {{ item.role }} --server-cert
+      {{ ciao_cert }} -role {{ item.role }} --anchor-cert
       cert-Scheduler-{{ ciao_controller_fqdn }}.pem -email={{ ciao_admin_email }}
       --organization="{{ ciao_cert_organization }}" -host=localhost -verify
     args:

--- a/ciao-cert/README.md
+++ b/ciao-cert/README.md
@@ -35,10 +35,10 @@ Usage of ciao-cert:
         Certificates organization
   -role value
         Comma separated list of SSNTP role [agent, scheduler, controller, netagent, server, cnciagent]
-  -server
-        Whether this cert should be a server one
-  -server-cert string
-        Server certificate for signing a client one
+  -anchor
+        Whether this cert should be the trust anchor
+  -anchor-cert string
+        Trust anchor certificate for signing
   -stderrthreshold value
         logs at or above this threshold go to stderr
   -v value
@@ -74,23 +74,23 @@ node agent, networking node agent, and CNCI agent).
 
 * Scheduler private key and CA certificate
 
-        $GOBIN/ciao-cert -server -role scheduler -email=ciao-devel@lists.clearlinux.org -organization=Intel -ip=192.168.1.118 -host=ciao-ctl.intel.com -verify
+        $GOBIN/ciao-cert -anchor -role scheduler -email=ciao-devel@lists.clearlinux.org -organization=Intel -ip=192.168.1.118 -host=ciao-ctl.intel.com -verify
   That will generate `CAcert-ciao-ctl.intel.com.pem` and `cert-Scheduler-ciao.ctl.intel.com.pem`.
 * Controller private key
 
-        $GOBIN/ciao-cert -role controller -server-cert cert-Scheduler-ciao-ctl.intel.com.pem -email=ciao-devel@lists.clearlinux.org -organization=Intel -host=ciao-ctl.intel.com -verify
+        $GOBIN/ciao-cert -role controller -anchor-cert cert-Scheduler-ciao-ctl.intel.com.pem -email=ciao-devel@lists.clearlinux.org -organization=Intel -host=ciao-ctl.intel.com -verify
   That will generate `cert-Controller-ciao-ctl.intel.com.pem`.
 * Compute Node Agent private key
 
-        $GOBIN/ciao-cert -role agent -server-cert cert-Scheduler-ciao-ctl.intel.com.pem -email=ciao-devel@lists.clearlinux.org -organization=Intel -host=localhost -verify
+        $GOBIN/ciao-cert -role agent -anchor-cert cert-Scheduler-ciao-ctl.intel.com.pem -email=ciao-devel@lists.clearlinux.org -organization=Intel -host=localhost -verify
   That will generate `cert-CNAgent-localhost.pem`.
 * Networking Node Agent private key
 
-        $GOBIN/ciao-cert -role netagent -server-cert cert-Scheduler-ciao-ctl.intel.com.pem -email=ciao-devel@lists.clearlinux.org -organization=Intel -host=localhost -verify
+        $GOBIN/ciao-cert -role netagent -anchor-cert cert-Scheduler-ciao-ctl.intel.com.pem -email=ciao-devel@lists.clearlinux.org -organization=Intel -host=localhost -verify
   That will generate `cert-NetworkingAgent-localhost.pem`.
 * CNCI Agent private key
 
-        $GOBIN/ciao-cert -role cnciagent -server-cert cert-Scheduler-ciao-ctl.intel.com.pem -email=ciao-devel@lists.clearlinux.org -organization=Intel -host=localhost -verify
+        $GOBIN/ciao-cert -role cnciagent -anchor-cert cert-Scheduler-ciao-ctl.intel.com.pem -email=ciao-devel@lists.clearlinux.org -organization=Intel -host=localhost -verify
   That will generate `cert-CNCIAgent-localhost.pem`.
 
 ## Multi roles support
@@ -103,7 +103,7 @@ separated list of roles to ciao-cert.  For example a specific testing
 focused launcher agent may want to expose both the CN and NN agent roles:
 
 ```shell
-$GOBIN/ciao-cert -role agent,netagent -server-cert cert-Scheduler-ciao-ctl.intel.com.pem -email=ciao-devel@lists.clearlinux.org -organization=Intel -host=localhost -verify
+$GOBIN/ciao-cert -role agent,netagent -anchor-cert cert-Scheduler-ciao-ctl.intel.com.pem -email=ciao-devel@lists.clearlinux.org -organization=Intel -host=localhost -verify
 ```
 
 ## Inspecting certificates

--- a/ssntp/certs/certs_test.go
+++ b/ssntp/certs/certs_test.go
@@ -166,7 +166,7 @@ func TestCreateCertTemplateRoles(t *testing.T) {
 	}
 }
 
-func TestCreateServerCert(t *testing.T) {
+func TestCreateAnchorCert(t *testing.T) {
 	var certOutput, caCertOutput bytes.Buffer
 
 	hosts := []string{"test.example.com", "test2.example.com"}
@@ -177,9 +177,9 @@ func TestCreateServerCert(t *testing.T) {
 		t.Errorf("Unexpected error when creating cert template: %v", err)
 	}
 
-	err = CreateServerCert(template, false, &certOutput, &caCertOutput)
+	err = CreateAnchorCert(template, false, &certOutput, &caCertOutput)
 	if err != nil {
-		t.Errorf("Unexpected error when creating server cert: %v", err)
+		t.Errorf("Unexpected error when creating anchor cert: %v", err)
 	}
 
 	// Decode server cert & private key
@@ -195,15 +195,15 @@ func TestCreateServerCert(t *testing.T) {
 
 	privKeyBlock, _ := pem.Decode(rest)
 	if privKeyBlock == nil {
-		t.Errorf("Unable to extract private key from server cert")
+		t.Errorf("Unable to extract private key from anchor cert")
 	}
 
-	serverPrivKey, err := keyFromPemBlock(privKeyBlock)
+	anchorPrivKey, err := keyFromPemBlock(privKeyBlock)
 	if err != nil {
-		t.Errorf("Unable to parse private key from server cert: %v", err)
+		t.Errorf("Unable to parse private key from anchor cert: %v", err)
 	}
 
-	_, ok := serverPrivKey.(*rsa.PrivateKey)
+	_, ok := anchorPrivKey.(*rsa.PrivateKey)
 	if !ok || err != nil {
 		t.Errorf("Expected RSA private key: %v", err)
 	}
@@ -224,8 +224,8 @@ func TestCreateServerCert(t *testing.T) {
 	}
 }
 
-func TestCreateClientCert(t *testing.T) {
-	var certOutput, caCertOutput, clientCertOutput bytes.Buffer
+func TestCreateCert(t *testing.T) {
+	var anchorCertOutput, caCertOutput, certOutput bytes.Buffer
 
 	hosts := []string{"test.example.com", "test2.example.com"}
 	mgmtIPs := []string{}
@@ -235,29 +235,29 @@ func TestCreateClientCert(t *testing.T) {
 		t.Errorf("Unexpected error when creating cert template: %v", err)
 	}
 
-	err = CreateServerCert(template, false, &certOutput, &caCertOutput)
+	err = CreateAnchorCert(template, false, &anchorCertOutput, &caCertOutput)
 	if err != nil {
-		t.Errorf("Unexpected error when creating server cert: %v", err)
+		t.Errorf("Unexpected error when creating anchor cert: %v", err)
 	}
 
-	err = CreateClientCert(template, false, certOutput.Bytes(), &clientCertOutput)
+	err = CreateCert(template, false, anchorCertOutput.Bytes(), &certOutput)
 	if err != nil {
-		t.Errorf("Unexpected error when creating client cert: %v", err)
+		t.Errorf("Unexpected error when creating signed cert: %v", err)
 	}
 
-	// Decode client cert & private key
-	certBlock, rest := pem.Decode(clientCertOutput.Bytes())
+	// Decode signed cert & private key
+	certBlock, rest := pem.Decode(certOutput.Bytes())
 	privKeyBlock, _ := pem.Decode(rest)
 	if privKeyBlock == nil {
-		t.Errorf("Unable to extract private key from server cert")
+		t.Errorf("Unable to extract private key from anchor cert")
 	}
 
-	serverPrivKey, err := keyFromPemBlock(privKeyBlock)
+	anchorPrivKey, err := keyFromPemBlock(privKeyBlock)
 	if err != nil {
-		t.Errorf("Unable to parse private key from server cert: %v", err)
+		t.Errorf("Unable to parse private key from anchor cert: %v", err)
 	}
 
-	_, ok := serverPrivKey.(*rsa.PrivateKey)
+	_, ok := anchorPrivKey.(*rsa.PrivateKey)
 	if !ok || err != nil {
 		t.Errorf("Expected RSA private key: %v", err)
 	}

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -142,13 +142,13 @@ then
 fi
 
 #Generate Certificates
-"$GOPATH"/bin/ciao-cert -server -role scheduler -email="$ciao_email" -organization="$ciao_org" -host="$ciao_host" -ip="$ciao_ip" -verify
+"$GOPATH"/bin/ciao-cert -anchor -role scheduler -email="$ciao_email" -organization="$ciao_org" -host="$ciao_host" -ip="$ciao_ip" -verify
 
-"$GOPATH"/bin/ciao-cert -role cnciagent -server-cert "$ciao_cert" -email="$ciao_email" -organization="$ciao_org" -host="$ciao_host" -ip="$ciao_ip" -verify
+"$GOPATH"/bin/ciao-cert -role cnciagent -anchor-cert "$ciao_cert" -email="$ciao_email" -organization="$ciao_org" -host="$ciao_host" -ip="$ciao_ip" -verify
 
-"$GOPATH"/bin/ciao-cert -role controller -server-cert "$ciao_cert" -email="$ciao_email" -organization="$ciao_org" -host="$ciao_host" -ip="$ciao_ip" -verify
+"$GOPATH"/bin/ciao-cert -role controller -anchor-cert "$ciao_cert" -email="$ciao_email" -organization="$ciao_org" -host="$ciao_host" -ip="$ciao_ip" -verify
 
-"$GOPATH"/bin/ciao-cert -role agent,netagent -server-cert "$ciao_cert" -email="$ciao_email" -organization="$ciao_org" -host="$ciao_host" -ip="$ciao_ip" -verify
+"$GOPATH"/bin/ciao-cert -role agent,netagent -anchor-cert "$ciao_cert" -email="$ciao_email" -organization="$ciao_org" -host="$ciao_host" -ip="$ciao_ip" -verify
 
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout controller_key.pem -out controller_cert.pem -subj "/C=US/ST=CA/L=Santa Clara/O=ciao/CN=$ciao_host"
 


### PR DESCRIPTION
Previously the -server and -server-cert flag were used to indicate that
the certificate being generated would be either the signing certificate
or signed by the signing certificate. This change updates the flags to
be -anchor and -anchor-cert to separate the ssntp.SERVER role term from
the trust anchor term used in the same command and APIs.

---

The motivation for this is that I was incredibly confused by the term server when talking about the certificate and I thought there was some sort of relation between that and the ssntp role that was embedded in the certificate. Based on existing tests and my own findings that does not appear to be the case and I do not find other documents which contradict these. That being the case, simply renaming the options and a few functions/documentation avoids the possible confusion of these two distinct uses.

As an aside my findings are that the anchor doesn't need to be a specific role (it was largely hinted through documentation/use that the ssntp.SCHEDULER or ssntp.SERVER roles were supposed to be the anchor though). There doesn't seem to be any tests which contradict this finding and there are tests which have for example ssntp.AGENT role certificates as the trust anchor. If this is not supposed to happen then this change needs further refinement.