### PR TITLE
ciao-cli: Indicate that newly created instance is pending

### DIFF
--- a/ciao-cli/instance.go
+++ b/ciao-cli/instance.go
@@ -139,7 +139,7 @@ func (cmd *instanceAddCommand) run(args []string) error {
 	}
 
 	for _, server := range servers.Servers {
-		fmt.Printf("Created new instance: %s\n", server.ID)
+		fmt.Printf("Created new (pending) instance: %s\n", server.ID)
 	}
 	return nil
 }


### PR DESCRIPTION
The message from ciao-cli for instance creation implied that the
instance was available immediately. Update the reported message to make
it clear that the instance is pending.

Fixes: #674

Signed-off-by: Rob Bradford <robert.bradford@intel.com>