### PR TITLE
ciao-controller: prevent deletion of instances with mapped IPs

### DIFF
--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -82,6 +82,14 @@ func (c *controller) deleteInstance(instanceID string) error {
 		return types.ErrInstanceNotAssigned
 	}
 
+	// check for any external IPs
+	IPs := c.ds.GetMappedIPs(&i.TenantID)
+	for _, m := range IPs {
+		if m.InstanceID == instanceID {
+			return types.ErrInstanceMapped
+		}
+	}
+
 	go c.client.DeleteInstance(instanceID, i.NodeID)
 	return nil
 }

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -543,6 +543,10 @@ var (
 
 	// ErrDuplicatePoolName is returned when a duplicate pool name is used
 	ErrDuplicatePoolName = errors.New("Pool by that name already exists")
+
+	// ErrInstanceMapped is returned when an instance cannot be deleted
+	// due to having an external IP assigned to it.
+	ErrInstanceMapped = errors.New("Unmap the external IP prior to deletion")
 )
 
 // Link provides a url and relationship for a resource.


### PR DESCRIPTION
If an instance has an external IP associated with it, refuse
to delete it. In this case, the user must explicitly unmap first.

Fixes: #898 

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>