### PR TITLE
ciao-image: Set status to 'Killed' when upload fails

### DIFF
--- a/ciao-image/datastore/datastore.go
+++ b/ciao-image/datastore/datastore.go
@@ -33,6 +33,9 @@ const (
 
 	// Active means that the image is created, uploaded and ready to use.
 	Active State = "active"
+
+	// Killed means that an image data upload error occurred.
+	Killed State = "killed"
 )
 
 // Status translate an image state to an openstack image status.
@@ -44,6 +47,8 @@ func (state State) Status() image.Status {
 		return image.Saving
 	case Active:
 		return image.Active
+	case Killed:
+		return image.Killed
 	}
 
 	return image.Active


### PR DESCRIPTION
In case of failure on image rawDs writting from upload operation,
it will automatically set image status to Killed.

Fixes #663

Signed-off-by: Obed N Munoz <obed.n.munoz@intel.com>