### PR TITLE
ciao-controller: Add boot flag to attachment

### DIFF
--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -95,7 +95,7 @@ func (i *instance) Add() error {
 	}
 	storage := i.newConfig.sc.Start.Storage
 	if (storage != payloads.StorageResources{}) {
-		_, err := ds.CreateStorageAttachment(i.Instance.ID, storage.ID, storage.Ephemeral)
+		_, err := ds.CreateStorageAttachment(i.Instance.ID, storage.ID, storage.Ephemeral, storage.Bootable)
 		if err != nil {
 			glog.Error(err)
 		}

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -1490,7 +1490,7 @@ func (ds *Datastore) UpdateBlockDevice(data types.BlockData) error {
 
 // CreateStorageAttachment will associate an instance with a block device in
 // the datastore
-func (ds *Datastore) CreateStorageAttachment(instanceID string, blockID string, ephemeral bool) (types.StorageAttachment, error) {
+func (ds *Datastore) CreateStorageAttachment(instanceID string, blockID string, ephemeral bool, boot bool) (types.StorageAttachment, error) {
 	link := attachment{
 		instanceID: instanceID,
 		volumeID:   blockID,
@@ -1501,6 +1501,7 @@ func (ds *Datastore) CreateStorageAttachment(instanceID string, blockID string, 
 		ID:         uuid.Generate().String(),
 		BlockID:    blockID,
 		Ephemeral:  ephemeral,
+		Boot:       boot,
 	}
 
 	err := ds.db.createStorageAttachment(a)

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -1818,7 +1818,7 @@ func TestCreateStorageAttachment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false)
+	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1875,7 +1875,7 @@ func TestUpdateStorageAttachmentExisting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false)
+	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1982,7 +1982,7 @@ func TestUpdateStorageAttachmentDeleted(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false)
+	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2032,7 +2032,7 @@ func TestGetStorageAttachment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false)
+	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2127,7 +2127,7 @@ func TestDeleteStorageAttachment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false)
+	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2189,7 +2189,7 @@ func TestDeleteStorageAttachmentError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false)
+	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2256,7 +2256,7 @@ func TestGetVolumeAttachments(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false)
+	_, err = ds.CreateStorageAttachment(instance.ID, data.ID, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -220,6 +220,7 @@ func (d attachments) Init() error {
 		instance_id string,
 		block_id string,
 		ephemeral int,
+		boot int,
 		foreign key(instance_id) references instances(id),
 		foreign key(block_id) references block_data(id)
 		);`
@@ -2317,7 +2318,7 @@ func (ds *sqliteDB) createStorageAttachment(a types.StorageAttachment) error {
 		return err
 	}
 
-	_, err = tx.Exec("INSERT INTO attachments (id, instance_id, block_id, ephemeral) VALUES (?, ?, ?, ?)", a.ID, a.InstanceID, a.BlockID, a.Ephemeral)
+	_, err = tx.Exec("INSERT INTO attachments (id, instance_id, block_id, ephemeral, boot) VALUES (?, ?, ?, ?, ?)", a.ID, a.InstanceID, a.BlockID, a.Ephemeral, a.Boot)
 	if err != nil {
 		tx.Rollback()
 		ds.dbLock.Unlock()
@@ -2338,7 +2339,8 @@ func (ds *sqliteDB) getAllStorageAttachments() (map[string]types.StorageAttachme
 	query := `SELECT	attachments.id,
 				attachments.instance_id,
 				attachments.block_id,
-				attachments.ephemeral
+				attachments.ephemeral,
+				attachments.boot
 		  FROM	attachments `
 
 	rows, err := datastore.Query(query)
@@ -2350,7 +2352,7 @@ func (ds *sqliteDB) getAllStorageAttachments() (map[string]types.StorageAttachme
 	for rows.Next() {
 		var a types.StorageAttachment
 
-		err = rows.Scan(&a.ID, &a.InstanceID, &a.BlockID, &a.Ephemeral)
+		err = rows.Scan(&a.ID, &a.InstanceID, &a.BlockID, &a.Ephemeral, &a.Boot)
 		if err != nil {
 			continue
 		}

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -235,6 +235,15 @@ func (c *controller) DetachVolume(tenant string, volume string, attachment strin
 		return block.ErrVolumeNotAttached
 	}
 
+	// we cannot detach a boot device - these aren't
+	// like regular attachments and shouldn't be treated
+	// as such.
+	for _, a := range attachments {
+		if a.Boot == true {
+			return block.ErrVolumeNotAttached
+		}
+	}
+
 	// update volume state to detaching
 	info.State = types.Detaching
 

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -252,6 +252,7 @@ type StorageAttachment struct {
 	InstanceID string // the instance this volume is attached to
 	BlockID    string // the ID of the block device
 	Ephemeral  bool   // whether the storage should be deleted on Cleanup
+	Boot       bool   // whether this is a boot device
 }
 
 // CiaoComputeTenants represents the unmarshalled version of the contents of a


### PR DESCRIPTION
Add a flag to indicate whether the attachment is for a boot volume.
If a user requests a detach of an attachment that is a boot device,
send a 403 to indicate this is a forbidden operation.

Fixes: #870

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>