### PR TITLE
ciao-controller: Fix build errors from patch merges

### DIFF
--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -36,6 +36,8 @@ type controllerClient interface {
 	RestartInstance(instanceID string, nodeID string) error
 	EvacuateNode(nodeID string) error
 	Disconnect()
+	mapExternalIP(t types.Tenant, m types.MappedIP) error
+	unMapExternalIP(t types.Tenant, m types.MappedIP) error
 	attachVolume(volID string, instanceID string, nodeID string) error
 	detachVolume(volID string, instanceID string, nodeID string) error
 	ssntpClient() *ssntp.Client

--- a/ciao-controller/client_wrapper.go
+++ b/ciao-controller/client_wrapper.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/01org/ciao/ciao-controller/types"
 	"github.com/01org/ciao/ssntp"
 )
 
@@ -96,6 +97,14 @@ func (client *ssntpClientWrapper) RestartInstance(instanceID string, nodeID stri
 
 func (client *ssntpClientWrapper) EvacuateNode(nodeID string) error {
 	return client.realClient.EvacuateNode(nodeID)
+}
+
+func (client *ssntpClientWrapper) mapExternalIP(t types.Tenant, m types.MappedIP) error {
+	return client.realClient.mapExternalIP(t, m)
+}
+
+func (client *ssntpClientWrapper) unMapExternalIP(t types.Tenant, m types.MappedIP) error {
+	return client.realClient.unMapExternalIP(t, m)
 }
 
 func (client *ssntpClientWrapper) attachVolume(volID string, instanceID string, nodeID string) error {


### PR DESCRIPTION
The controller unit test improvements and external IP PRs conflicted
when new functions were added to ssntpClient but were missing from the
newly added interface.

This PR adds those missing mapExternalIP/unMapExternalIP methods to the
interface and implements them in ssntpClientWrapper

Signed-off-by: Rob Bradford <robert.bradford@intel.com>