### PR TITLE
ciao-image: Fix open file issue on posix write ops

### DIFF
--- a/ciao-image/datastore/datastore.go
+++ b/ciao-image/datastore/datastore.go
@@ -104,6 +104,6 @@ type MetaDataStore interface {
 // RawDataStore is the raw data storage interface that's used by the
 // image cache implementation.
 type RawDataStore interface {
-	Write(ID string, body io.Reader) (int64, error)
+	Write(ID string, body io.Reader) error
 	Delete(ID string) error
 }

--- a/ciao-image/datastore/posix.go
+++ b/ciao-image/datastore/posix.go
@@ -40,7 +40,15 @@ func (p *Posix) Write(ID string, body io.Reader) (int64, error) {
 
 	buf := make([]byte, 1<<16)
 
-	return io.CopyBuffer(image, body, buf)
+	length, err := io.CopyBuffer(image, body, buf)
+	defer func() {
+		err1 := image.Close()
+		if err == nil {
+			err = err1
+		}
+	}()
+
+	return length, err
 }
 
 // Delete removes an image from the posix filesystem

--- a/ciao-image/datastore/posix.go
+++ b/ciao-image/datastore/posix.go
@@ -27,20 +27,20 @@ type Posix struct {
 }
 
 // Write copies an image into the posix filesystem.
-func (p *Posix) Write(ID string, body io.Reader) (int64, error) {
+func (p *Posix) Write(ID string, body io.Reader) (err error) {
 	imageName := path.Join(p.MountPoint, ID)
 	if _, err := os.Stat(imageName); !os.IsNotExist(err) {
-		return 0, fmt.Errorf("image already uploaded with that ID")
+		return fmt.Errorf("image already uploaded with that ID")
 	}
 
 	image, err := os.Create(imageName)
 	if err != nil {
-		return 0, err
+		return err
 	}
 
 	buf := make([]byte, 1<<16)
 
-	length, err := io.CopyBuffer(image, body, buf)
+	_, err = io.CopyBuffer(image, body, buf)
 	defer func() {
 		err1 := image.Close()
 		if err == nil {
@@ -48,7 +48,7 @@ func (p *Posix) Write(ID string, body io.Reader) (int64, error) {
 		}
 	}()
 
-	return length, err
+	return err
 }
 
 // Delete removes an image from the posix filesystem

--- a/ciao-image/datastore/store.go
+++ b/ciao-image/datastore/store.go
@@ -159,7 +159,7 @@ func (s *ImageStore) UploadImage(ID string, body io.Reader) error {
 	img.State = Saving
 
 	if s.rawDs != nil {
-		_, err := s.rawDs.Write(ID, body)
+		err := s.rawDs.Write(ID, body)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When writing a new image on posix backend, we open a new file
and drop all image data there, this opened file needs to be
closed before ending the function.

Fixes #661

Signed-off-by: Obed N Munoz <obed.n.munoz@intel.com>