### PR TITLE
ciao-image: Fix raw datastore error handling on ciao-image service

### DIFF
--- a/ciao-image/datastore/datastore_test.go
+++ b/ciao-image/datastore/datastore_test.go
@@ -15,15 +15,23 @@
 package datastore
 
 import (
+	"os"
+	"path"
 	"strings"
 	"testing"
 
 	"github.com/01org/ciao/database"
 )
 
+var mountPoint = "/tmp"
+var metaDsTables = []string{"images"}
+var dbDir = "/tmp"
+var dbFile = "ciao-image.db"
+var testImageID = "12345678-1234-5678-1234-567812345678"
+
 func testCreateAndGet(t *testing.T, d RawDataStore, m MetaDataStore) {
 	i := Image{
-		ID:    "validID",
+		ID:    testImageID,
 		State: Created,
 	}
 
@@ -49,7 +57,7 @@ func testCreateAndGet(t *testing.T, d RawDataStore, m MetaDataStore) {
 
 func testGetAll(t *testing.T, d RawDataStore, m MetaDataStore) {
 	i := Image{
-		ID:    "validID",
+		ID:    testImageID,
 		State: Created,
 	}
 
@@ -81,7 +89,7 @@ func testGetAll(t *testing.T, d RawDataStore, m MetaDataStore) {
 
 func testDelete(t *testing.T, d RawDataStore, m MetaDataStore) {
 	i := Image{
-		ID:    "validID",
+		ID:    testImageID,
 		State: Created,
 	}
 
@@ -111,7 +119,7 @@ func testDelete(t *testing.T, d RawDataStore, m MetaDataStore) {
 
 func testUpload(t *testing.T, d RawDataStore, m MetaDataStore) {
 	i := Image{
-		ID:    "validID",
+		ID:    testImageID,
 		State: Created,
 	}
 
@@ -131,10 +139,11 @@ func testUpload(t *testing.T, d RawDataStore, m MetaDataStore) {
 	}
 }
 
-var mountPoint = "/tmp"
-var metaDsTables = []string{"images"}
-var dbDir = "/tmp"
-var dbFile = "ciao-image.db"
+// cleanDatastore cleans temporal files that were created during the test
+func cleanDatastore() {
+	_ = os.Remove(path.Join(mountPoint, testImageID))
+	_ = os.Remove(path.Join(dbDir, dbFile))
+}
 
 // Tests for Noop metaDs
 
@@ -152,6 +161,7 @@ func TestPosixNoopDelete(t *testing.T) {
 
 func TestPosixNoopUpload(t *testing.T) {
 	testUpload(t, &Posix{MountPoint: mountPoint}, &Noop{})
+	cleanDatastore()
 }
 
 // Tests for MetaDs
@@ -191,4 +201,5 @@ func TestPosixMetaDsUpload(t *testing.T) {
 	metaDs := initMetaDs()
 	defer metaDs.DbClose()
 	testUpload(t, &Posix{MountPoint: mountPoint}, metaDs)
+	cleanDatastore()
 }

--- a/ciao-image/datastore/store.go
+++ b/ciao-image/datastore/store.go
@@ -181,10 +181,14 @@ func (s *ImageStore) UploadImage(ID string, body io.Reader) error {
 	if err == nil {
 		img.State = Active
 	}
+
 	s.ImageMap.Lock()
 	defer s.ImageMap.Unlock()
+	metaDsErr := s.metaDs.Write(img)
 
-	err = s.metaDs.Write(img)
+	if err == nil && metaDsErr != nil {
+		err = metaDsErr
+	}
 
 	return err
 }


### PR DESCRIPTION
This commit fixes the loss of ceph error when an image upload operation
is performed. Now, Ceph errors are properly returned and Metadata errors
are separately handled.

Fixes #905

Signed-off-by: Obed N Munoz <obed.n.munoz@intel.com>