### PR TITLE
networking: libsnnet: Export bridge API

### DIFF
--- a/networking/libsnnet/bridge.go
+++ b/networking/libsnnet/bridge.go
@@ -24,7 +24,7 @@ import (
 
 // NewBridge is used to initialize the bridge properties
 // This has to be called prior to Create() or GetDevice()
-func newBridge(id string) (*Bridge, error) {
+func NewBridge(id string) (*Bridge, error) {
 	bridge := &Bridge{}
 	bridge.Link = &netlink.Bridge{}
 	bridge.GlobalID = id //TODO: Add other parameters
@@ -34,7 +34,7 @@ func newBridge(id string) (*Bridge, error) {
 // GetDevice associates the bridge with an existing bridge with that GlobalId.
 // If there are multiple bridges incorrectly created with the same id, it will
 // associate the bridge with the first
-func (b *Bridge) getDevice() error {
+func (b *Bridge) GetDevice() error {
 
 	if b.GlobalID == "" {
 		return netError(b, "GetDevice: unnamed bridge")
@@ -57,7 +57,7 @@ func (b *Bridge) getDevice() error {
 }
 
 // Create instantiates a new bridge.
-func (b *Bridge) create() error {
+func (b *Bridge) Create() error {
 
 	if b.GlobalID == "" {
 		return netError(b, "create an unnamed bridge")
@@ -93,7 +93,7 @@ func (b *Bridge) create() error {
 
 	b.Link = brl
 	if err := b.setAlias(b.GlobalID); err != nil {
-		err1 := b.destroy()
+		err1 := b.Destroy()
 		return netError(b, "create set alias [%v] [%v]", err, err1)
 	}
 
@@ -101,7 +101,7 @@ func (b *Bridge) create() error {
 }
 
 // Destroy an existing bridge
-func (b *Bridge) destroy() error {
+func (b *Bridge) Destroy() error {
 	if b.Link == nil || b.Link.Index == 0 {
 		return netError(b, "destroy bridge unnitialized")
 	}
@@ -113,7 +113,7 @@ func (b *Bridge) destroy() error {
 }
 
 // Enable the bridge
-func (b *Bridge) enable() error {
+func (b *Bridge) Enable() error {
 	if b.Link == nil || b.Link.Index == 0 {
 		return netError(b, "enable bridge unnitialized")
 	}
@@ -126,7 +126,7 @@ func (b *Bridge) enable() error {
 }
 
 // Disable the bridge
-func (b *Bridge) disable() error {
+func (b *Bridge) Disable() error {
 	if b.Link == nil || b.Link.Index == 0 {
 		return netError(b, "disable bridge unnitialized")
 	}
@@ -139,7 +139,7 @@ func (b *Bridge) disable() error {
 }
 
 // AddIP Adds an IP Address to the bridge
-func (b *Bridge) addIP(ip *net.IPNet) error {
+func (b *Bridge) AddIP(ip *net.IPNet) error {
 	if b.Link == nil || b.Link.Index == 0 {
 		return netError(b, "add ip bridge unnitialized")
 	}
@@ -154,7 +154,7 @@ func (b *Bridge) addIP(ip *net.IPNet) error {
 }
 
 // DelIP Deletes an IP Address assigned to the bridge
-func (b *Bridge) delIP(ip *net.IPNet) error {
+func (b *Bridge) DelIP(ip *net.IPNet) error {
 
 	if b.Link == nil || b.Link.Index == 0 {
 		return netError(b, "del ip bridge unnitialized")

--- a/networking/libsnnet/bridge_test.go
+++ b/networking/libsnnet/bridge_test.go
@@ -27,9 +27,9 @@ func performBridgeOps(shouldPass bool, assert *assert.Assertions, bridge *Bridge
 	if !shouldPass {
 		a = assert.NotNil
 	}
-	a(bridge.enable())
-	a(bridge.disable())
-	a(bridge.destroy())
+	a(bridge.Enable())
+	a(bridge.Disable())
+	a(bridge.Destroy())
 }
 
 //Test all Bridge primitives
@@ -42,18 +42,18 @@ func performBridgeOps(shouldPass bool, assert *assert.Assertions, bridge *Bridge
 func TestBridge_Basic(t *testing.T) {
 	assert := assert.New(t)
 
-	bridge, err := newBridge("go_testbr")
+	bridge, err := NewBridge("go_testbr")
 	assert.Nil(err)
 
-	assert.Nil(bridge.create())
+	assert.Nil(bridge.Create())
 
-	bridge1, err := newBridge("go_testbr")
+	bridge1, err := NewBridge("go_testbr")
 	assert.Nil(err)
 
-	assert.Nil(bridge1.getDevice())
+	assert.Nil(bridge1.GetDevice())
 	performBridgeOps(true, assert, bridge)
 
-	assert.NotNil(bridge.destroy())
+	assert.NotNil(bridge.Destroy())
 
 }
 
@@ -65,15 +65,15 @@ func TestBridge_Basic(t *testing.T) {
 //Test is expected to pass
 func TestBridge_Dup(t *testing.T) {
 	assert := assert.New(t)
-	bridge, err := newBridge("go_testbr")
+	bridge, err := NewBridge("go_testbr")
 	assert.Nil(err)
 
-	assert.Nil(bridge.create())
-	defer func() { _ = bridge.destroy() }()
+	assert.Nil(bridge.Create())
+	defer func() { _ = bridge.Destroy() }()
 
-	bridge1, err := newBridge("go_testbr")
+	bridge1, err := NewBridge("go_testbr")
 	assert.Nil(err)
-	assert.NotNil(bridge1.create())
+	assert.NotNil(bridge1.Create())
 }
 
 //Negative test cases for bridge primitives
@@ -85,10 +85,10 @@ func TestBridge_Dup(t *testing.T) {
 func TestBridge_Invalid(t *testing.T) {
 	assert := assert.New(t)
 
-	bridge, err := newBridge("go_testbr")
+	bridge, err := NewBridge("go_testbr")
 	assert.Nil(err)
 
-	assert.NotNil(bridge.getDevice())
+	assert.NotNil(bridge.GetDevice())
 
 	performBridgeOps(false, assert, bridge)
 }
@@ -101,14 +101,14 @@ func TestBridge_Invalid(t *testing.T) {
 //Test is expected to pass
 func TestBridge_GetDevice(t *testing.T) {
 	assert := assert.New(t)
-	bridge, err := newBridge("go_testbr")
+	bridge, err := NewBridge("go_testbr")
 	assert.Nil(err)
 
-	assert.Nil(bridge.create())
+	assert.Nil(bridge.Create())
 
-	bridge1, err := newBridge("go_testbr")
+	bridge1, err := NewBridge("go_testbr")
 	assert.Nil(err)
 
-	assert.Nil(bridge1.getDevice())
+	assert.Nil(bridge1.GetDevice())
 	performBridgeOps(true, assert, bridge1)
 }

--- a/networking/libsnnet/cn.go
+++ b/networking/libsnnet/cn.go
@@ -734,7 +734,7 @@ func (cn *ComputeNode) createDevicesFromCfg(cfg *VnicConfig) (*Vnic, *Bridge, *G
 
 	alias := genCnVnicAliases(cfg)
 
-	bridge, err := newBridge(alias.bridge)
+	bridge, err := NewBridge(alias.bridge)
 	if err != nil {
 		return nil, nil, nil, NewAPIError(err.Error())
 	}
@@ -950,7 +950,7 @@ func (cn *ComputeNode) logicallyCreateBridge(bridge *Bridge, gre *GreTunEP, vnic
 //TODO: Try to be more fault tolerant here. We may miss errors but try to
 // honor the request  e.g. If bridge exists use it and try and create tunnel
 func createAndEnableBridge(bridge *Bridge, gre *GreTunEP) error {
-	if err := bridge.create(); err != nil {
+	if err := bridge.Create(); err != nil {
 		return fmt.Errorf("Bridge creation failed %s %s", bridge.GlobalID, err.Error())
 	}
 	if err := gre.create(); err != nil {
@@ -963,7 +963,7 @@ func createAndEnableBridge(bridge *Bridge, gre *GreTunEP) error {
 	if err := gre.enable(); err != nil {
 		return fmt.Errorf("GRE enable failed %s %s %s", gre.GlobalID, bridge.GlobalID, err.Error())
 	}
-	if err := bridge.enable(); err != nil {
+	if err := bridge.Enable(); err != nil {
 		return fmt.Errorf("Bridge enable failed %s %s %s", gre.GlobalID, bridge.GlobalID, err.Error())
 	}
 	return nil
@@ -1080,7 +1080,7 @@ func (cn *ComputeNode) deleteBridgeInternal(bridge *Bridge, bLink *linkInfo, brD
 		return NewFatalError(bridge.GlobalID + err.Error())
 	}
 
-	if err := bridge.destroy(); err != nil {
+	if err := bridge.Destroy(); err != nil {
 		return NewFatalError("bridge destroy failed " + err.Error())
 	}
 	// We delete the container network when the bridge is deleted
@@ -1137,7 +1137,7 @@ func (cn *ComputeNode) destroyVnicInternal(cfg *VnicConfig) (*SsntpEventInfo, er
 		return nil, nil
 	}
 
-	bridge, err := newBridge(alias.bridge)
+	bridge, err := NewBridge(alias.bridge)
 	if err != nil {
 		return nil, NewFatalError(err.Error())
 	}

--- a/networking/libsnnet/cn_test.go
+++ b/networking/libsnnet/cn_test.go
@@ -714,12 +714,12 @@ func TestCN_Whitebox(t *testing.T) {
 
 	// Create the CN tenant bridge only if it does not exist
 	bridgeAlias := fmt.Sprintf("br_%s_%s_%s", tenantUUID, subnetUUID, concUUID)
-	bridge, _ := newBridge(bridgeAlias)
+	bridge, _ := NewBridge(bridgeAlias)
 
-	if assert.NotNil(bridge.getDevice()) {
+	if assert.NotNil(bridge.GetDevice()) {
 		// First instance to land, create the bridge and tunnel
-		assert.Nil(bridge.create())
-		defer func() { _ = bridge.destroy() }()
+		assert.Nil(bridge.Create())
+		defer func() { _ = bridge.Destroy() }()
 
 		// Create the tunnel to connect to the CNCI
 		local := cnIP
@@ -733,7 +733,7 @@ func TestCN_Whitebox(t *testing.T) {
 
 		assert.Nil(gre.attach(bridge))
 		assert.Nil(gre.enable())
-		assert.Nil(bridge.enable())
+		assert.Nil(bridge.Enable())
 	}
 
 	// Create the VNIC for the instance
@@ -746,5 +746,5 @@ func TestCN_Whitebox(t *testing.T) {
 
 	assert.Nil(vnic.attach(bridge))
 	assert.Nil(vnic.enable())
-	assert.Nil(bridge.enable())
+	assert.Nil(bridge.Enable())
 }

--- a/networking/libsnnet/cnci.go
+++ b/networking/libsnnet/cnci.go
@@ -230,12 +230,12 @@ func (cnci *Cnci) rebuildBridgeMap(links []netlink.Link) error {
 			continue
 		}
 
-		br, err := newBridge(bridgeID)
+		br, err := NewBridge(bridgeID)
 		if err != nil {
 			return (err)
 		}
 
-		if err = br.getDevice(); err != nil {
+		if err = br.GetDevice(); err != nil {
 			return (err)
 		}
 
@@ -367,10 +367,10 @@ func createCnciBridge(bridge *Bridge, brInfo *bridgeInfo, tenant string, subnet 
 	if bridge == nil || brInfo == nil {
 		return fmt.Errorf("nil pointer encountered bridge[%v] brInfo[%v]", bridge, brInfo)
 	}
-	if err = bridge.create(); err != nil {
+	if err = bridge.Create(); err != nil {
 		return err
 	}
-	if err = bridge.enable(); err != nil {
+	if err = bridge.Enable(); err != nil {
 		return err
 	}
 	brInfo.Dnsmasq, err = startDnsmasq(bridge, tenant, subnet)
@@ -472,7 +472,7 @@ func (cnci *Cnci) AddRemoteSubnet(subnet net.IPNet, subnetKey int, cnIP net.IP) 
 		return "", err
 	}
 
-	bridge, err := newBridge(genBridgeAlias(subnet))
+	bridge, err := NewBridge(genBridgeAlias(subnet))
 	if err != nil {
 		return "", err
 	}

--- a/networking/libsnnet/cnci_test.go
+++ b/networking/libsnnet/cnci_test.go
@@ -139,12 +139,12 @@ func TestCNCI_Internal(t *testing.T) {
 
 	// Create the CNCI aggregation bridge
 	bridgeAlias := fmt.Sprintf("br_%s_%s_%s", tenantUUID, subnetUUID, concUUID)
-	bridge, _ := newBridge(bridgeAlias)
+	bridge, _ := NewBridge(bridgeAlias)
 
-	assert.Nil(bridge.create())
-	defer func() { _ = bridge.destroy() }()
+	assert.Nil(bridge.Create())
+	defer func() { _ = bridge.Destroy() }()
 
-	assert.Nil(bridge.enable())
+	assert.Nil(bridge.Enable())
 
 	// Attach the DNS masq against the CNCI bridge. This gives it an IP address
 	d, err := newDnsmasq(bridgeAlias, tenantUUID, subnet, reserved, bridge)

--- a/networking/libsnnet/dnsmasq.go
+++ b/networking/libsnnet/dnsmasq.go
@@ -111,9 +111,9 @@ func (d *Dnsmasq) start() error {
 		return fmt.Errorf("d.createHostsFile failed %v", err)
 	}
 
-	if err := d.Dev.addIP(&d.gateway); err != nil {
-		_ = d.Dev.delIP(&d.gateway) //TODO: check it already has the IP
-		if err = d.Dev.addIP(&d.gateway); err != nil {
+	if err := d.Dev.AddIP(&d.gateway); err != nil {
+		_ = d.Dev.DelIP(&d.gateway) //TODO: check it already has the IP
+		if err = d.Dev.AddIP(&d.gateway); err != nil {
 			return fmt.Errorf("d.Dev.AddIP failed %v %v", err, d.gateway.String())
 		}
 	}
@@ -161,7 +161,7 @@ func (d *Dnsmasq) stop() error {
 		}
 	}
 
-	if err = d.Dev.delIP(&d.gateway); err != nil {
+	if err = d.Dev.DelIP(&d.gateway); err != nil {
 		cumError = append(cumError, fmt.Errorf("Unable to delete bridge IP %v", err))
 	}
 

--- a/networking/libsnnet/dnsmasq_test.go
+++ b/networking/libsnnet/dnsmasq_test.go
@@ -44,12 +44,12 @@ func TestDnsmasq_Basic(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 0),
 	}
 
-	bridge, _ := newBridge("dns_testbr")
+	bridge, _ := NewBridge("dns_testbr")
 
-	err := bridge.create()
+	err := bridge.Create()
 	assert.Nil(err)
 
-	defer func() { _ = bridge.destroy() }()
+	defer func() { _ = bridge.Destroy() }()
 
 	d, err := newDnsmasq(id, tenant, subnet, reserved, bridge)
 	assert.Nil(err)
@@ -99,11 +99,11 @@ func TestDnsmasq_Negative(t *testing.T) {
 		Mask: net.IPv4Mask(255, 255, 255, 0),
 	}
 
-	bridge, _ := newBridge("dns_testbr")
+	bridge, _ := NewBridge("dns_testbr")
 
-	err := bridge.create()
+	err := bridge.Create()
 	assert.Nil(err)
-	defer func() { _ = bridge.destroy() }()
+	defer func() { _ = bridge.Destroy() }()
 
 	// Note: Re instantiate d each time as that
 	// is how it will be used

--- a/networking/libsnnet/fuzz_test.go
+++ b/networking/libsnnet/fuzz_test.go
@@ -126,20 +126,20 @@ func TestNwPrimitives_Fuzz(t *testing.T) {
 	}
 
 	bridge := Bridge{}
-	_ = bridge.create()
-	_ = bridge.enable()
-	_ = bridge.disable()
-	_ = bridge.getDevice()
-	_ = bridge.destroy()
+	_ = bridge.Create()
+	_ = bridge.Enable()
+	_ = bridge.Disable()
+	_ = bridge.GetDevice()
+	_ = bridge.Destroy()
 	for i := 0; i < 100; i++ {
 		bridge := Bridge{}
 		f.Fuzz(&bridge.GlobalID)
 		f.Fuzz(&bridge.TenantID)
-		_ = bridge.create()
-		_ = bridge.enable()
-		_ = bridge.disable()
-		_ = bridge.getDevice()
-		_ = bridge.destroy()
+		_ = bridge.Create()
+		_ = bridge.Enable()
+		_ = bridge.Disable()
+		_ = bridge.GetDevice()
+		_ = bridge.Destroy()
 	}
 
 	gre := &GreTunEP{}

--- a/networking/libsnnet/gre_test.go
+++ b/networking/libsnnet/gre_test.go
@@ -73,20 +73,20 @@ func TestGre_Bridge(t *testing.T) {
 
 	gre, err := newGreTunEP(id, local, remote, key)
 	assert.Nil(err)
-	bridge, err := newBridge("testbridge")
+	bridge, err := NewBridge("testbridge")
 	assert.Nil(err)
 
 	assert.Nil(gre.create())
 	defer func() { _ = gre.destroy() }()
 
-	assert.Nil(bridge.create())
-	defer func() { _ = bridge.destroy() }()
+	assert.Nil(bridge.Create())
+	defer func() { _ = bridge.Destroy() }()
 
 	assert.Nil(gre.attach(bridge))
 	//Duplicate
 	assert.Nil(gre.attach(bridge))
 	assert.Nil(gre.enable())
-	assert.Nil(bridge.enable())
+	assert.Nil(bridge.Enable())
 	assert.Nil(gre.detach(bridge))
 	//Duplicate
 	assert.Nil(gre.detach(bridge))

--- a/networking/libsnnet/internal_test.go
+++ b/networking/libsnnet/internal_test.go
@@ -53,12 +53,12 @@ func TestCN_dbRebuild(t *testing.T) {
 	vnicAlias := alias.vnic
 	greAlias := alias.gre
 
-	bridge, _ := newBridge(bridgeAlias)
+	bridge, _ := NewBridge(bridgeAlias)
 
-	if assert.NotNil(bridge.getDevice()) {
+	if assert.NotNil(bridge.GetDevice()) {
 		// First instance to land, create the bridge and tunnel
-		assert.Nil(bridge.create())
-		defer func(b *Bridge) { _ = b.destroy() }(bridge)
+		assert.Nil(bridge.Create())
+		defer func(b *Bridge) { _ = b.Destroy() }(bridge)
 
 		// Create the tunnel to connect to the CNCI
 		local := vnicCfg.VnicIP //Fake it for now

--- a/networking/libsnnet/vnic_test.go
+++ b/networking/libsnnet/vnic_test.go
@@ -192,17 +192,17 @@ func TestVnicContainer_GetDevice(t *testing.T) {
 func TestVnic_Bridge(t *testing.T) {
 	assert := assert.New(t)
 	vnic, _ := newVnic("testvnic")
-	bridge, _ := newBridge("testbridge")
+	bridge, _ := NewBridge("testbridge")
 
 	assert.Nil(vnic.create())
 	defer func() { _ = vnic.destroy() }()
 
-	assert.Nil(bridge.create())
-	defer func() { _ = bridge.destroy() }()
+	assert.Nil(bridge.Create())
+	defer func() { _ = bridge.Destroy() }()
 
 	assert.Nil(vnic.attach(bridge))
 	assert.Nil(vnic.enable())
-	assert.Nil(bridge.enable())
+	assert.Nil(bridge.Enable())
 	assert.Nil(vnic.detach(bridge))
 
 }
@@ -215,17 +215,17 @@ func TestVnic_Bridge(t *testing.T) {
 func TestVnicContainer_Bridge(t *testing.T) {
 	assert := assert.New(t)
 	vnic, _ := newContainerVnic("testvnic")
-	bridge, _ := newBridge("testbridge")
+	bridge, _ := NewBridge("testbridge")
 
 	assert.Nil(vnic.create())
 
 	defer func() { _ = vnic.destroy() }()
 
-	assert.Nil(bridge.create())
-	defer func() { _ = bridge.destroy() }()
+	assert.Nil(bridge.Create())
+	defer func() { _ = bridge.Destroy() }()
 
 	assert.Nil(vnic.attach(bridge))
 	assert.Nil(vnic.enable())
-	assert.Nil(bridge.enable())
+	assert.Nil(bridge.Enable())
 	assert.Nil(vnic.detach(bridge))
 }


### PR DESCRIPTION
Methods from bridge.go can be reused by some other projects such as
virtcontainers, that's the reason why we export them to make them
accessible.