### PR TITLE
ciao-controller: Make CNCI storage ephemeral

### DIFF
--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -87,18 +87,18 @@ func newInstance(ctl *controller, tenantID string, workload *types.Workload) (*i
 }
 
 func (i *instance) Add() error {
+	ds := i.ctl.ds
 	if i.CNCI == false {
-		ds := i.ctl.ds
 		ds.AddInstance(&i.Instance)
-		storage := i.newConfig.sc.Start.Storage
-		if (storage != payloads.StorageResources{}) {
-			_, err := ds.CreateStorageAttachment(i.Instance.ID, storage.ID, storage.Ephemeral)
-			if err != nil {
-				glog.Error(err)
-			}
-		}
 	} else {
-		i.ctl.ds.AddTenantCNCI(i.TenantID, i.ID, i.MACAddress)
+		ds.AddTenantCNCI(i.TenantID, i.ID, i.MACAddress)
+	}
+	storage := i.newConfig.sc.Start.Storage
+	if (storage != payloads.StorageResources{}) {
+		_, err := ds.CreateStorageAttachment(i.Instance.ID, storage.ID, storage.Ephemeral)
+		if err != nil {
+			glog.Error(err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Refactor the instance launching code to make storage for the CNCI
ephemeral so that it will be cleaned up when the CNCI is deleted.

Fixes: #851

Signed-off-by: Rob Bradford <robert.bradford@intel.com>