### PR TITLE
ansible: Make sure the deployment node is using the correct ciao-cli

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/build.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/build.yml
@@ -42,6 +42,7 @@
         with_items:
           - ciao-cert
           - ciao-cnci-agent
+          - ciao-cli
 
       - name: Make ciao files runnable
         connection: local
@@ -49,4 +50,5 @@
         with_items:
           - ciao-cert
           - ciao-cnci-agent
+          - ciao-cli
     when: not ciao_dev

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/upload_images.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/upload_images.yml
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+  - name: Set ciao-cli location
+    set_fact: ciao_cli={{ (gopath + '/bin/ciao-cli') if ciao_dev else '{{ playbook_dir }}/fetch/ciao-cli' }}
+
   - name: Check if {{ image.name }} exists
-    shell: ciao-cli image show -image {{ image.id }}
+    shell: "{{ ciao_cli }} image show -image {{ image.id }}"
     register: imagerc
     failed_when: False
     changed_when: False
@@ -27,7 +30,7 @@
       CIAO_CA_CERT_FILE: certificates/keystone/keystone_cert.pem
 
   - name: Upload {{ image.name }}
-    shell: ciao-cli image add --file images/{{ image.file }} --name "{{ image.name }}" --id {{ image.id }}
+    shell: "{{ ciao_cli }} image add --file images/{{ image.file }} --name {{ image.name }} --id {{ image.id }}"
     environment:
       CIAO_CONTROLLER: "{{ keystone_fqdn }}"
       CIAO_IDENTITY: "https://{{ keystone_fqdn }}:35357"


### PR DESCRIPTION
If ciao is installed from packages, the ciao-cli binary will be retrieved from
the controller node. Otherwise, the ciao-cli from the local GOPATH will be used.

Fixes https://github.com/01org/ciao/issues/943