### PR TITLE
testutil: channels are a reference type

### DIFF
--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -532,7 +532,7 @@ func doAttachVolumeCommand(t *testing.T, fail bool) (client *testutil.SsntpTestC
 
 	serverCh := server.AddCmdChan(ssntp.AttachVolume)
 	agentCh := client.AddCmdChan(ssntp.AttachVolume)
-	var serverErrorCh *chan testutil.Result
+	var serverErrorCh chan testutil.Result
 
 	time.Sleep(1 * time.Second)
 
@@ -616,7 +616,7 @@ func doDetachVolumeCommand(t *testing.T, fail bool) {
 
 	serverCh := server.AddCmdChan(ssntp.DetachVolume)
 	agentCh := client.AddCmdChan(ssntp.DetachVolume)
-	var serverErrorCh *chan testutil.Result
+	var serverErrorCh chan testutil.Result
 
 	if fail == true {
 		serverErrorCh = server.AddErrorChan(ssntp.DetachVolumeFailure)

--- a/ciao-scheduler/scheduler_ssntp_test.go
+++ b/ciao-scheduler/scheduler_ssntp_test.go
@@ -307,7 +307,7 @@ func TestRestartFailure(t *testing.T) {
 func doDelete(fail bool) error {
 	agentCh := agent.AddCmdChan(ssntp.DELETE)
 
-	var controllerErrorCh *chan testutil.Result
+	var controllerErrorCh chan testutil.Result
 
 	if fail == true {
 		controllerErrorCh = controller.AddErrorChan(ssntp.DeleteFailure)

--- a/testutil/agent.go
+++ b/testutil/agent.go
@@ -107,20 +107,20 @@ func NewSsntpTestClientConnection(name string, role ssntp.Role, uuid string) (*S
 }
 
 // AddCmdChan adds an ssntp.Command to the SsntpTestClient command channel
-func (client *SsntpTestClient) AddCmdChan(cmd ssntp.Command) *chan Result {
+func (client *SsntpTestClient) AddCmdChan(cmd ssntp.Command) chan Result {
 	c := make(chan Result)
 
 	client.CmdChansLock.Lock()
 	client.CmdChans[cmd] = c
 	client.CmdChansLock.Unlock()
 
-	return &c
+	return c
 }
 
 // GetCmdChanResult gets a Result from the SsntpTestClient command channel
-func (client *SsntpTestClient) GetCmdChanResult(c *chan Result, cmd ssntp.Command) (result Result, err error) {
+func (client *SsntpTestClient) GetCmdChanResult(c chan Result, cmd ssntp.Command) (result Result, err error) {
 	select {
-	case result = <-*c:
+	case result = <-c:
 		if result.Err != nil {
 			err = fmt.Errorf("Client error sending %s command: %s", cmd, result.Err)
 		}
@@ -146,20 +146,20 @@ func (client *SsntpTestClient) SendResultAndDelCmdChan(cmd ssntp.Command, result
 }
 
 // AddEventChan adds a ssntp.Event to the SsntpTestClient event channel
-func (client *SsntpTestClient) AddEventChan(evt ssntp.Event) *chan Result {
+func (client *SsntpTestClient) AddEventChan(evt ssntp.Event) chan Result {
 	c := make(chan Result)
 
 	client.EventChansLock.Lock()
 	client.EventChans[evt] = c
 	client.EventChansLock.Unlock()
 
-	return &c
+	return c
 }
 
 // GetEventChanResult gets a Result from the SsntpTestClient event channel
-func (client *SsntpTestClient) GetEventChanResult(c *chan Result, evt ssntp.Event) (result Result, err error) {
+func (client *SsntpTestClient) GetEventChanResult(c chan Result, evt ssntp.Event) (result Result, err error) {
 	select {
-	case result = <-*c:
+	case result = <-c:
 		if result.Err != nil {
 			err = fmt.Errorf("Client error sending %s event: %s", evt, result.Err)
 		}
@@ -185,20 +185,20 @@ func (client *SsntpTestClient) SendResultAndDelEventChan(evt ssntp.Event, result
 }
 
 // AddErrorChan adds a ssntp.Error to the SsntpTestClient error channel
-func (client *SsntpTestClient) AddErrorChan(error ssntp.Error) *chan Result {
+func (client *SsntpTestClient) AddErrorChan(error ssntp.Error) chan Result {
 	c := make(chan Result)
 
 	client.ErrorChansLock.Lock()
 	client.ErrorChans[error] = c
 	client.ErrorChansLock.Unlock()
 
-	return &c
+	return c
 }
 
 // GetErrorChanResult gets a Result from the SsntpTestClient error channel
-func (client *SsntpTestClient) GetErrorChanResult(c *chan Result, error ssntp.Error) (result Result, err error) {
+func (client *SsntpTestClient) GetErrorChanResult(c chan Result, error ssntp.Error) (result Result, err error) {
 	select {
-	case result = <-*c:
+	case result = <-c:
 		if result.Err != nil {
 			err = fmt.Errorf("Client error sending %s error: %s", error, result.Err)
 		}
@@ -224,20 +224,20 @@ func (client *SsntpTestClient) SendResultAndDelErrorChan(error ssntp.Error, resu
 }
 
 // AddStatusChan adds an ssntp.Status to the SsntpTestClient status channel
-func (client *SsntpTestClient) AddStatusChan(status ssntp.Status) *chan Result {
+func (client *SsntpTestClient) AddStatusChan(status ssntp.Status) chan Result {
 	c := make(chan Result)
 
 	client.StatusChansLock.Lock()
 	client.StatusChans[status] = c
 	client.StatusChansLock.Unlock()
 
-	return &c
+	return c
 }
 
 // GetStatusChanResult gets a Result from the SsntpTestClient status channel
-func (client *SsntpTestClient) GetStatusChanResult(c *chan Result, status ssntp.Status) (result Result, err error) {
+func (client *SsntpTestClient) GetStatusChanResult(c chan Result, status ssntp.Status) (result Result, err error) {
 	select {
-	case result = <-*c:
+	case result = <-c:
 		if result.Err != nil {
 			err = fmt.Errorf("Client error sending %s status: %s", status, result.Err)
 		}

--- a/testutil/client_server_test.go
+++ b/testutil/client_server_test.go
@@ -341,8 +341,8 @@ func doDelete(fail bool) error {
 	agentCh := agent.AddCmdChan(ssntp.DELETE)
 	serverCh := server.AddCmdChan(ssntp.DELETE)
 
-	var serverErrorCh *chan Result
-	var controllerErrorCh *chan Result
+	var serverErrorCh chan Result
+	var controllerErrorCh chan Result
 
 	if fail == true {
 		serverErrorCh = server.AddErrorChan(ssntp.DeleteFailure)
@@ -435,8 +435,8 @@ func doAttachVolume(fail bool) error {
 	agentCh := agent.AddCmdChan(ssntp.AttachVolume)
 	serverCh := server.AddCmdChan(ssntp.AttachVolume)
 
-	var serverErrorCh *chan Result
-	var controllerErrorCh *chan Result
+	var serverErrorCh chan Result
+	var controllerErrorCh chan Result
 
 	if fail == true {
 		serverErrorCh = server.AddErrorChan(ssntp.AttachVolumeFailure)
@@ -502,8 +502,8 @@ func doDetachVolume(fail bool) error {
 	agentCh := agent.AddCmdChan(ssntp.DetachVolume)
 	serverCh := server.AddCmdChan(ssntp.DetachVolume)
 
-	var serverErrorCh *chan Result
-	var controllerErrorCh *chan Result
+	var serverErrorCh chan Result
+	var controllerErrorCh chan Result
 
 	if fail == true {
 		serverErrorCh = server.AddErrorChan(ssntp.DetachVolumeFailure)

--- a/testutil/controller.go
+++ b/testutil/controller.go
@@ -81,20 +81,20 @@ func NewSsntpTestControllerConnection(name string, uuid string) (*SsntpTestContr
 }
 
 // AddCmdChan adds an ssntp.Command to the SsntpTestController command channel
-func (ctl *SsntpTestController) AddCmdChan(cmd ssntp.Command) *chan Result {
+func (ctl *SsntpTestController) AddCmdChan(cmd ssntp.Command) chan Result {
 	c := make(chan Result)
 
 	ctl.CmdChansLock.Lock()
 	ctl.CmdChans[cmd] = c
 	ctl.CmdChansLock.Unlock()
 
-	return &c
+	return c
 }
 
 // GetCmdChanResult gets a Result from the SsntpTestController command channel
-func (ctl *SsntpTestController) GetCmdChanResult(c *chan Result, cmd ssntp.Command) (result Result, err error) {
+func (ctl *SsntpTestController) GetCmdChanResult(c chan Result, cmd ssntp.Command) (result Result, err error) {
 	select {
-	case result = <-*c:
+	case result = <-c:
 		if result.Err != nil {
 			err = fmt.Errorf("Controller error sending %s command: %s", cmd, result.Err)
 		}
@@ -120,20 +120,20 @@ func (ctl *SsntpTestController) SendResultAndDelCmdChan(cmd ssntp.Command, resul
 }
 
 // AddEventChan adds an ssntp.Event to the SsntpTestController event channel
-func (ctl *SsntpTestController) AddEventChan(evt ssntp.Event) *chan Result {
+func (ctl *SsntpTestController) AddEventChan(evt ssntp.Event) chan Result {
 	c := make(chan Result)
 
 	ctl.EventChansLock.Lock()
 	ctl.EventChans[evt] = c
 	ctl.EventChansLock.Unlock()
 
-	return &c
+	return c
 }
 
 // GetEventChanResult gets a Result from the SsntpTestController event channel
-func (ctl *SsntpTestController) GetEventChanResult(c *chan Result, evt ssntp.Event) (result Result, err error) {
+func (ctl *SsntpTestController) GetEventChanResult(c chan Result, evt ssntp.Event) (result Result, err error) {
 	select {
-	case result = <-*c:
+	case result = <-c:
 		if result.Err != nil {
 			err = fmt.Errorf("Controller error sending %s event: %s", evt, result.Err)
 		}
@@ -159,20 +159,20 @@ func (ctl *SsntpTestController) SendResultAndDelEventChan(evt ssntp.Event, resul
 }
 
 // AddErrorChan adds an ssntp.Error to the SsntpTestController error channel
-func (ctl *SsntpTestController) AddErrorChan(error ssntp.Error) *chan Result {
+func (ctl *SsntpTestController) AddErrorChan(error ssntp.Error) chan Result {
 	c := make(chan Result)
 
 	ctl.ErrorChansLock.Lock()
 	ctl.ErrorChans[error] = c
 	ctl.ErrorChansLock.Unlock()
 
-	return &c
+	return c
 }
 
 // GetErrorChanResult gets a Result from the SsntpTestController error channel
-func (ctl *SsntpTestController) GetErrorChanResult(c *chan Result, error ssntp.Error) (result Result, err error) {
+func (ctl *SsntpTestController) GetErrorChanResult(c chan Result, error ssntp.Error) (result Result, err error) {
 	select {
-	case result = <-*c:
+	case result = <-c:
 		if result.Err != nil {
 			err = fmt.Errorf("Controller error sending %s error: %s", error, result.Err)
 		}

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -48,20 +48,20 @@ type SsntpTestServer struct {
 }
 
 // AddCmdChan adds an ssntp.Command to the SsntpTestServer command channel
-func (server *SsntpTestServer) AddCmdChan(cmd ssntp.Command) *chan Result {
+func (server *SsntpTestServer) AddCmdChan(cmd ssntp.Command) chan Result {
 	c := make(chan Result)
 
 	server.CmdChansLock.Lock()
 	server.CmdChans[cmd] = c
 	server.CmdChansLock.Unlock()
 
-	return &c
+	return c
 }
 
 // GetCmdChanResult gets a Result from the SsntpTestServer command channel
-func (server *SsntpTestServer) GetCmdChanResult(c *chan Result, cmd ssntp.Command) (result Result, err error) {
+func (server *SsntpTestServer) GetCmdChanResult(c chan Result, cmd ssntp.Command) (result Result, err error) {
 	select {
-	case result = <-*c:
+	case result = <-c:
 		if result.Err != nil {
 			err = fmt.Errorf("Server error on %s command: %s", cmd, result.Err)
 		}
@@ -87,20 +87,20 @@ func (server *SsntpTestServer) SendResultAndDelCmdChan(cmd ssntp.Command, result
 }
 
 // AddEventChan adds an ssntp.Event to the SsntpTestServer event channel
-func (server *SsntpTestServer) AddEventChan(evt ssntp.Event) *chan Result {
+func (server *SsntpTestServer) AddEventChan(evt ssntp.Event) chan Result {
 	c := make(chan Result)
 
 	server.EventChansLock.Lock()
 	server.EventChans[evt] = c
 	server.EventChansLock.Unlock()
 
-	return &c
+	return c
 }
 
 // GetEventChanResult gets a Result from the SsntpTestServer event channel
-func (server *SsntpTestServer) GetEventChanResult(c *chan Result, evt ssntp.Event) (result Result, err error) {
+func (server *SsntpTestServer) GetEventChanResult(c chan Result, evt ssntp.Event) (result Result, err error) {
 	select {
-	case result = <-*c:
+	case result = <-c:
 		if result.Err != nil {
 			err = fmt.Errorf("Server error handling %s event: %s", evt, result.Err)
 		}
@@ -126,20 +126,20 @@ func (server *SsntpTestServer) SendResultAndDelEventChan(evt ssntp.Event, result
 }
 
 // AddErrorChan adds an ssntp.Error to the SsntpTestServer error channel
-func (server *SsntpTestServer) AddErrorChan(error ssntp.Error) *chan Result {
+func (server *SsntpTestServer) AddErrorChan(error ssntp.Error) chan Result {
 	c := make(chan Result)
 
 	server.ErrorChansLock.Lock()
 	server.ErrorChans[error] = c
 	server.ErrorChansLock.Unlock()
 
-	return &c
+	return c
 }
 
 // GetErrorChanResult gets a CmdResult from the SsntpTestServer error channel
-func (server *SsntpTestServer) GetErrorChanResult(c *chan Result, error ssntp.Error) (result Result, err error) {
+func (server *SsntpTestServer) GetErrorChanResult(c chan Result, error ssntp.Error) (result Result, err error) {
 	select {
-	case result = <-*c:
+	case result = <-c:
 		if result.Err != nil {
 			err = fmt.Errorf("Server error handling %s error: %s", error, result.Err)
 		}
@@ -165,20 +165,20 @@ func (server *SsntpTestServer) SendResultAndDelErrorChan(error ssntp.Error, resu
 }
 
 // AddStatusChan adds an ssntp.Status to the SsntpTestServer status channel
-func (server *SsntpTestServer) AddStatusChan(status ssntp.Status) *chan Result {
+func (server *SsntpTestServer) AddStatusChan(status ssntp.Status) chan Result {
 	c := make(chan Result)
 
 	server.StatusChansLock.Lock()
 	server.StatusChans[status] = c
 	server.StatusChansLock.Unlock()
 
-	return &c
+	return c
 }
 
 // GetStatusChanResult gets a Result from the SsntpTestServer status channel
-func (server *SsntpTestServer) GetStatusChanResult(c *chan Result, status ssntp.Status) (result Result, err error) {
+func (server *SsntpTestServer) GetStatusChanResult(c chan Result, status ssntp.Status) (result Result, err error) {
 	select {
-	case result = <-*c:
+	case result = <-c:
 		if result.Err != nil {
 			err = fmt.Errorf("Server error handling %s status: %s", status, result.Err)
 		}


### PR DESCRIPTION
Mark Ryan noted in https://github.com/01org/ciao/pull/877 that
channels are reference type.  That means there's no need for the
reference/deference/address-of operators in the result channels in
testutil.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>