### PR TITLE
ciao-controller: Add qemu-img as dependency

### DIFF
--- a/ciao-controller/deps.go
+++ b/ciao-controller/deps.go
@@ -20,14 +20,13 @@ package main
 import "github.com/01org/ciao/osprepare"
 
 var controllerDeps = osprepare.PackageRequirements{
-	// no known dependencies
 	"clearlinux": {
-		{BinaryName: "", PackageName: ""},
+		{BinaryName: "/usr/bin/qemu-img", PackageName: "kvm-host"},
 	},
 	"fedora": {
-		{BinaryName: "", PackageName: ""},
+		{BinaryName: "/usr/bin/qemu-img", PackageName: "qemu-img"},
 	},
 	"ubuntu": {
-		{BinaryName: "", PackageName: ""},
+		{BinaryName: "/usr/bin/qemu-img", PackageName: "qemu-utils"},
 	},
 }


### PR DESCRIPTION
qemu-img is required by ciao-image to convert images into
rbd block devices in ceph.

Fixes #861

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>