### PR TITLE
ciao-controller: allow overlapping subnets for tenant internal IPs

### DIFF
--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -153,7 +153,6 @@ type Datastore struct {
 
 	tenants     map[string]*tenant
 	tenantsLock *sync.RWMutex
-	allSubnets  map[int]bool
 
 	workloads      map[string]*workload
 	workloadsLock  *sync.RWMutex
@@ -230,7 +229,6 @@ func (ds *Datastore) Init(config Config) error {
 	// networking information right now.  that is not
 	// updated, just the resources
 	ds.tenants = make(map[string]*tenant)
-	ds.allSubnets = make(map[int]bool)
 	ds.tenantsLock = &sync.RWMutex{}
 
 	// cache all our instances prior to getting tenants
@@ -683,16 +681,11 @@ func (ds *Datastore) AllocateTenantIP(tenantID string) (net.IP, error) {
 		i := binary.BigEndian.Uint16(subnetBytes)
 
 		for {
-			// sub, ok := network[int(i)]
-			// for now, prevent overlapping subnets
-			// due to bug in docker.
-			ok := ds.allSubnets[int(i)]
+			// check for new subnet.
+			_, ok := network[int(i)]
 			if !ok {
 				sub := make(map[int]bool)
 				network[int(i)] = sub
-
-				// claim so no one else can use it
-				ds.allSubnets[int(i)] = true
 
 				break
 			}

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -969,38 +969,6 @@ func TestAllocateTenantIP(t *testing.T) {
 	}
 }
 
-func TestNonOverlappingTenantIP(t *testing.T) {
-	/* add a new tenant */
-	tenant, err := addTestTenant()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ip1, err := ds.AllocateTenantIP(tenant.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	tenant, err = addTestTenant()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ip2, err := ds.AllocateTenantIP(tenant.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// make sure the subnet for ip1 and ip2 don't match
-	b1 := ip1.To4()
-	subnetInt1 := binary.BigEndian.Uint16(b1[1:3])
-	b2 := ip2.To4()
-	subnetInt2 := binary.BigEndian.Uint16(b2[1:3])
-	if subnetInt1 == subnetInt2 {
-		t.Fatal(errors.New("Tenant subnets must not overlap"))
-	}
-}
-
 func TestGetCNCIWorkloadID(t *testing.T) {
 	_, err := ds.db.getCNCIWorkloadID()
 	if err != nil {


### PR DESCRIPTION
We no longer need to prevent overlapping subnets for internal IP
addresses between tenants. Modify the algorithm to allocate
internal IPs to allow tenants to have overlapping/duplicate IPs.
Remove the test for overlapping IPs since we don't need it anymore.

Fixes: #712

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>