### PR TITLE
Add Storage bat tests

### DIFF
--- a/_release/bat/README.md
+++ b/_release/bat/README.md
@@ -44,19 +44,35 @@ before running the tests, e.g.,
 . ~/local/demo.sh
 ```
 
-## Running all the BAT tests
-
-```
-# cd $GOPATH/src/github.com/01org/ciao/_release/bat
-# go test -v ./...
-```
-
 ## Run the BAT Tests and Generate a Pretty Report
 
 ```
 # cd $GOPATH/src/github.com/01org/ciao/_release/bat
 # test-cases ./...
 ```
+
+## DON'T use go test to run the BAT tests!
+
+You might be forgiven for thinking that the easiest way to run all the
+BAT tests would be to do the following.
+
+```
+# cd $GOPATH/src/github.com/01org/ciao/_release/bat
+# go test -v ./...
+```
+
+This currently does not work.  The reason is that when go test is run
+with a wildcard and that widlcard matches multiple packages the tests
+for all of these packages are run in parallel.  As all tests are run in
+the same tenant and some tests call ciao-cli instance delete -all, the
+tests from different packages can interfere with each other.  This means
+we cannot safely use go test to run all the BAT tests.  Once
+we have ciao-cli support for tenant creation, it will be possible to
+have each set of tests create their own tenants.  It will then be
+possible to run the BAT tests concurrently.  For the time being, use
+test-cases which runs the tests for all packages serially.  go test
+can be safely used to run the BAT tests for a specific package.
+
 
 ## Run the BAT Tests and Generate TAP report
 

--- a/_release/bat/storage_bat/storage_bat_test.go
+++ b/_release/bat/storage_bat/storage_bat_test.go
@@ -1,0 +1,636 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage_bat
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/01org/ciao/bat"
+)
+
+const standardTimeout = time.Second * 300
+
+// TODO: We're launching an instance from a known workload UUID that
+// that has no data volumes attached.
+
+func createSpecificInstance(ctx context.Context, t *testing.T, tenant, workloadID string,
+	mustBeActive bool) string {
+	wklds, err := bat.GetAllWorkloads(ctx, tenant)
+	if err != nil {
+		t.Fatalf("Unable to retrieve workload list : %v", err)
+	}
+
+	i := 0
+	for ; i < len(wklds); i++ {
+		if wklds[i].ID == workloadID {
+			break
+		}
+	}
+
+	if i == len(wklds) {
+		t.Skip()
+	}
+
+	instances, err := bat.LaunchInstances(ctx, tenant, workloadID, 1)
+	if err != nil {
+		t.Fatalf("Unable to launch instance : %v", err)
+	}
+
+	_, err = bat.WaitForInstancesLaunch(ctx, tenant, instances, mustBeActive)
+	if err != nil {
+		_ = bat.DeleteInstance(ctx, tenant, instances[0])
+		t.Fatalf("Instance %s did not start correctly : %v",
+			instances[0], err)
+	}
+
+	return instances[0]
+}
+
+func createVMInstance(ctx context.Context, t *testing.T, tenant string) string {
+	const testWorkloadID = "79034317-3beb-447e-987d-4e310a8cf410"
+	return createSpecificInstance(ctx, t, tenant, testWorkloadID, true)
+}
+
+func createContainerInstance(ctx context.Context, t *testing.T, tenant string) string {
+	const testWorkloadID = "ca957444-fa46-11e5-94f9-38607786d9ec"
+	return createSpecificInstance(ctx, t, tenant, testWorkloadID, true)
+}
+
+func checkBootedVolume(ctx context.Context, t *testing.T, tenant, instanceID string) string {
+	instance, err := bat.GetInstance(ctx, tenant, instanceID)
+	if err != nil {
+		t.Fatalf("Unable to retrieve instance %s details : %v",
+			instanceID, err)
+	}
+
+	if len(instance.Volumes) == 0 {
+		t.Fatalf("No volumes are attached to the launched instance %s",
+			instanceID)
+	}
+
+	volumeID := instance.Volumes[0]
+	vol, err := bat.GetVolume(ctx, tenant, volumeID)
+	if err != nil {
+		t.Fatalf("Failed to retrieve volume information for %s",
+			volumeID, err)
+	}
+
+	if vol.TenantID != instance.TenantID {
+		t.Fatalf("Volume and instance tenant ids do not match %s != %s",
+			vol.TenantID, instance.TenantID)
+	}
+
+	if vol.Status != "in-use" {
+		t.Fatalf("Incorrect volume status in-use expected found '%s'", vol.Status)
+	}
+
+	return volumeID
+}
+
+// Test bootable volumes are created and deleted correctly
+//
+// Boot a VM which has no data volumes attached, retrieve the volume ID from
+// ciao-cli, retrieve information about the volume, delete the instance and
+// check that the volume has also been deleted.
+//
+// The instance should be created succesfully.  It should have one volume attached.
+// The status of the volume should be in-use.  The volume should be deleted with
+// the instance.
+func TestBootFromVolume(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+
+	instanceID := createVMInstance(ctx, t, "")
+	defer func() {
+		if instanceID != "" {
+			err := bat.DeleteInstance(ctx, "", instanceID)
+			if err != nil {
+				t.Errorf("Failed to delete instance %s : %v",
+					instanceID, err)
+			}
+		}
+	}()
+
+	volumeID := checkBootedVolume(ctx, t, "", instanceID)
+
+	err := bat.DeleteInstanceAndWait(ctx, "", instanceID)
+	if err != nil {
+		t.Fatalf("Unable to delete instance %s : %v", instanceID, err)
+	}
+
+	instanceID = ""
+	_, err = bat.GetVolume(ctx, "", volumeID)
+	if err == nil {
+		t.Errorf("Volume %s not deleted", volumeID)
+	}
+}
+
+// Check bootable volumes of stopped instances are in-use
+//
+// Boot a VM which has no data volumes attached and stop the instance.  Check
+// the status of the bootable volume.  Delete the instance.
+//
+// The instance should be created succesfully.  It should have one volume attached.
+// The status of the volume should be in-use.
+func TestStoppedInstance(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+
+	instanceID := createVMInstance(ctx, t, "")
+	defer func() {
+		err := bat.DeleteInstance(ctx, "", instanceID)
+		if err != nil {
+			t.Errorf("Failed to delete instance %s : %v",
+				instanceID, err)
+		}
+	}()
+
+	err := bat.StopInstanceAndWait(ctx, "", instanceID)
+	if err != nil {
+		t.Fatalf("Failed to stop instance %s : %v", instanceID, err)
+	}
+
+	_ = checkBootedVolume(ctx, t, "", instanceID)
+}
+
+// Check that in-use volumes cannot be deleted
+//
+// Boot a VM and try to delete the volume from which it booted.  Delete the instance.
+//
+// The instance should be created, the attempt to delete the volume should fail, and
+// the instance should be correctly deleted.
+func TestDeleteInUse(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+
+	instanceID := createVMInstance(ctx, t, "")
+	defer func() {
+		err := bat.DeleteInstance(ctx, "", instanceID)
+		if err != nil {
+			t.Errorf("Failed to delete instance %s : %v",
+				instanceID, err)
+		}
+	}()
+
+	volumeID := checkBootedVolume(ctx, t, "", instanceID)
+	err := bat.DeleteVolume(ctx, "", volumeID)
+	if err == nil {
+		t.Fatalf("Succeeded in deleting in-use volume %s", volumeID)
+	} else if err == context.Canceled {
+		t.Fatalf("Attempt to delete volume %s cancelled or timed out : %v",
+			volumeID, err)
+	}
+}
+
+// Check that the rootfs volumes cannot be detached
+//
+// Boot a VM and try to detach the volume from which it booted.  Delete the instance.
+//
+// The instance should be created, the attempt to detach the volume should fail, and
+// the instance and volume should be correctly deleted.
+func TestDetachRootFS(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+
+	instanceID := createVMInstance(ctx, t, "")
+	defer func() {
+		err := bat.DeleteInstance(ctx, "", instanceID)
+		if err != nil {
+			t.Errorf("Failed to delete instance %s : %v",
+				instanceID, err)
+		}
+	}()
+
+	volumeID := checkBootedVolume(ctx, t, "", instanceID)
+	err := bat.DetachVolume(ctx, "", volumeID)
+	if err == nil {
+		t.Fatalf("Succeeded in detaching in-use volume %s", volumeID)
+	} else if err == context.Canceled {
+		t.Fatalf("Attempt to detach volume %s cancelled or timed out : %v",
+			volumeID, err)
+	}
+}
+
+// Check that volumes can be added, listed and deleted
+//
+// This test creates 10 new volumes of 1GB each.  It then retrieves the meta
+// data for each volume, checks it matches the meta data specified at volume
+// creation and then deletes the volumes.
+//
+// The volumes should be created and enumerated correctly.  The enumerated
+// meta data should match the meta data specified during volume creation
+// and the volumes should be deleted without error.
+func TestAddListDelete(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+
+	const volumeCount = 10
+	volumeIDs := make([]string, 0, volumeCount)
+
+	defer func() {
+		for _, id := range volumeIDs {
+			if err := bat.DeleteVolume(ctx, "", id); err != nil {
+				t.Errorf("Failed to delete volume %s : %v", id, err)
+			}
+		}
+	}()
+
+	for i := 0; i < volumeCount; i++ {
+		id, err := bat.AddVolume(ctx, "", "", "", &bat.VolumeOptions{
+			Size:        1,
+			Name:        fmt.Sprintf("%d", i+1),
+			Description: fmt.Sprintf("%d description", i+1),
+		})
+		if err != nil {
+			t.Fatalf("Unable to add volume %d :%v", i, err)
+		}
+		volumeIDs = append(volumeIDs, id)
+	}
+
+	volumes, err := bat.GetAllVolumes(ctx, "")
+	if err != nil {
+		t.Fatalf("Unable to retrieve list of errors %v", err)
+	}
+
+	for i, id := range volumeIDs {
+		vol := volumes[id]
+		if vol == nil {
+			t.Fatalf("Unable to find volume %s", id)
+		}
+		if vol.Size != 1 || vol.Name != fmt.Sprintf("%d", i+1) ||
+			vol.Description != fmt.Sprintf("%d description", i+1) {
+			t.Fatalf("Incorrect meta data for %s: size %d, name %s, description %s",
+				vol.Size, vol.Name, vol.Description)
+		}
+
+		if vol.Status != "available" {
+			t.Fatalf("Incorrect status %s for volume %s.  Expected available",
+				vol.Status, id)
+		}
+	}
+}
+
+// Check attaching volumes become available when deleting their instance
+//
+// Create a VM and a volume and then attach the volume to the VM.  Don't wait for the
+// volume to attach.  Instead delete the instance straight away and then delete the
+// volume.
+//
+// Instance and volume should be created and the volume should transition to the
+// attaching state without issue.  The volume should become available after the
+// the instance has been deleted and should be deleted correctly.
+func TestDeleteInstanceWhileAttaching(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+
+	instanceID := createVMInstance(ctx, t, "")
+	var volumeID string
+	defer func() {
+		if instanceID != "" {
+			err := bat.DeleteInstanceAndWait(ctx, "", instanceID)
+			if err != nil {
+				t.Errorf("Failed to delete instance %s : %v",
+					instanceID, err)
+			}
+		}
+		if volumeID != "" {
+			err := bat.DeleteVolume(ctx, "", volumeID)
+			if err != nil {
+				t.Errorf("Failed to delete volume %s : %v", volumeID, err)
+			}
+		}
+	}()
+
+	volumeID, err := bat.AddVolume(ctx, "", "", "", &bat.VolumeOptions{
+		Size: 1,
+	})
+
+	if err != nil {
+		t.Fatalf("Unable to add volume :%v", err)
+	}
+
+	defer func() {
+	}()
+
+	err = bat.AttachVolume(ctx, "", instanceID, volumeID)
+	if err != nil {
+		t.Fatalf("Unable to attach volume %s to instance %s : %v",
+			volumeID, instanceID, err)
+	}
+
+	err = bat.DeleteInstance(ctx, "", instanceID)
+	if err != nil {
+		t.Errorf("Failed to delete instance %s : %v", instanceID, err)
+	}
+	instanceID = ""
+
+	err = bat.WaitForVolumeStatus(ctx, "", volumeID, "available")
+	if err != nil {
+		t.Errorf("Timed out waiting for volume %s to become available : %v",
+			volumeID, err)
+	}
+}
+
+// Check that a deleting a detaching volume fails
+//
+// Create an instance and a volume, attach the volume to the instance and wait
+// for it to transition to available.  Detach and delete the volume before the
+// state of the volume has transitioned back to available.
+//
+// Volume and instance should be created correctly and the volume should be
+// attached without issue.  The first attempt to delete the detaching volume
+// may fail, but the subsequent attempt made after the volume has become
+// available again, should succeed.
+func TestDeleteBeforeDetached(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+
+	instanceID := createVMInstance(ctx, t, "")
+	var volumeID string
+	defer func() {
+		err := bat.DeleteInstanceAndWait(ctx, "", instanceID)
+		if err != nil {
+			t.Errorf("Failed to delete instance %s : %v",
+				instanceID, err)
+		}
+		if volumeID != "" {
+			err = bat.DeleteVolume(ctx, "", volumeID)
+			if err != nil {
+				t.Errorf("Failed to delete volume %s : %v", volumeID, err)
+			}
+		}
+	}()
+
+	volumeID, err := bat.AddVolume(ctx, "", "", "", &bat.VolumeOptions{
+		Size: 1,
+	})
+
+	if err != nil {
+		t.Fatalf("Unable to add volume :%v", err)
+	}
+
+	err = bat.AttachVolumeAndWait(ctx, "", instanceID, volumeID)
+	if err != nil {
+		t.Fatalf("Unable to attach volume %s to instance %s : %v",
+			volumeID, instanceID, err)
+	}
+
+	err = bat.DetachVolume(ctx, "", volumeID)
+	if err != nil {
+		t.Fatalf("Unable to detach volume %s from instance %s : %v",
+			volumeID, instanceID, err)
+	}
+
+	err = bat.DeleteVolume(ctx, "", volumeID)
+	if err != nil {
+		err = bat.WaitForVolumeStatus(ctx, "", volumeID, "available")
+		if err != nil {
+			t.Fatalf("Volume %s status not available", volumeID)
+		}
+		err = bat.DeleteVolume(ctx, "", volumeID)
+		if err != nil {
+			t.Fatalf("Failed to delete volume %s : %v", volumeID, err)
+		}
+	}
+
+	volumeID = ""
+}
+
+// Check that we can attach and detach volumes
+//
+// Create an instance and a volume.  Attach the volume and wait for its status to
+// change to in-use.  Detach the volume and wait for its status to change back to
+// available.  Delete the instance and volume.
+//
+// The instance and volume should be created correctly.  The volume should be attached
+// and detached without issue and its status should transition from available to in-use
+// and back to available.  The instance and the volume should be deleted without issue.
+func TestAttachDetach(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+
+	instanceID := createVMInstance(ctx, t, "")
+	var volumeID string
+	defer func() {
+		err := bat.DeleteInstanceAndWait(ctx, "", instanceID)
+		if err != nil {
+			t.Errorf("Failed to delete instance %s : %v",
+				instanceID, err)
+		}
+		if volumeID != "" {
+			err = bat.DeleteVolume(ctx, "", volumeID)
+			if err != nil {
+				t.Errorf("Failed to delete volume %s : %v", volumeID, err)
+			}
+		}
+
+	}()
+
+	volumeID, err := bat.AddVolume(ctx, "", "", "", &bat.VolumeOptions{
+		Size: 1,
+	})
+
+	if err != nil {
+		t.Fatalf("Unable to add volume :%v", err)
+	}
+
+	err = bat.AttachVolumeAndWait(ctx, "", instanceID, volumeID)
+	if err != nil {
+		t.Fatalf("Unable to attach volume %s to instance %s : %v",
+			volumeID, instanceID, err)
+	}
+
+	err = bat.DetachVolumeAndWait(ctx, "", volumeID)
+	if err != nil {
+		t.Fatalf("Unable to detach volume %s from instance %s : %v",
+			volumeID, instanceID, err)
+	}
+}
+
+// Check that we cannot attach to a running container
+//
+// Create a container instance and a volume.  Attach the volume.  Delete the container
+// and the volume.
+//
+// The container and the volume should be correctly created.  The attempt to
+// attach the volume to the container should initially succeed, but the volume should
+// quickly return to available state as it cannot be attached to a container.  The
+// container and the volume should be deleted correctly.
+func TestAttachToRunningContainer(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+
+	instanceID := createContainerInstance(ctx, t, "")
+	var volumeID string
+	defer func() {
+		err := bat.DeleteInstanceAndWait(ctx, "", instanceID)
+		if err != nil {
+			t.Errorf("Failed to delete instance %s : %v",
+				instanceID, err)
+		}
+		if volumeID != "" {
+			err = bat.DeleteVolume(ctx, "", volumeID)
+			if err != nil {
+				t.Errorf("Failed to delete volume %s : %v", volumeID, err)
+			}
+		}
+	}()
+
+	volumeID, err := bat.AddVolume(ctx, "", "", "", &bat.VolumeOptions{
+		Size: 1,
+	})
+
+	if err != nil {
+		t.Fatalf("Unable to add volume :%v", err)
+	}
+
+	err = bat.AttachVolume(ctx, "", instanceID, volumeID)
+	if err != nil {
+		t.Fatalf("Failed to attach volume %s to instance %s : %v",
+			volumeID, instanceID, err)
+	}
+
+	err = bat.WaitForVolumeStatus(ctx, "", volumeID, "available")
+	if err != nil {
+		t.Fatalf("An error occurred waiting for volume %s to become available : %v",
+			volumeID, err)
+	}
+}
+
+// Check that we cannot attach a volume to two instances
+//
+// Create two VM instances and a volume.  Attach the volume to both instances.
+// Delete the instances and the volume
+//
+// The instances and the volume should be correctly created.  However, the attempt to
+// attach the volume to the second instance should fail.  The volume and the instances
+// should be deleted without any problems.
+func TestDoubleAttach(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+
+	var volumeID string
+
+	defer func() {
+		if volumeID != "" {
+			err := bat.DeleteVolume(ctx, "", volumeID)
+			if err != nil {
+				t.Errorf("Failed to delete volume %s : %v", volumeID, err)
+			}
+		}
+	}()
+
+	instanceID1 := createVMInstance(ctx, t, "")
+	defer func() {
+		err := bat.DeleteInstanceAndWait(ctx, "", instanceID1)
+		if err != nil {
+			t.Errorf("Failed to delete instance %s : %v",
+				instanceID1, err)
+		}
+	}()
+
+	instanceID2 := createVMInstance(ctx, t, "")
+	defer func() {
+		err := bat.DeleteInstance(ctx, "", instanceID2)
+		if err != nil {
+			t.Errorf("Failed to delete instance %s : %v",
+				instanceID2, err)
+		}
+	}()
+
+	volumeID, err := bat.AddVolume(ctx, "", "", "", &bat.VolumeOptions{
+		Size: 1,
+	})
+
+	if err != nil {
+		t.Fatalf("Unable to add volume :%v", err)
+	}
+
+	err = bat.AttachVolume(ctx, "", instanceID1, volumeID)
+	if err != nil {
+		t.Fatalf("Unable to attach volume %s to instance %s : %v",
+			volumeID, instanceID1, err)
+	}
+
+	err = bat.AttachVolume(ctx, "", instanceID2, volumeID)
+	if err == nil {
+		t.Fatalf("Attempt to attach volume %s to instance %s should have failed",
+			volumeID, instanceID2)
+	} else if err == context.Canceled {
+		t.Fatalf("Attempt to attach volume %s to instance %s timed out : %v",
+			volumeID, instanceID2, err)
+	}
+
+	err = bat.WaitForVolumeStatus(ctx, "", volumeID, "in-use")
+	if err != nil {
+		t.Fatalf("Volume %s did not attach correctly : %v", volumeID, err)
+	}
+
+	err = bat.DetachVolumeAndWait(ctx, "", volumeID)
+	if err != nil {
+		t.Fatalf("Volume %s did not detach correctly : %v", volumeID, err)
+	}
+}
+
+// Check we can attach a volume to a stopped instance
+//
+// Boot a VM which has no data volumes attached and stop the instance.  Create
+// and attach a volume.  Delete the instance and the volume.
+//
+// The instance should be created and stopped succesfully.  The volume should be
+// created and attached succesfully.  The volume and instance should be deleted
+// without error.
+func TestAttachToStoppedInstance(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+
+	instanceID := createVMInstance(ctx, t, "")
+	var volumeID string
+	defer func() {
+		err := bat.DeleteInstanceAndWait(ctx, "", instanceID)
+		if err != nil {
+			t.Errorf("Failed to delete instance %s : %v",
+				instanceID, err)
+		}
+		if volumeID != "" {
+			err = bat.DeleteVolume(ctx, "", volumeID)
+			if err != nil {
+				t.Errorf("Failed to delete volume %s : %v", volumeID, err)
+			}
+		}
+	}()
+
+	err := bat.StopInstanceAndWait(ctx, "", instanceID)
+	if err != nil {
+		t.Fatalf("Failed to stop instance %s : %v", instanceID, err)
+	}
+
+	volumeID, err = bat.AddVolume(ctx, "", "", "", &bat.VolumeOptions{
+		Size: 1,
+	})
+
+	if err != nil {
+		t.Fatalf("Unable to add volume :%v", err)
+	}
+
+	err = bat.AttachVolumeAndWait(ctx, "", instanceID, volumeID)
+	if err != nil {
+		t.Fatalf("Unable to attach volume %s to instance %s : %v",
+			volumeID, instanceID, err)
+	}
+}

--- a/bat/compute.go
+++ b/bat/compute.go
@@ -29,11 +29,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -94,32 +92,6 @@ type ClusterStatus struct {
 	TotalNodesFull        int `json:"total_nodes_full"`
 	TotalNodesOffline     int `json:"total_nodes_offline"`
 	TotalNodesMaintenance int `json:"total_nodes_maintenance"`
-}
-
-// ImageOptions contains user supplied image meta data
-type ImageOptions struct {
-	Name             string
-	ID               string
-	ContainerFormat  string
-	DiskFormat       string
-	MinDiskGigabytes int
-	MinRAMMegabytes  int
-	Protected        bool
-	Visibility       string
-	Tags             []string
-}
-
-// Image contains all the meta data for a single image
-type Image struct {
-	ImageOptions
-	SizeBytes   int
-	Status      string
-	Owner       string
-	Checksum    string
-	CreatedDate string
-	LastUpdate  string
-	File        string
-	Schema      string
 }
 
 func checkEnv(vars []string) error {
@@ -555,163 +527,4 @@ func GetClusterStatus(ctx context.Context) (*ClusterStatus, error) {
 	}
 
 	return cs, nil
-}
-
-func computeImageAddArgs(options *ImageOptions) []string {
-	args := make([]string, 0, 8)
-
-	if options.ContainerFormat != "" {
-		args = append(args, "-container-format", options.ContainerFormat)
-	}
-	if options.DiskFormat != "" {
-		args = append(args, "-disk-format", options.DiskFormat)
-	}
-	if options.ID != "" {
-		args = append(args, "-id", options.ID)
-	}
-	if options.MinDiskGigabytes != 0 {
-		args = append(args, "-min-disk-size",
-			fmt.Sprintf("%d", options.MinDiskGigabytes))
-	}
-	if options.MinRAMMegabytes != 0 {
-		args = append(args, "-min-ram-size",
-			fmt.Sprintf("%d", options.MinRAMMegabytes))
-	}
-	if options.Name != "" {
-		args = append(args, "-name", options.Name)
-	}
-	if options.Protected {
-		args = append(args, "-protected")
-	}
-	if len(options.Tags) > 0 {
-		args = append(args, "-tags", strings.Join(options.Tags, ","))
-	}
-	if options.Visibility != "" {
-		args = append(args, "-visibility", options.Visibility)
-	}
-
-	return args
-}
-
-// AddImage uploads a new image to the ciao-image service.  The caller can
-// supply a number of pieces of meta data about the image via the options
-// parameter.  It is implemented by calling ciao-cli image add.
-// On success the function returns the entire meta data of the
-// newly updated image that includes the caller supplied meta data and the
-// meta data added by the image service.  An error will be returned
-// if the following environment variables are not set; CIAO_IDENTITY,
-// CIAO_CONTROLLER, CIAO_ADMIN_USERNAME, CIAO_ADMIN_PASSWORD.
-func AddImage(ctx context.Context, tenant, path string, options *ImageOptions) (*Image, error) {
-	var img *Image
-	args := []string{"image", "add", "-f", "{{tojson .}}", "-file", path}
-	args = append(args, computeImageAddArgs(options)...)
-	err := RunCIAOCLIAsAdminJS(ctx, tenant, args, &img)
-	if err != nil {
-		return nil, err
-	}
-
-	return img, nil
-}
-
-// DeleteImage deletes an image from the image service.  It is implemented
-// by calling ciao-cli image delete.  An error will be returned if the following
-// environment variables are not set; CIAO_IDENTITY, CIAO_CONTROLLER,
-// CIAO_ADMIN_USERNAME, CIAO_ADMIN_PASSWORD.
-func DeleteImage(ctx context.Context, tenant, ID string) error {
-	args := []string{"image", "delete", "-image", ID}
-	_, err := RunCIAOCLIAsAdmin(ctx, tenant, args)
-	return err
-}
-
-// GetImage retrieves the meta data for a given image.  It is implemented by
-// calling ciao-cli image show.  An error will be returned if the following
-// environment variables are not set; CIAO_IDENTITY, CIAO_CONTROLLER,
-// CIAO_ADMIN_USERNAME, CIAO_ADMIN_PASSWORD.
-func GetImage(ctx context.Context, tenant, ID string) (*Image, error) {
-	var img *Image
-	args := []string{"image", "show", "-image", ID, "-f", "{{tojson .}}"}
-
-	err := RunCIAOCLIAsAdminJS(ctx, tenant, args, &img)
-	if err != nil {
-		return nil, err
-	}
-
-	return img, nil
-}
-
-// GetImages retrieves the meta data for all images.  It is implemented by
-// calling ciao-cli image list.  An error will be returned if the following
-// environment variables are not set; CIAO_IDENTITY, CIAO_CONTROLLER,
-// CIAO_ADMIN_USERNAME, CIAO_ADMIN_PASSWORD.
-func GetImages(ctx context.Context, tenant string) (map[string]*Image, error) {
-	var images map[string]*Image
-	template := `
-{
-{{- range $i, $val := .}}
-  {{- if $i }},{{end}}
-  "{{$val.ID | js }}" : {{tojson $val}}
-{{- end }}
-}
-`
-	args := []string{"image", "list", "-f", template}
-	err := RunCIAOCLIAsAdminJS(ctx, tenant, args, &images)
-	if err != nil {
-		return nil, err
-	}
-
-	return images, nil
-}
-
-// GetImageCount returns the number of images currently stored in the
-// image service.  It is implemented by calling ciao-cli image list.
-// An error will be returned if the following environment variables are
-// not set; CIAO_IDENTITY, CIAO_CONTROLLER, CIAO_ADMIN_USERNAME,
-// CIAO_ADMIN_PASSWORD.
-func GetImageCount(ctx context.Context, tenant string) (int, error) {
-	args := []string{"image", "list", "-f", "{{len .}}"}
-
-	data, err := RunCIAOCLIAsAdmin(ctx, tenant, args)
-	if err != nil {
-		return 0, err
-	}
-
-	return strconv.Atoi(string(data))
-}
-
-// UploadImage overrides the contents of an existing image with a new file.  It is
-// implemented by calling ciao-cli image upload.  An error will be returned if the
-// following environment variables are not set; CIAO_IDENTITY, CIAO_CONTROLLER,
-// CIAO_ADMIN_USERNAME, CIAO_ADMIN_PASSWORD.
-func UploadImage(ctx context.Context, tenant, ID, path string) error {
-	args := []string{"image", "upload", "-image", ID, "-file", path}
-	_, err := RunCIAOCLIAsAdmin(ctx, tenant, args)
-	return err
-}
-
-// CreateRandomFile creates a file of the desired size with random data
-// returning the path.
-func CreateRandomFile(sizeMB int) (path string, err error) {
-	var f *os.File
-	f, err = ioutil.TempFile("/tmp", "ciao-random-")
-	if err != nil {
-		return
-	}
-	defer func() {
-		err1 := f.Close()
-		if err1 != nil && err == nil {
-			err = err1
-		}
-	}()
-
-	b := make([]byte, sizeMB*1000000)
-	_, err = rand.Read(b)
-	if err != nil {
-		return
-	}
-	_, err = f.Write(b)
-	if err == nil {
-		path = f.Name()
-	}
-
-	return
 }

--- a/bat/image.go
+++ b/bat/image.go
@@ -1,0 +1,219 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package bat contains a number of helper functions that can be used to perform
+// various operations on a ciao cluster such as creating an instance or retrieving
+// a list of all the defined workloads, etc.  All of these helper functions are
+// implemented by calling ciao-cli rather than by using ciao's REST APIs.  This
+// package is mainly intended for use by BAT tests.  Manipulating the cluster
+// via ciao-cli, rather than through the REST APIs, allows us to test a little
+// bit more of ciao.
+package bat
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// ImageOptions contains user supplied image meta data
+type ImageOptions struct {
+	Name             string
+	ID               string
+	ContainerFormat  string
+	DiskFormat       string
+	MinDiskGigabytes int
+	MinRAMMegabytes  int
+	Protected        bool
+	Visibility       string
+	Tags             []string
+}
+
+// Image contains all the meta data for a single image
+type Image struct {
+	ImageOptions
+	SizeBytes   int
+	Status      string
+	Owner       string
+	Checksum    string
+	CreatedDate string
+	LastUpdate  string
+	File        string
+	Schema      string
+}
+
+func computeImageAddArgs(options *ImageOptions) []string {
+	args := make([]string, 0, 8)
+
+	if options.ContainerFormat != "" {
+		args = append(args, "-container-format", options.ContainerFormat)
+	}
+	if options.DiskFormat != "" {
+		args = append(args, "-disk-format", options.DiskFormat)
+	}
+	if options.ID != "" {
+		args = append(args, "-id", options.ID)
+	}
+	if options.MinDiskGigabytes != 0 {
+		args = append(args, "-min-disk-size",
+			fmt.Sprintf("%d", options.MinDiskGigabytes))
+	}
+	if options.MinRAMMegabytes != 0 {
+		args = append(args, "-min-ram-size",
+			fmt.Sprintf("%d", options.MinRAMMegabytes))
+	}
+	if options.Name != "" {
+		args = append(args, "-name", options.Name)
+	}
+	if options.Protected {
+		args = append(args, "-protected")
+	}
+	if len(options.Tags) > 0 {
+		args = append(args, "-tags", strings.Join(options.Tags, ","))
+	}
+	if options.Visibility != "" {
+		args = append(args, "-visibility", options.Visibility)
+	}
+
+	return args
+}
+
+// AddImage uploads a new image to the ciao-image service.  The caller can
+// supply a number of pieces of meta data about the image via the options
+// parameter.  It is implemented by calling ciao-cli image add.
+// On success the function returns the entire meta data of the
+// newly updated image that includes the caller supplied meta data and the
+// meta data added by the image service.  An error will be returned
+// if the following environment variables are not set; CIAO_IDENTITY,
+// CIAO_CONTROLLER, CIAO_ADMIN_USERNAME, CIAO_ADMIN_PASSWORD.
+func AddImage(ctx context.Context, tenant, path string, options *ImageOptions) (*Image, error) {
+	var img *Image
+	args := []string{"image", "add", "-f", "{{tojson .}}", "-file", path}
+	args = append(args, computeImageAddArgs(options)...)
+	err := RunCIAOCLIAsAdminJS(ctx, tenant, args, &img)
+	if err != nil {
+		return nil, err
+	}
+
+	return img, nil
+}
+
+// DeleteImage deletes an image from the image service.  It is implemented
+// by calling ciao-cli image delete.  An error will be returned if the following
+// environment variables are not set; CIAO_IDENTITY, CIAO_CONTROLLER,
+// CIAO_ADMIN_USERNAME, CIAO_ADMIN_PASSWORD.
+func DeleteImage(ctx context.Context, tenant, ID string) error {
+	args := []string{"image", "delete", "-image", ID}
+	_, err := RunCIAOCLIAsAdmin(ctx, tenant, args)
+	return err
+}
+
+// GetImage retrieves the meta data for a given image.  It is implemented by
+// calling ciao-cli image show.  An error will be returned if the following
+// environment variables are not set; CIAO_IDENTITY, CIAO_CONTROLLER,
+// CIAO_ADMIN_USERNAME, CIAO_ADMIN_PASSWORD.
+func GetImage(ctx context.Context, tenant, ID string) (*Image, error) {
+	var img *Image
+	args := []string{"image", "show", "-image", ID, "-f", "{{tojson .}}"}
+
+	err := RunCIAOCLIAsAdminJS(ctx, tenant, args, &img)
+	if err != nil {
+		return nil, err
+	}
+
+	return img, nil
+}
+
+// GetImages retrieves the meta data for all images.  It is implemented by
+// calling ciao-cli image list.  An error will be returned if the following
+// environment variables are not set; CIAO_IDENTITY, CIAO_CONTROLLER,
+// CIAO_ADMIN_USERNAME, CIAO_ADMIN_PASSWORD.
+func GetImages(ctx context.Context, tenant string) (map[string]*Image, error) {
+	var images map[string]*Image
+	template := `
+{
+{{- range $i, $val := .}}
+  {{- if $i }},{{end}}
+  "{{$val.ID | js }}" : {{tojson $val}}
+{{- end }}
+}
+`
+	args := []string{"image", "list", "-f", template}
+	err := RunCIAOCLIAsAdminJS(ctx, tenant, args, &images)
+	if err != nil {
+		return nil, err
+	}
+
+	return images, nil
+}
+
+// GetImageCount returns the number of images currently stored in the
+// image service.  It is implemented by calling ciao-cli image list.
+// An error will be returned if the following environment variables are
+// not set; CIAO_IDENTITY, CIAO_CONTROLLER, CIAO_ADMIN_USERNAME,
+// CIAO_ADMIN_PASSWORD.
+func GetImageCount(ctx context.Context, tenant string) (int, error) {
+	args := []string{"image", "list", "-f", "{{len .}}"}
+
+	data, err := RunCIAOCLIAsAdmin(ctx, tenant, args)
+	if err != nil {
+		return 0, err
+	}
+
+	return strconv.Atoi(string(data))
+}
+
+// UploadImage overrides the contents of an existing image with a new file.  It is
+// implemented by calling ciao-cli image upload.  An error will be returned if the
+// following environment variables are not set; CIAO_IDENTITY, CIAO_CONTROLLER,
+// CIAO_ADMIN_USERNAME, CIAO_ADMIN_PASSWORD.
+func UploadImage(ctx context.Context, tenant, ID, path string) error {
+	args := []string{"image", "upload", "-image", ID, "-file", path}
+	_, err := RunCIAOCLIAsAdmin(ctx, tenant, args)
+	return err
+}
+
+// CreateRandomFile creates a file of the desired size with random data
+// returning the path.
+func CreateRandomFile(sizeMB int) (path string, err error) {
+	var f *os.File
+	f, err = ioutil.TempFile("/tmp", "ciao-random-")
+	if err != nil {
+		return
+	}
+	defer func() {
+		err1 := f.Close()
+		if err1 != nil && err == nil {
+			err = err1
+		}
+	}()
+
+	b := make([]byte, sizeMB*1000000)
+	_, err = rand.Read(b)
+	if err != nil {
+		return
+	}
+	_, err = f.Write(b)
+	if err == nil {
+		path = f.Name()
+	}
+
+	return
+}

--- a/bat/storage.go
+++ b/bat/storage.go
@@ -1,0 +1,201 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package bat
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// VolumeOptions contains user supplied volume meta data
+type VolumeOptions struct {
+	Size        int
+	Name        string
+	Description string
+}
+
+// Volume contains information about a single volume
+type Volume struct {
+	VolumeOptions
+	ID        string
+	TenantID  string
+	CreatedAt string
+	Status    string
+}
+
+// GetVolume returns a Volume structure containing information about a specific
+// volume.  The information is retrieved by calling ciao-cli volume show.  An
+// error will be returned if the following environment variables are not set;
+// CIAO_IDENTITY,  CIAO_CONTROLLER, CIAO_USERNAME, CIAO_PASSWORD.
+func GetVolume(ctx context.Context, tenant, ID string) (*Volume, error) {
+	var vol *Volume
+	args := []string{"volume", "show", "--volume", ID, "-f", "{{tojson .}}"}
+	err := RunCIAOCLIJS(ctx, tenant, args, &vol)
+	if err != nil {
+		return nil, err
+	}
+
+	return vol, nil
+}
+
+// DeleteVolume deletes the specified volume from a given tenant.  The volume
+// is deleted by calling ciao-cli volume delete.  An error will be returned
+// if the following environment variables are not set; CIAO_IDENTITY,
+// CIAO_CONTROLLER, CIAO_USERNAME, CIAO_PASSWORD.
+func DeleteVolume(ctx context.Context, tenant, ID string) error {
+	args := []string{"volume", "delete", "--volume", ID}
+	_, err := RunCIAOCLI(ctx, tenant, args)
+	return err
+}
+
+// AddVolume adds a new volume to a tenant.  The volume is added using
+// ciao-cli volume add.  An error will be returned if the following environment
+// variables are not set; CIAO_IDENTITY, CIAO_CONTROLLER, CIAO_USERNAME,
+// CIAO_PASSWORD.
+func AddVolume(ctx context.Context, tenant, source, sourceType string,
+	options *VolumeOptions) (string, error) {
+	args := []string{"volume", "add"}
+
+	if sourceType != "" {
+		if source == "" {
+			panic("sourceType supplied but source is empty")
+		}
+		args = append(args, "--source-type", sourceType)
+	}
+
+	if source != "" {
+		args = append(args, "--source", source)
+	}
+
+	if options.Name != "" {
+		args = append(args, "--name", options.Name)
+	}
+
+	if options.Description != "" {
+		args = append(args, "--description", options.Description)
+	}
+
+	if options.Size != 0 {
+		args = append(args, "--size", fmt.Sprintf("%d", options.Size))
+	}
+
+	data, err := RunCIAOCLI(ctx, tenant, args)
+	if err != nil {
+		return "", err
+	}
+
+	split := bytes.Split(data, []byte{':'})
+	if len(split) != 2 {
+		return "", fmt.Errorf("unable to determine id of created volume")
+	}
+
+	return strings.TrimSpace(string(split[1])), nil
+}
+
+// GetAllVolumes returns a map of all the volumes defined in the specified
+// tenant.  The map is indexed by volume ID.  The map is retrieved by calling
+// ciao-cli volume list.  An error will be returned if the following environment
+// variables are not set; CIAO_IDENTITY, CIAO_CONTROLLER, CIAO_USERNAME,
+// CIAO_PASSWORD.
+func GetAllVolumes(ctx context.Context, tenant string) (map[string]*Volume, error) {
+	var volumes map[string]*Volume
+
+	template := `
+{
+{{- range $i, $val := .}}
+  {{- if $i }},{{end}}
+  "{{$val.ID | js }}" : {{tojson $val}}
+{{- end }}
+}
+`
+	args := []string{"volume", "list", "-f", template}
+	err := RunCIAOCLIJS(ctx, tenant, args, &volumes)
+	if err != nil {
+		return nil, err
+	}
+
+	return volumes, nil
+}
+
+// WaitForVolumeStatus blocks until the status of the specified volume matches
+// the status parameter or the context is cancelled.    An error will be returned
+// if the following environment variables are not set; CIAO_IDENTITY, CIAO_CONTROLLER,
+// CIAO_USERNAME, CIAO_PASSWORD.
+func WaitForVolumeStatus(ctx context.Context, tenant, volume, status string) error {
+	for {
+		vol, err := GetVolume(ctx, tenant, volume)
+		if err != nil {
+			return fmt.Errorf("Unable to retrieve meta data for volume %s :%v",
+				volume, err)
+		}
+		if status == vol.Status {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("Test timed out waiting for volume %s status=%s",
+				volume, status)
+		case <-time.After(time.Second):
+		}
+	}
+
+	return nil
+}
+
+// AttachVolume attaches a volume to an instance.    An error will be returned
+// if the following environment variables are not set; CIAO_IDENTITY, CIAO_CONTROLLER,
+// CIAO_USERNAME, CIAO_PASSWORD.
+func AttachVolume(ctx context.Context, tenant, instance, volume string) error {
+	args := []string{"volume", "attach", "--volume", volume,
+		"--instance", instance}
+	_, err := RunCIAOCLI(ctx, tenant, args)
+	return err
+}
+
+// AttachVolumeAndWait attaches a volume to an instance and waits for the status of that
+// volume to transition to "in-use".  An error will be returned if the following environment
+// variables are not set; CIAO_IDENTITY, CIAO_CONTROLLER, CIAO_USERNAME, CIAO_PASSWORD.
+func AttachVolumeAndWait(ctx context.Context, tenant, instance, volume string) error {
+	err := AttachVolume(ctx, tenant, instance, volume)
+	if err != nil {
+		return err
+	}
+	return WaitForVolumeStatus(ctx, tenant, volume, "in-use")
+}
+
+// DetachVolume detaches a volume from an instance.    An error will be returned
+// if the following environment variables are not set; CIAO_IDENTITY, CIAO_CONTROLLER,
+// CIAO_USERNAME, CIAO_PASSWORD.
+func DetachVolume(ctx context.Context, tenant, volume string) error {
+	args := []string{"volume", "detach", "--volume", volume}
+	_, err := RunCIAOCLI(ctx, tenant, args)
+	return err
+}
+
+// DetachVolumeAndWait attaches a volume to an instance and waits for the status of that
+// volume to transition to "available".  An error will be returned if the following environment
+// variables are not set; CIAO_IDENTITY, CIAO_CONTROLLER, CIAO_USERNAME, CIAO_PASSWORD.
+func DetachVolumeAndWait(ctx context.Context, tenant, volume string) error {
+	err := DetachVolume(ctx, tenant, volume)
+	if err != nil {
+		return err
+	}
+	return WaitForVolumeStatus(ctx, tenant, volume, "available")
+}


### PR DESCRIPTION
bat: Add storage bat tests
    
This PR adds the following storage BAT tests
    
- Test bootable volumes are created and deleted correctly
- Check bootable volumes of stopped instances are in-use
- Check that in-use volumes cannot be deleted
- Check that the rootfs volumes cannot be detached
- Check that volumes can be added, listed and deleted
- Check attaching volumes become available when deleting their instance.
- Check that a deleting a detaching volume fails
- Check that we can attach and detach volumes
- Check that we cannot attach to a running container
- Check that we cannot attach a volume to two instances
- Check we can attach a volume to a stopped instance
    
As we now have multiple BAT tests that create and delete instances in the same tenant the BAT tests should be run with test-cases, rather than go test, as the latter runs tests for separate packages concurrently, which is not what we currently want.

This PR also splits the bat.go file into multiple go files to make it easier to navigate.  Finally, it updates the ciao-cli command to take advantage of the new functions in the ciao-cli template language. 
    
Fixes #682
