### PR TITLE
fix comments on ssntp error versus event

### DIFF
--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -951,19 +951,19 @@ func setSSNTPForwardRules(sched *ssntpSchedulerServer) {
 			Operand: ssntp.ConcentratorInstanceAdded,
 			Dest:    ssntp.Controller,
 		},
-		{ // all StartFailure events go to all Controllers
+		{ // all StartFailure errors go to all Controllers
 			Operand: ssntp.StartFailure,
 			Dest:    ssntp.Controller,
 		},
-		{ // all StopFailure events go to all Controllers
+		{ // all StopFailure errors go to all Controllers
 			Operand: ssntp.StopFailure,
 			Dest:    ssntp.Controller,
 		},
-		{ // all RestartFailure events go to all Controllers
+		{ // all RestartFailure errors go to all Controllers
 			Operand: ssntp.RestartFailure,
 			Dest:    ssntp.Controller,
 		},
-		{ // all DeleteFailure events go to all Controllers
+		{ // all DeleteFailure errors go to all Controllers
 			Operand: ssntp.DeleteFailure,
 			Dest:    ssntp.Controller,
 		},

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -702,27 +702,27 @@ func StartTestServer() *SsntpTestServer {
 				Operand: ssntp.ConcentratorInstanceAdded,
 				Dest:    ssntp.Controller,
 			},
-			{ // all StartFailure events go to all Controllers
+			{ // all StartFailure errors go to all Controllers
 				Operand: ssntp.StartFailure,
 				Dest:    ssntp.Controller,
 			},
-			{ // all StopFailure events go to all Controllers
+			{ // all StopFailure errors go to all Controllers
 				Operand: ssntp.StopFailure,
 				Dest:    ssntp.Controller,
 			},
-			{ // all RestartFailure events go to all Controllers
+			{ // all RestartFailure errors go to all Controllers
 				Operand: ssntp.RestartFailure,
 				Dest:    ssntp.Controller,
 			},
-			{ // all DeleteFailure events go to all Controllers
+			{ // all DeleteFailure errors go to all Controllers
 				Operand: ssntp.DeleteFailure,
 				Dest:    ssntp.Controller,
 			},
-			{ // all VolumeAttachFailure events go to all Controllers
+			{ // all VolumeAttachFailure errors go to all Controllers
 				Operand: ssntp.AttachVolumeFailure,
 				Dest:    ssntp.Controller,
 			},
-			{ // all VolumeDetachFailure events go to all Controllers
+			{ // all VolumeDetachFailure errors go to all Controllers
 				Operand: ssntp.DetachVolumeFailure,
 				Dest:    ssntp.Controller,
 			},


### PR DESCRIPTION
A series of SSNTP Error type frames are mis-identified in comments in
the ciao-scheduler and testutil ssntp servers.  They are referred to as
"event", which is a specific ssntp frame type distinct from "error".  This
mis-identification can lead to confusion regarding what must be explicitly
forwarded by an ssntp server versus is automatically propagated.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>