### PR TITLE
ciao-image: Add regex pattern for validating UUID

### DIFF
--- a/ciao-image/datastore/store.go
+++ b/ciao-image/datastore/store.go
@@ -132,6 +132,10 @@ func (s *ImageStore) DeleteImage(ID string) error {
 
 	img, err := s.metaDs.Get(ID)
 	if err != nil {
+		return err
+	}
+
+	if img == (Image{}) {
 		return image.ErrNoImage
 	}
 
@@ -154,6 +158,10 @@ func (s *ImageStore) UploadImage(ID string, body io.Reader) error {
 	img, err := s.metaDs.Get(ID)
 	s.ImageMap.RUnlock()
 	if err != nil {
+		return err
+	}
+
+	if img == (Image{}) {
 		return image.ErrNoImage
 	}
 

--- a/openstack/image/api.go
+++ b/openstack/image/api.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/01org/ciao/ssntp/uuid"
 	"github.com/gorilla/mux"
 )
 
@@ -409,10 +410,10 @@ func Routes(config APIConfig) *mux.Router {
 	// API versions
 	r.Handle("/", APIHandler{context, listAPIVersions}).Methods("GET")
 	r.Handle("/v2/images", APIHandler{context, createImage}).Methods("POST")
-	r.Handle("/v2/images/{image_id}/file", APIHandler{context, uploadImage}).Methods("PUT")
+	r.Handle("/v2/images/{image_id:"+uuid.UUIDRegex+"}/file", APIHandler{context, uploadImage}).Methods("PUT")
 	r.Handle("/v2/images", APIHandler{context, listImages}).Methods("GET")
-	r.Handle("/v2/images/{image_id}", APIHandler{context, getImage}).Methods("GET")
-	r.Handle("/v2/images/{image_id}", APIHandler{context, deleteImage}).Methods("DELETE")
+	r.Handle("/v2/images/{image_id:"+uuid.UUIDRegex+"}", APIHandler{context, getImage}).Methods("GET")
+	r.Handle("/v2/images/{image_id:"+uuid.UUIDRegex+"}", APIHandler{context, deleteImage}).Methods("DELETE")
 
 	return r
 }

--- a/ssntp/uuid/uuid.go
+++ b/ssntp/uuid/uuid.go
@@ -33,6 +33,9 @@ import (
 // UUID represents a single 128 bit UUID as an array of 16 bytes.
 type UUID [16]byte
 
+// UUIDRegex defines a pattern for validating UUIDs
+const UUIDRegex = "[a-fA-F0-9]{8}-?[a-fA-F0-9]{4}-?4[a-fA-F0-9]{3}-?[8|9|aA|bB][a-fA-F0-9]{3}-?[a-fA-F0-9]{12}"
+
 var (
 	// ErrUUIDInvalid indicates that a UIID is invalid.  Currently,
 	// returned by uuid.Parse if the string passed to this function


### PR DESCRIPTION
It implements a regex validator for UUIDs in ciao-image service HTTP requests. It will respond with a ``Not Found`` (404) HTTP Error for all those requests that contain a malformed UUID.

It also fixes an issue with images getting from meta datastore. Errors handling needs to return a valid error when we have diferent than ``Not Found`` errors.

Fixes #563 and #566 
