### PR TITLE
testutil: Add temporary test cert file generation

### DIFF
--- a/testutil/ssntp_test_certs_test.go
+++ b/testutil/ssntp_test_certs_test.go
@@ -45,3 +45,11 @@ func TestRoleToTestCert(t *testing.T) {
 		}
 	}
 }
+
+func TestMakeTestCerts(t *testing.T) {
+	err := MakeTestCerts()
+	if err != nil {
+		t.Errorf("Failed to create test certificates: %v", err)
+	}
+	RemoveTestCerts()
+}


### PR DESCRIPTION
In order to run tests, cert files may need to be available outside of
the /etc/pki/ciao folder. This patch makes use of ssntp/certs to
generate certificates for the scheduler, controller, agent, cnci agent,
and net agent roles in a testutil function.

Test components can use testutil.MakeTestCerts() and if no error is
returned be reasonbly confident a valid set of certs can be found in the
paths returned by testutil.RoleToTestCertPath(role) which returns the ca
file path, the cert path for the given role and a potential error. Test
components should cleanup certs with RemoveTestCerts().

For example:

import "github.com/01org/ciao/testutil"

func TestMain(m *testing.M) {
	if err := testutil.MakeTestCerts(); err != nil {
        	// Inform of error/run tests not using certs/etc
        	os.Exit(1)
        }
	result := m.Run()
        testutil.RemoveTestCerts()
        os.Exit(result)
}

---
This change supercedes #827 after discussion about how to best handle test certificates.