### PR TITLE
ciao-scheduler: add forwarding rules for attach/detach volume failure

### DIFF
--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -1007,6 +1007,14 @@ func setSSNTPForwardRules(sched *ssntpSchedulerServer) {
 			Operand:        ssntp.DetachVolume,
 			CommandForward: sched,
 		},
+		{ // all AttachVolumeFailure errors go to all Controllers
+			Operand: ssntp.AttachVolumeFailure,
+			Dest:    ssntp.Controller,
+		},
+		{ // all DetachVolumeFailure errors go to all Controllers
+			Operand: ssntp.DetachVolumeFailure,
+			Dest:    ssntp.Controller,
+		},
 	}
 }
 


### PR DESCRIPTION
Modify the scheduler forwarding rules to forward attach/detach errors
to controller.

Fixes: #871

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>