### PR TITLE
Refactor logging interface used in osprepare

### DIFF
--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -37,6 +37,7 @@ import (
 	datastore "github.com/01org/ciao/ciao-controller/internal/datastore"
 	image "github.com/01org/ciao/ciao-image/client"
 	storage "github.com/01org/ciao/ciao-storage"
+	"github.com/01org/ciao/clogger/gloginterface"
 	"github.com/01org/ciao/openstack/block"
 	"github.com/01org/ciao/openstack/compute"
 	osIdentity "github.com/01org/ciao/openstack/identity"
@@ -157,9 +158,9 @@ func main() {
 		*cephID = clusterConfig.Configure.Storage.CephID
 	}
 
-	ospLogger := osprepare.OSPGlogLogger{}
-	osprepare.Bootstrap(context.TODO(), ospLogger)
-	osprepare.InstallDeps(context.TODO(), controllerDeps, ospLogger)
+	logger := gloginterface.CiaoGlogLogger{}
+	osprepare.Bootstrap(context.TODO(), logger)
+	osprepare.InstallDeps(context.TODO(), controllerDeps, logger)
 
 	if *singleMachine {
 		hostname, _ := os.Hostname()

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -30,6 +30,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/01org/ciao/clogger/gloginterface"
 	"github.com/01org/ciao/osprepare"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp"
@@ -256,8 +257,8 @@ func (client *agentClient) installLauncherDeps(doneCh chan struct{}) {
 	ch := make(chan error)
 	go func() {
 
-		ospLogger := osprepare.OSPGlogLogger{}
-		osprepare.Bootstrap(ctx, ospLogger)
+		logger := gloginterface.CiaoGlogLogger{}
+		osprepare.Bootstrap(ctx, logger)
 
 		launcherDeps := osprepare.NewPackageRequirements()
 
@@ -269,7 +270,7 @@ func (client *agentClient) installLauncherDeps(doneCh chan struct{}) {
 			launcherDeps.Append(launcherComputeNodeDeps)
 		}
 
-		osprepare.InstallDeps(ctx, launcherDeps, ospLogger)
+		osprepare.InstallDeps(ctx, launcherDeps, logger)
 
 		ch <- nil
 	}()

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -27,6 +27,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/01org/ciao/clogger/gloginterface"
 	"github.com/01org/ciao/osprepare"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp"
@@ -1108,9 +1109,9 @@ func configSchedulerServer() (sched *ssntpSchedulerServer) {
 
 func main() {
 	flag.Parse()
-	ospLogger := osprepare.OSPGlogLogger{}
-	osprepare.Bootstrap(context.TODO(), ospLogger)
-	osprepare.InstallDeps(context.TODO(), schedDeps, ospLogger)
+	logger := gloginterface.CiaoGlogLogger{}
+	osprepare.Bootstrap(context.TODO(), logger)
+	osprepare.InstallDeps(context.TODO(), schedDeps, logger)
 
 	sched := configSchedulerServer()
 	if sched == nil {

--- a/clogger/README.md
+++ b/clogger/README.md
@@ -1,0 +1,13 @@
+Ciao Logger
+===========
+
+Given the variety of different requirements for logging in Ciao, there is
+a need to provide a custom logging interface that different modules can
+share.
+
+The clogger package provides a such a logging interface, adding no
+additional imports to avoid issues such as glog getting its flags added
+to usage messages. While at the same time rather than provide no default
+logging interface other than a CiaoNullLogger implementation, which does
+not write messages, a separate package, gloginterface, where a glog
+backend is used is also available.

--- a/clogger/gloginterface/interface.go
+++ b/clogger/gloginterface/interface.go
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gloginterface
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+)
+
+// CiaoGlogLogger is a type that makes use of glog for the CiaoLog interface
+type CiaoGlogLogger struct{}
+
+// V returns true if the given argument is less than or equal
+// to glog's verbosity level.
+func (l CiaoGlogLogger) V(level int32) bool {
+	return bool(glog.V(glog.Level(level)))
+}
+
+// Infof writes informational output to glog.
+func (l CiaoGlogLogger) Infof(format string, v ...interface{}) {
+	glog.InfoDepth(2, fmt.Sprintf(format, v...))
+}
+
+// Warningf writes warning output to glog.
+func (l CiaoGlogLogger) Warningf(format string, v ...interface{}) {
+	glog.WarningDepth(2, fmt.Sprintf(format, v...))
+}
+
+// Errorf writes error output to glog.
+func (l CiaoGlogLogger) Errorf(format string, v ...interface{}) {
+	glog.ErrorDepth(2, fmt.Sprintf(format, v...))
+}

--- a/clogger/logger.go
+++ b/clogger/logger.go
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package clogger
+
+// CiaoLog is a logging interface to be used by other packages to log various
+// interesting pieces of information.  Rather than introduce a dependency
+// on a given logging package, ciao-logger presents this interface that allows
+// clients to provide their own logging type.
+type CiaoLog interface {
+	// V returns true if the given argument is less than or equal
+	// to the implementation's defined verbosity level.
+	V(int32) bool
+
+	// Infof writes informational output to the log.  A newline will be
+	// added to the output if one is not provided.
+	Infof(string, ...interface{})
+
+	// Warningf writes warning output to the log.  A newline will be
+	// added to the output if one is not provided.
+	Warningf(string, ...interface{})
+
+	// Errorf writes error output to the log.  A newline will be
+	// added to the output if one is not provided.
+	Errorf(string, ...interface{})
+}
+
+// CiaoNullLogger is a do nothing implementation of CiaoLog
+type CiaoNullLogger struct{}
+
+// V no message is verbose
+func (l CiaoNullLogger) V(level int32) bool {
+	return false
+}
+
+// Infof no logging done
+func (l CiaoNullLogger) Infof(format string, v ...interface{}) {
+}
+
+// Warningf no logging done
+func (l CiaoNullLogger) Warningf(format string, v ...interface{}) {
+}
+
+// Errorf no logging done
+func (l CiaoNullLogger) Errorf(format string, v ...interface{}) {
+}

--- a/osprepare/distro.go
+++ b/osprepare/distro.go
@@ -25,6 +25,8 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	"github.com/01org/ciao/clogger"
 )
 
 const (
@@ -175,7 +177,7 @@ type distro interface {
 	// InstallPackages should implement the installation
 	// of packages using distro specific methods for
 	// the given target list of items to install
-	InstallPackages(ctx context.Context, packages []string, logger OSPLog) bool
+	InstallPackages(ctx context.Context, packages []string, logger clogger.CiaoLog) bool
 
 	// getID should return a string specifying
 	// the distribution ID (e.g: "clearlinux")
@@ -212,7 +214,7 @@ func (d *clearLinuxDistro) getID() string {
 
 // Correctly split and format the command, using sudo if appropriate, as a
 // common mechanism for the various package install functions.
-func sudoFormatCommand(ctx context.Context, command string, packages []string, logger OSPLog) bool {
+func sudoFormatCommand(ctx context.Context, command string, packages []string, logger clogger.CiaoLog) bool {
 	var executable string
 	var args string
 
@@ -251,7 +253,7 @@ func sudoFormatCommand(ctx context.Context, command string, packages []string, l
 	return true
 }
 
-func (d *clearLinuxDistro) InstallPackages(ctx context.Context, packages []string, logger OSPLog) bool {
+func (d *clearLinuxDistro) InstallPackages(ctx context.Context, packages []string, logger clogger.CiaoLog) bool {
 	return sudoFormatCommand(ctx, "swupd bundle-add %s", packages, logger)
 }
 
@@ -264,7 +266,7 @@ func (d *ubuntuDistro) getID() string {
 	return "ubuntu"
 }
 
-func (d *ubuntuDistro) InstallPackages(ctx context.Context, packages []string, logger OSPLog) bool {
+func (d *ubuntuDistro) InstallPackages(ctx context.Context, packages []string, logger clogger.CiaoLog) bool {
 	return sudoFormatCommand(ctx, "apt-get --yes --force-yes install %s", packages, logger)
 }
 
@@ -277,6 +279,6 @@ func (d *fedoraDistro) getID() string {
 }
 
 // Use dnf to install on Fedora
-func (d *fedoraDistro) InstallPackages(ctx context.Context, packages []string, logger OSPLog) bool {
+func (d *fedoraDistro) InstallPackages(ctx context.Context, packages []string, logger clogger.CiaoLog) bool {
 	return sudoFormatCommand(ctx, "dnf install -y %s", packages, logger)
 }

--- a/osprepare/osprepare.go
+++ b/osprepare/osprepare.go
@@ -18,72 +18,10 @@ package osprepare
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
-	"github.com/golang/glog"
+	"github.com/01org/ciao/clogger"
 )
-
-// OSPLog is a logging interface used by the osprepare package to log various
-// interesting pieces of information.  Rather than introduce a dependency
-// on a given logging package, osprepare presents this interface that allows
-// clients to provide their own logging type or reuse the OSPGlogLogger..
-type OSPLog interface {
-	// V returns true if the given argument is less than or equal
-	// to the implementation's defined verbosity level.
-	V(int32) bool
-
-	// Infof writes informational output to the log.  A newline will be
-	// added to the output if one is not provided.
-	Infof(string, ...interface{})
-
-	// Warningf writes warning output to the log.  A newline will be
-	// added to the output if one is not provided.
-	Warningf(string, ...interface{})
-
-	// Errorf writes error output to the log.  A newline will be
-	// added to the output if one is not provided.
-	Errorf(string, ...interface{})
-}
-
-type ospNullLogger struct{}
-
-func (l ospNullLogger) V(level int32) bool {
-	return false
-}
-
-func (l ospNullLogger) Infof(format string, v ...interface{}) {
-}
-
-func (l ospNullLogger) Warningf(format string, v ...interface{}) {
-}
-
-func (l ospNullLogger) Errorf(format string, v ...interface{}) {
-}
-
-// OSPGlogLogger is a type that makes use of glog for the OSPLog interface
-type OSPGlogLogger struct{}
-
-// V returns true if the given argument is less than or equal
-// to glog's verbosity level.
-func (l OSPGlogLogger) V(level int32) bool {
-	return bool(glog.V(glog.Level(level)))
-}
-
-// Infof writes informational output to glog.
-func (l OSPGlogLogger) Infof(format string, v ...interface{}) {
-	glog.InfoDepth(2, fmt.Sprintf(format, v...))
-}
-
-// Warningf writes warning output to glog.
-func (l OSPGlogLogger) Warningf(format string, v ...interface{}) {
-	glog.WarningDepth(2, fmt.Sprintf(format, v...))
-}
-
-// Errorf writes error output to glog.
-func (l OSPGlogLogger) Errorf(format string, v ...interface{}) {
-	glog.ErrorDepth(2, fmt.Sprintf(format, v...))
-}
 
 // Minimal versions supported by ciao
 const (
@@ -188,9 +126,9 @@ func collectPackages(dist distro, reqs PackageRequirements) []string {
 
 // InstallDeps installs all the dependencies defined in a component
 // specific PackageRequirements in order to enable running the component
-func InstallDeps(ctx context.Context, reqs PackageRequirements, logger OSPLog) {
+func InstallDeps(ctx context.Context, reqs PackageRequirements, logger clogger.CiaoLog) {
 	if logger == nil {
-		logger = ospNullLogger{}
+		logger = clogger.CiaoNullLogger{}
 	}
 
 	distro := getDistro()
@@ -222,6 +160,6 @@ func InstallDeps(ctx context.Context, reqs PackageRequirements, logger OSPLog) {
 
 // Bootstrap installs all the core dependencies required to bootstrap the core
 // configuration of all Ciao components
-func Bootstrap(ctx context.Context, logger OSPLog) {
+func Bootstrap(ctx context.Context, logger clogger.CiaoLog) {
 	InstallDeps(ctx, BootstrapRequirements, logger)
 }

--- a/osprepare/versions.go
+++ b/osprepare/versions.go
@@ -22,9 +22,11 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/01org/ciao/clogger"
 )
 
-func getCommandOutput(command string, logger OSPLog) string {
+func getCommandOutput(command string, logger clogger.CiaoLog) string {
 	splits := strings.Split(command, " ")
 	c := exec.Command(splits[0], splits[1:]...)
 	c.Env = os.Environ()
@@ -42,7 +44,7 @@ func getCommandOutput(command string, logger OSPLog) string {
 	return string(out)
 }
 
-func getDockerVersion(logger OSPLog) string {
+func getDockerVersion(logger clogger.CiaoLog) string {
 	ret := getCommandOutput("docker --version", logger)
 	var version string
 
@@ -56,7 +58,7 @@ func getDockerVersion(logger OSPLog) string {
 	return version
 }
 
-func getQemuVersion(logger OSPLog) string {
+func getQemuVersion(logger clogger.CiaoLog) string {
 	ret := getCommandOutput("qemu-system-x86_64 --version", logger)
 	var version string
 


### PR DESCRIPTION
Instead of having osprepare attempt to provide all the logging interface
components, add a new ciao module for logging that provides by default
only a no log implementation.

Also add a separate module that provides an interface implementation
that uses glog.

This change is done to avoid any interface implementor getting glog
flags added to their messages (since previously osprepare always
required glog).

Addresses #919.