### PR TITLE
Single VM: Fix SSH Key provisioning issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 go_import_path: github.com/01org/ciao
 
 before_install:
+  - sudo apt-get install dnsmasq-base
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/pierrre/gotestcover

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -321,6 +321,8 @@ users:
 EOF
 ) > $workload_cloudinit
 
+sudo cp -f "$workload_cloudinit" ${ciao_ctl_dir}/workloads
+
 
 #Copy the launch scripts
 cp "$ciao_scripts"/run_scheduler.sh "$ciao_bin"


### PR DESCRIPTION
The cloud-init configuration was not being updated with the updated
ssh key.

Fixes https://github.com/01org/ciao/issues/913

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>