### PR TITLE
networking: libsnnet: Export Vnic API

### DIFF
--- a/networking/libsnnet/cn.go
+++ b/networking/libsnnet/cn.go
@@ -693,9 +693,9 @@ func newCNVnic(cfg *VnicConfig, id string) (*Vnic, error) {
 
 	switch cfg.VnicRole {
 	case TenantVM:
-		vnic, err = newVnic(id)
+		vnic, err = NewVnic(id)
 	case TenantContainer:
-		vnic, err = newContainerVnic(id)
+		vnic, err = NewContainerVnic(id)
 	}
 	if err != nil {
 		return nil, NewAPIError(err.Error())
@@ -971,20 +971,20 @@ func createAndEnableBridge(bridge *Bridge, gre *GreTunEP) error {
 
 //Physically create the VNIC and attach it to the bridge
 func createAndEnableVnic(vnic *Vnic, bridge *Bridge) error {
-	if err := vnic.create(); err != nil {
+	if err := vnic.Create(); err != nil {
 		return fmt.Errorf("VNIC creation failed %s %s", vnic.GlobalID, err.Error())
 	}
-	if err := vnic.setHardwareAddr(*vnic.MACAddr); err != nil {
+	if err := vnic.SetHardwareAddr(*vnic.MACAddr); err != nil {
 		return fmt.Errorf("VNIC Set MAC Address %s %s", vnic.GlobalID, err.Error())
 	}
-	if err := vnic.setMTU(vnic.MTU); err != nil {
+	if err := vnic.SetMTU(vnic.MTU); err != nil {
 		return fmt.Errorf("VNIC Set MTU Address %s %s", vnic.GlobalID, err.Error())
 	}
-	if err := vnic.attach(bridge); err != nil {
+	if err := vnic.Attach(bridge); err != nil {
 		return fmt.Errorf("VNIC attach failed %s %s %s", vnic.GlobalID, bridge.GlobalID, err.Error())
 	}
 	vnic.BridgeID = bridge.LinkName
-	if err := vnic.enable(); err != nil {
+	if err := vnic.Enable(); err != nil {
 		return fmt.Errorf("VNIC enable failed %s %s %s", vnic.GlobalID, bridge.GlobalID, err.Error())
 	}
 	return nil
@@ -1048,7 +1048,7 @@ func (cn *ComputeNode) deleteVnicInternal(vnic *Vnic, vLink *linkInfo) (err erro
 	if err != nil {
 		return NewFatalError(vnic.GlobalID + err.Error())
 	}
-	err = vnic.destroy()
+	err = vnic.Destroy()
 	if err != nil {
 		return NewFatalError(err.Error())
 	}
@@ -1107,7 +1107,7 @@ func (cn *ComputeNode) destroyVnicInternal(cfg *VnicConfig) (*SsntpEventInfo, er
 	var brDeleteMsg *SsntpEventInfo
 
 	alias := genCnVnicAliases(cfg)
-	vnic, err := newVnic(alias.vnic)
+	vnic, err := NewVnic(alias.vnic)
 	if err != nil {
 		return nil, NewAPIError(err.Error())
 	}

--- a/networking/libsnnet/cn_container_test.go
+++ b/networking/libsnnet/cn_container_test.go
@@ -259,7 +259,7 @@ func TestCNContainer_Base(t *testing.T) {
 
 		//Cache the first subnet ID we see. All subsequent should have the same
 		subnetID = cInfo.SubnetID
-		iface = vnic.interfaceName()
+		iface = vnic.InterfaceName()
 		assert.NotEqual(iface, "")
 
 		//Launcher will attach to this name and send out the event
@@ -282,7 +282,7 @@ func TestCNContainer_Base(t *testing.T) {
 		if assert.NotNil(cInfo) {
 			assert.Equal(cInfo.SubnetID, subnetID)
 			assert.Equal(cInfo.CNContainerEvent, ContainerNetworkInfo)
-			assert.Equal(iface, vnic.interfaceName())
+			assert.Equal(iface, vnic.InterfaceName())
 		}
 	}
 
@@ -295,7 +295,7 @@ func TestCNContainer_Base(t *testing.T) {
 			assert.Equal(cInfo.SubnetID, subnetID)
 			assert.Equal(cInfo.CNContainerEvent, ContainerNetworkInfo)
 		}
-		iface = vnic.interfaceName()
+		iface = vnic.InterfaceName()
 		assert.NotEqual(iface, "")
 		assert.Nil(dockerRunVerify(vnicCfg2.VnicIP.String(), vnicCfg2.VnicIP,
 			vnicCfg2.VnicMAC, cInfo.SubnetID))
@@ -310,7 +310,7 @@ func TestCNContainer_Base(t *testing.T) {
 		if assert.NotNil(cInfo) {
 			assert.Equal(cInfo.SubnetID, subnetID)
 			assert.Equal(cInfo.CNContainerEvent, ContainerNetworkInfo)
-			assert.Equal(iface, vnic.interfaceName())
+			assert.Equal(iface, vnic.InterfaceName())
 		}
 	}
 

--- a/networking/libsnnet/cn_test.go
+++ b/networking/libsnnet/cn_test.go
@@ -738,13 +738,13 @@ func TestCN_Whitebox(t *testing.T) {
 
 	// Create the VNIC for the instance
 	vnicAlias := fmt.Sprintf("vnic_%s_%s_%s_%s", tenantUUID, instanceUUID, instanceMAC, concUUID)
-	vnic, _ := newVnic(vnicAlias)
+	vnic, _ := NewVnic(vnicAlias)
 	vnic.MACAddr = &instanceMAC
 
-	assert.Nil(vnic.create())
-	defer func() { _ = vnic.destroy() }()
+	assert.Nil(vnic.Create())
+	defer func() { _ = vnic.Destroy() }()
 
-	assert.Nil(vnic.attach(bridge))
-	assert.Nil(vnic.enable())
+	assert.Nil(vnic.Attach(bridge))
+	assert.Nil(vnic.Enable())
 	assert.Nil(bridge.Enable())
 }

--- a/networking/libsnnet/cnci.go
+++ b/networking/libsnnet/cnci.go
@@ -606,7 +606,7 @@ func (cnci *Cnci) Shutdown() error {
 	for alias, linfo := range cnci.topology.linkMap {
 		if linfo != nil {
 			//HACKING: Better to create the right type
-			vnic, err := newVnic(alias)
+			vnic, err := NewVnic(alias)
 			if err != nil {
 				lasterr = err
 				continue
@@ -616,7 +616,7 @@ func (cnci *Cnci) Shutdown() error {
 				lasterr = err
 				continue
 			}
-			if err := vnic.destroy(); err != nil {
+			if err := vnic.Destroy(); err != nil {
 				lasterr = err
 				continue
 			}

--- a/networking/libsnnet/docker_plugin.go
+++ b/networking/libsnnet/docker_plugin.go
@@ -425,14 +425,14 @@ func handlerCreateEndpoint(d *DockerPlugin, w http.ResponseWriter, r *http.Reque
 	//We can also get this directly from the SDN controller.
 	//However that will prevent the plugin from being its own service
 	//in the future
-	vnic, err := newContainerVnic(vnicID)
+	vnic, err := NewContainerVnic(vnicID)
 	if err != nil {
 		resp.Err = "Error: invalid interface " + err.Error()
 		sendResponse(resp, w)
 		return
 	}
 
-	if err := vnic.getDevice(); err != nil {
+	if err := vnic.GetDevice(); err != nil {
 		resp.Err = "Error: invalid interface " + err.Error()
 		sendResponse(resp, w)
 		return
@@ -444,8 +444,8 @@ func handlerCreateEndpoint(d *DockerPlugin, w http.ResponseWriter, r *http.Reque
 	d.DockerEpMap.m[req.EndpointID] = &DockerEpVal{
 		ID:    vnicID,
 		IP:    req.Interface.Address,
-		Hveth: vnic.interfaceName(),
-		Cveth: vnic.peerName(),
+		Hveth: vnic.InterfaceName(),
+		Cveth: vnic.PeerName(),
 	}
 
 	if err := d.DbAdd(tableEndPointMap, req.EndpointID, d.DockerEpMap.m[req.EndpointID]); err != nil {

--- a/networking/libsnnet/fuzz_test.go
+++ b/networking/libsnnet/fuzz_test.go
@@ -106,11 +106,11 @@ func TestNwPrimitives_Fuzz(t *testing.T) {
 	f := fuzz.New()
 
 	vnic := Vnic{}
-	_ = vnic.create()
-	_ = vnic.enable()
-	_ = vnic.disable()
-	_ = vnic.getDevice()
-	_ = vnic.destroy()
+	_ = vnic.Create()
+	_ = vnic.Enable()
+	_ = vnic.Disable()
+	_ = vnic.GetDevice()
+	_ = vnic.Destroy()
 	for i := 0; i < 100; i++ {
 		vnic := Vnic{}
 		f.Fuzz(&vnic.Role)
@@ -118,11 +118,11 @@ func TestNwPrimitives_Fuzz(t *testing.T) {
 		f.Fuzz(&vnic.TenantID)
 		f.Fuzz(&vnic.InstanceID)
 		f.Fuzz(&vnic.BridgeID)
-		_ = vnic.create()
-		_ = vnic.enable()
-		_ = vnic.disable()
-		_ = vnic.getDevice()
-		_ = vnic.destroy()
+		_ = vnic.Create()
+		_ = vnic.Enable()
+		_ = vnic.Disable()
+		_ = vnic.GetDevice()
+		_ = vnic.Destroy()
 	}
 
 	bridge := Bridge{}
@@ -175,16 +175,16 @@ func TestNwPrimitives_Fuzz(t *testing.T) {
 	}
 
 	for i := 0; i < 100; i++ {
-		vnic, _ := newVnic("xyz")
+		vnic, _ := NewVnic("xyz")
 		f.Fuzz(&vnic.Role)
 		f.Fuzz(&vnic.GlobalID)
 		f.Fuzz(&vnic.TenantID)
 		f.Fuzz(&vnic.InstanceID)
 		f.Fuzz(&vnic.BridgeID)
-		_ = vnic.create()
-		_ = vnic.enable()
-		_ = vnic.disable()
-		_ = vnic.getDevice()
-		_ = vnic.destroy()
+		_ = vnic.Create()
+		_ = vnic.Enable()
+		_ = vnic.Disable()
+		_ = vnic.GetDevice()
+		_ = vnic.Destroy()
 	}
 }

--- a/networking/libsnnet/internal_test.go
+++ b/networking/libsnnet/internal_test.go
@@ -74,22 +74,22 @@ func TestCN_dbRebuild(t *testing.T) {
 	}
 
 	// Create the VNIC for the instance
-	vnic, _ := newVnic(vnicAlias)
+	vnic, _ := NewVnic(vnicAlias)
 
-	assert.Nil(vnic.create())
-	defer func() { _ = vnic.destroy() }()
+	assert.Nil(vnic.Create())
+	defer func() { _ = vnic.Destroy() }()
 
-	assert.Nil(vnic.attach(bridge))
+	assert.Nil(vnic.Attach(bridge))
 
 	//Add a second vnic
 	vnicCfg.VnicIP = net.IPv4(192, 168, 1, 101)
 	alias1 := genCnVnicAliases(vnicCfg)
-	vnic1, _ := newVnic(alias1.vnic)
+	vnic1, _ := NewVnic(alias1.vnic)
 
-	assert.Nil(vnic1.create())
-	defer func() { _ = vnic1.destroy() }()
+	assert.Nil(vnic1.Create())
+	defer func() { _ = vnic1.Destroy() }()
 
-	assert.Nil(vnic1.attach(bridge))
+	assert.Nil(vnic1.Attach(bridge))
 
 	/* Test negative test cases */
 	assert.NotNil(cn.DbRebuild(nil))

--- a/networking/libsnnet/vnic.go
+++ b/networking/libsnnet/vnic.go
@@ -26,7 +26,7 @@ import (
 
 // NewVnic is used to initialize the Vnic properties
 // This has to be called prior to Create() or GetDevice()
-func newVnic(id string) (*Vnic, error) {
+func NewVnic(id string) (*Vnic, error) {
 	Vnic := &Vnic{}
 	Vnic.Link = &netlink.GenericLink{}
 	Vnic.GlobalID = id
@@ -36,7 +36,7 @@ func newVnic(id string) (*Vnic, error) {
 
 // NewContainerVnic is used to initialize a container Vnic properties
 // This has to be called prior to Create() or GetDevice()
-func newContainerVnic(id string) (*Vnic, error) {
+func NewContainerVnic(id string) (*Vnic, error) {
 	Vnic := &Vnic{}
 	Vnic.Link = &netlink.Veth{}
 	Vnic.GlobalID = id
@@ -47,12 +47,12 @@ func newContainerVnic(id string) (*Vnic, error) {
 //InterfaceName is used to retrieve the name of the physical interface to
 //which the VM or the container needs to be connected to
 //Returns "" if the link is not setup
-func (v *Vnic) interfaceName() string {
+func (v *Vnic) InterfaceName() string {
 	switch v.Role {
 	case TenantVM:
 		return v.LinkName
 	case TenantContainer:
-		return v.peerName()
+		return v.PeerName()
 	default:
 		return ""
 	}
@@ -61,7 +61,7 @@ func (v *Vnic) interfaceName() string {
 //PeerName is used to retrieve the peer name
 //Returns "" if the link is not setup or if the link
 //has no peer
-func (v *Vnic) peerName() string {
+func (v *Vnic) PeerName() string {
 	if v.Role != TenantContainer {
 		return v.LinkName
 	}
@@ -77,7 +77,7 @@ func (v *Vnic) peerName() string {
 
 // GetDevice is used to associate with an existing VNIC provided it satisfies
 // the needs of a Vnic. Returns error if the VNIC does not exist
-func (v *Vnic) getDevice() error {
+func (v *Vnic) GetDevice() error {
 
 	if v.GlobalID == "" {
 		return netError(v, "get device unnamed vnic")
@@ -149,7 +149,7 @@ func createContainerVnic(v *Vnic) (link netlink.Link, err error) {
 		LinkAttrs: netlink.LinkAttrs{
 			Name: v.LinkName,
 		},
-		PeerName: v.peerName(),
+		PeerName: v.PeerName(),
 	}
 
 	if err := netlink.LinkAdd(veth); err != nil {
@@ -169,7 +169,7 @@ func createContainerVnic(v *Vnic) (link netlink.Link, err error) {
 }
 
 // Create instantiates new VNIC
-func (v *Vnic) create() error {
+func (v *Vnic) Create() error {
 	var err error
 
 	if v.GlobalID == "" {
@@ -207,7 +207,7 @@ func (v *Vnic) create() error {
 	}
 
 	if err := v.setAlias(v.GlobalID); err != nil {
-		_ = v.destroy()
+		_ = v.Destroy()
 		return netError(v, "create set alias %v %v", v.GlobalID, err)
 	}
 
@@ -215,7 +215,7 @@ func (v *Vnic) create() error {
 }
 
 // Destroy a VNIC
-func (v *Vnic) destroy() error {
+func (v *Vnic) Destroy() error {
 
 	if v.Link == nil || v.Link.Attrs().Index == 0 {
 		return netError(v, "destroy unnitialized")
@@ -231,7 +231,7 @@ func (v *Vnic) destroy() error {
 
 // Attach the VNIC to a bridge or a switch. Will return error if the VNIC
 // incapable of binding to the specified device
-func (v *Vnic) attach(dev interface{}) error {
+func (v *Vnic) Attach(dev interface{}) error {
 
 	if v.Link == nil || v.Link.Attrs().Index == 0 {
 		return netError(v, "attach unnitialized")
@@ -254,7 +254,7 @@ func (v *Vnic) attach(dev interface{}) error {
 }
 
 // Detach the VNIC from the device it is attached to
-func (v *Vnic) detach(dev interface{}) error {
+func (v *Vnic) Detach(dev interface{}) error {
 
 	if v.Link == nil || v.Link.Attrs().Index == 0 {
 		return netError(v, "detach unnitialized")
@@ -278,7 +278,7 @@ func (v *Vnic) detach(dev interface{}) error {
 }
 
 // Enable the VNIC
-func (v *Vnic) enable() error {
+func (v *Vnic) Enable() error {
 
 	if v.Link == nil || v.Link.Attrs().Index == 0 {
 		return netError(v, "enable unnitialized")
@@ -293,7 +293,7 @@ func (v *Vnic) enable() error {
 }
 
 // Disable the VNIC
-func (v *Vnic) disable() error {
+func (v *Vnic) Disable() error {
 
 	if v.Link == nil || v.Link.Attrs().Index == 0 {
 		return netError(v, "disable unnitialized")
@@ -307,7 +307,7 @@ func (v *Vnic) disable() error {
 }
 
 //SetMTU of the interface
-func (v *Vnic) setMTU(mtu int) error {
+func (v *Vnic) SetMTU(mtu int) error {
 
 	if v.Link == nil || v.Link.Attrs().Index == 0 {
 		return netError(v, "disable unnitialized")
@@ -323,7 +323,7 @@ func (v *Vnic) setMTU(mtu int) error {
 		}
 		peerVeth := &netlink.Veth{
 			LinkAttrs: netlink.LinkAttrs{
-				Name: v.peerName(),
+				Name: v.PeerName(),
 			},
 			PeerName: v.LinkName,
 		}
@@ -336,7 +336,7 @@ func (v *Vnic) setMTU(mtu int) error {
 }
 
 //SetHardwareAddr of the interface
-func (v *Vnic) setHardwareAddr(addr net.HardwareAddr) error {
+func (v *Vnic) SetHardwareAddr(addr net.HardwareAddr) error {
 
 	if v.Link == nil || v.Link.Attrs().Index == 0 {
 		return netError(v, "disable unnitialized")
@@ -349,7 +349,7 @@ func (v *Vnic) setHardwareAddr(addr net.HardwareAddr) error {
 		/* Need to set the MAC on the container side */
 		peerVeth := &netlink.Veth{
 			LinkAttrs: netlink.LinkAttrs{
-				Name: v.peerName(),
+				Name: v.PeerName(),
 			},
 			PeerName: v.LinkName,
 		}

--- a/networking/libsnnet/vnic_test.go
+++ b/networking/libsnnet/vnic_test.go
@@ -27,9 +27,9 @@ func performVnicOps(shouldPass bool, assert *assert.Assertions, vnic *Vnic) {
 	if !shouldPass {
 		a = assert.NotNil
 	}
-	a(vnic.enable())
-	a(vnic.disable())
-	a(vnic.destroy())
+	a(vnic.Enable())
+	a(vnic.Disable())
+	a(vnic.Destroy())
 }
 
 //Tests all the basic VNIC primitives
@@ -42,16 +42,16 @@ func performVnicOps(shouldPass bool, assert *assert.Assertions, vnic *Vnic) {
 func TestVnic_Basic(t *testing.T) {
 	assert := assert.New(t)
 
-	vnic, err := newVnic("testvnic")
+	vnic, err := NewVnic("testvnic")
 	assert.Nil(err)
-	assert.Nil(vnic.create())
+	assert.Nil(vnic.Create())
 
-	vnic1, err := newVnic("testvnic")
+	vnic1, err := NewVnic("testvnic")
 	assert.Nil(err)
 
-	assert.Nil(vnic1.getDevice())
-	assert.NotEqual(vnic.interfaceName(), "")
-	assert.Equal(vnic.peerName(), vnic.interfaceName())
+	assert.Nil(vnic1.GetDevice())
+	assert.NotEqual(vnic.InterfaceName(), "")
+	assert.Equal(vnic.PeerName(), vnic.InterfaceName())
 
 	performVnicOps(true, assert, vnic)
 }
@@ -66,11 +66,11 @@ func TestVnic_Basic(t *testing.T) {
 func TestVnicContainer_Basic(t *testing.T) {
 	assert := assert.New(t)
 
-	vnic, _ := newContainerVnic("testvnic")
-	assert.Nil(vnic.create())
+	vnic, _ := NewContainerVnic("testvnic")
+	assert.Nil(vnic.Create())
 
-	vnic1, _ := newContainerVnic("testvnic")
-	assert.Nil(vnic1.getDevice())
+	vnic1, _ := NewContainerVnic("testvnic")
+	assert.Nil(vnic1.GetDevice())
 
 	performVnicOps(true, assert, vnic)
 }
@@ -83,12 +83,12 @@ func TestVnicContainer_Basic(t *testing.T) {
 //Test is expected to pass
 func TestVnic_Dup(t *testing.T) {
 	assert := assert.New(t)
-	vnic, _ := newVnic("testvnic")
-	vnic1, _ := newVnic("testvnic")
+	vnic, _ := NewVnic("testvnic")
+	vnic1, _ := NewVnic("testvnic")
 
-	assert.Nil(vnic.create())
-	defer func() { _ = vnic.destroy() }()
-	assert.NotNil(vnic1.create())
+	assert.Nil(vnic.Create())
+	defer func() { _ = vnic.Destroy() }()
+	assert.NotNil(vnic1.Create())
 }
 
 //Duplicate Container VNIC creation detection
@@ -99,12 +99,12 @@ func TestVnic_Dup(t *testing.T) {
 //Test is expected to pass
 func TestVnicContainer_Dup(t *testing.T) {
 	assert := assert.New(t)
-	vnic, _ := newContainerVnic("testconvnic")
-	vnic1, _ := newContainerVnic("testconvnic")
+	vnic, _ := NewContainerVnic("testconvnic")
+	vnic1, _ := NewContainerVnic("testconvnic")
 
-	assert.Nil(vnic.create())
-	defer func() { _ = vnic.destroy() }()
-	assert.NotNil(vnic1.create())
+	assert.Nil(vnic.Create())
+	defer func() { _ = vnic.Destroy() }()
+	assert.NotNil(vnic1.Create())
 }
 
 //Negative test case for VNIC primitives
@@ -115,10 +115,10 @@ func TestVnicContainer_Dup(t *testing.T) {
 //Test is expected to pass
 func TestVnic_Invalid(t *testing.T) {
 	assert := assert.New(t)
-	vnic, err := newVnic("testvnic")
+	vnic, err := NewVnic("testvnic")
 	assert.Nil(err)
 
-	assert.NotNil(vnic.getDevice())
+	assert.NotNil(vnic.GetDevice())
 
 	performVnicOps(false, assert, vnic)
 }
@@ -132,10 +132,10 @@ func TestVnic_Invalid(t *testing.T) {
 func TestVnicContainer_Invalid(t *testing.T) {
 	assert := assert.New(t)
 
-	vnic, err := newContainerVnic("testcvnic")
+	vnic, err := NewContainerVnic("testcvnic")
 	assert.Nil(err)
 
-	assert.NotNil(vnic.getDevice())
+	assert.NotNil(vnic.GetDevice())
 
 	performVnicOps(false, assert, vnic)
 }
@@ -148,16 +148,16 @@ func TestVnicContainer_Invalid(t *testing.T) {
 //Test is expected to pass
 func TestVnic_GetDevice(t *testing.T) {
 	assert := assert.New(t)
-	vnic1, _ := newVnic("testvnic")
+	vnic1, _ := NewVnic("testvnic")
 
-	assert.Nil(vnic1.create())
-	vnic, _ := newVnic("testvnic")
+	assert.Nil(vnic1.Create())
+	vnic, _ := NewVnic("testvnic")
 
-	assert.Nil(vnic.getDevice())
-	assert.NotEqual(vnic.interfaceName(), "")
-	assert.Equal(vnic.interfaceName(), vnic1.interfaceName())
-	assert.NotEqual(vnic1.peerName(), "")
-	assert.Equal(vnic1.peerName(), vnic.peerName())
+	assert.Nil(vnic.GetDevice())
+	assert.NotEqual(vnic.InterfaceName(), "")
+	assert.Equal(vnic.InterfaceName(), vnic1.InterfaceName())
+	assert.NotEqual(vnic1.PeerName(), "")
+	assert.Equal(vnic1.PeerName(), vnic.PeerName())
 
 	performVnicOps(true, assert, vnic)
 }
@@ -171,16 +171,16 @@ func TestVnic_GetDevice(t *testing.T) {
 func TestVnicContainer_GetDevice(t *testing.T) {
 	assert := assert.New(t)
 
-	vnic1, err := newContainerVnic("testvnic")
+	vnic1, err := NewContainerVnic("testvnic")
 	assert.Nil(err)
 
-	err = vnic1.create()
+	err = vnic1.Create()
 	assert.Nil(err)
 
-	vnic, err := newContainerVnic("testvnic")
+	vnic, err := NewContainerVnic("testvnic")
 	assert.Nil(err)
 
-	assert.Nil(vnic.getDevice())
+	assert.Nil(vnic.GetDevice())
 	performVnicOps(true, assert, vnic)
 }
 
@@ -191,19 +191,19 @@ func TestVnicContainer_GetDevice(t *testing.T) {
 //Test is expected to pass
 func TestVnic_Bridge(t *testing.T) {
 	assert := assert.New(t)
-	vnic, _ := newVnic("testvnic")
+	vnic, _ := NewVnic("testvnic")
 	bridge, _ := NewBridge("testbridge")
 
-	assert.Nil(vnic.create())
-	defer func() { _ = vnic.destroy() }()
+	assert.Nil(vnic.Create())
+	defer func() { _ = vnic.Destroy() }()
 
 	assert.Nil(bridge.Create())
 	defer func() { _ = bridge.Destroy() }()
 
-	assert.Nil(vnic.attach(bridge))
-	assert.Nil(vnic.enable())
+	assert.Nil(vnic.Attach(bridge))
+	assert.Nil(vnic.Enable())
 	assert.Nil(bridge.Enable())
-	assert.Nil(vnic.detach(bridge))
+	assert.Nil(vnic.Detach(bridge))
 
 }
 
@@ -214,18 +214,18 @@ func TestVnic_Bridge(t *testing.T) {
 //Test is expected to pass
 func TestVnicContainer_Bridge(t *testing.T) {
 	assert := assert.New(t)
-	vnic, _ := newContainerVnic("testvnic")
+	vnic, _ := NewContainerVnic("testvnic")
 	bridge, _ := NewBridge("testbridge")
 
-	assert.Nil(vnic.create())
+	assert.Nil(vnic.Create())
 
-	defer func() { _ = vnic.destroy() }()
+	defer func() { _ = vnic.Destroy() }()
 
 	assert.Nil(bridge.Create())
 	defer func() { _ = bridge.Destroy() }()
 
-	assert.Nil(vnic.attach(bridge))
-	assert.Nil(vnic.enable())
+	assert.Nil(vnic.Attach(bridge))
+	assert.Nil(vnic.Enable())
 	assert.Nil(bridge.Enable())
-	assert.Nil(vnic.detach(bridge))
+	assert.Nil(vnic.Detach(bridge))
 }


### PR DESCRIPTION
Methods from vnic.go can be reused by some other projects such as
virtcontainers, that's the reason why we export them to make them
accessible.