### PR TITLE
ciao-cli: fix typo

### DIFF
--- a/ciao-cli/instance.go
+++ b/ciao-cli/instance.go
@@ -153,7 +153,7 @@ type instanceDeleteCommand struct {
 func (cmd *instanceDeleteCommand) usage(...string) {
 	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] instance delete [flags]
 
-Deltes a given instance
+Deletes a given instance
 
 The delete flags are:
 


### PR DESCRIPTION
The usage printout for "ciao-cli instance delete" claimed it "Deltes" an
instance, when in fact it "Deletes" an instance.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>