### PR TITLE
ciao-cli: use correct identity endpoint for unscoped token

### DIFF
--- a/ciao-cli/identity.go
+++ b/ciao-cli/identity.go
@@ -231,7 +231,7 @@ func getAllProjects(username string, password string) (*IdentityProjects, error)
 		return nil, err
 	}
 
-	identity := fmt.Sprintf("%s/v3/projects", *identityURL)
+	identity := fmt.Sprintf("%s/v3/auth/projects", *identityURL)
 
 	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil)
 	if err != nil {


### PR DESCRIPTION
When using an unscoped token, you need to use a different
endpoint to list projects than when you have a scoped token.

Fixes: #864 

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>