### PR TITLE
singlevm: update wiki link

### DIFF
--- a/testutil/singlevm/README.rst
+++ b/testutil/singlevm/README.rst
@@ -1,2 +1,2 @@
 Full instructions on how to use this simple CI script are available at
-[Single VM Development Enviornment](https://github.com/01org/ciao/wiki/HOWTO:-Single-VM-Development-Environment)
+[Single Machine Development Enviornment](https://github.com/01org/ciao/wiki/Single-Machine-Development-Environment)


### PR DESCRIPTION
I thought we'd already done this, but maybe only the wiki was updated to
refer to the new page.  There's no point reading a minimal readme that
refers to a page that refers to another page, when you could just straight
refer to the target page.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>