### PR TITLE
ciao-image: Return an empty list when there are no images

### DIFF
--- a/ciao-controller/openstack_image.go
+++ b/ciao-controller/openstack_image.go
@@ -112,7 +112,7 @@ func createImageResponse(img imageDatastore.Image) (image.DefaultResponse, error
 // ListImages will return a list of all the images in the datastore.
 func (is ImageService) ListImages() ([]image.DefaultResponse, error) {
 	glog.Info("Listing images")
-	var response []image.DefaultResponse
+	response := []image.DefaultResponse{}
 
 	images, err := is.ds.GetAllImages()
 	if err != nil {


### PR DESCRIPTION
GET /v2/images should always return a list according to OpenStack
image api V2

This change creates an empty list of image.DefaultResponse from the
begining of ListImages() rather than when the first append
to the list is done.

Fixes #892

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>