### PR TITLE
ciao-controller: more verbose error message

### DIFF
--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -261,7 +261,7 @@ func getStorage(c *controller, wl *types.Workload, tenant string, instanceID str
 
 	}
 
-	return payloads.StorageResources{}, errors.New("Not implemented yet")
+	return payloads.StorageResources{}, errors.New("Unsupported workload storage variant in getStorage()")
 }
 
 func newConfig(ctl *controller, wl *types.Workload, instanceID string, tenantID string) (config, error) {


### PR DESCRIPTION
I caused myself an error in dev/test and had to look for
sources of "Not implemented yet".  That generic phrase encouraged me to
make the error print more verbose in order to ease future searches.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>