### PR TITLE
Travis: Add go 1.8 support, fix go lint on tip and delete unused misspell invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,7 @@ script:
    - go get github.com/google/gofuzz github.com/stretchr/testify
    - go get github.com/golang/lint/golint github.com/client9/misspell/cmd/misspell
    - go list ./... | grep -v github.com/01org/ciao/vendor | xargs -t go vet
-#  - go list ./... | grep -v github.com/01org/ciao/vendor | xargs -tL 1 golint -set_exit_status
-   - if [[ "$TRAVIS_GO_VERSION" != "tip" ]] ; then go list ./... | grep -v github.com/01org/ciao/vendor | xargs -tL 1 golint -set_exit_status ; fi
+   - go list ./... | grep -v github.com/01org/ciao/vendor | xargs -tL 1 golint -set_exit_status
    - go list ./... | grep -v github.com/01org/ciao/vendor | xargs go list -f '{{.Dir}}/*.go' | xargs -I % bash -c "misspell -error %"
    - go list ./... | grep -v github.com/01org/ciao/vendor | xargs go list -f '{{.Dir}}' | xargs gocyclo -over 15
    - go list ./... | grep -v github.com/01org/ciao/vendor | xargs go list -f '{{.Dir}}' | xargs -L 1 ineffassign

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 
 go:
     - 1.7
+    - go1.8beta1
     - tip
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ script:
    - sudo ip addr add 198.51.100.1/24 dev testdummy
    - go get github.com/google/gofuzz github.com/stretchr/testify
    - go get github.com/golang/lint/golint github.com/client9/misspell/cmd/misspell
-   - go list ./... | grep -v github.com/01org/ciao/vendor | xargs -t misspell
    - go list ./... | grep -v github.com/01org/ciao/vendor | xargs -t go vet
 #  - go list ./... | grep -v github.com/01org/ciao/vendor | xargs -tL 1 golint -set_exit_status
    - if [[ "$TRAVIS_GO_VERSION" != "tip" ]] ; then go list ./... | grep -v github.com/01org/ciao/vendor | xargs -tL 1 golint -set_exit_status ; fi


### PR DESCRIPTION
This PR fixes #911.

In short it

- Adds go1.8beta1 as a build target
- Removes an unused call to misspell
- Re-enables golint on tip.