### PR TITLE
Add support for creating custom workloads

### DIFF
--- a/ciao-cli/examples/README.md
+++ b/ciao-cli/examples/README.md
@@ -1,0 +1,142 @@
+# workload examples
+
+A workload can be uploaded into the ciao datastore via the ciao-cli
+command.
+
+`ciao-cli workload create -yaml my_workload.yaml`
+
+This directory includes some sample workloads that illustrate a few
+basic workload definitions. A workload consists of a yaml file which
+defines the properties and resources the workload needs, as well as a
+yaml file which contains the cloud config to use when launching the instance.
+section.
+
+## workload properties yaml
+
+The workload properties yaml file contains information which define the
+workload. This configuration will be used for each instance that is started
+with the workload ID.
+
+The first section of the file contains some basic information about the
+workload.
+
+```
+description: "My awesome container workload"
+vm_type: docker
+image_name: "ubuntu:latest"
+```
+
+`description` is just a human readable string which will be
+displayed when you list workloads with `ciao-cli workload list`.
+
+There are two types of workloads - container based, and vm based. The `vm_type`
+string specifies whether this workload is a container or a VM. Currently ciao
+supports only docker based containers, and qemu for vms. Valid values for
+vm_type are `docker` or `qemu`.
+
+The above example is for a container workload. The `vm_type` is set to `docker`
+and the docker hub image name is provided by the `image_name` value.
+
+For VMs, the configuration would be slightly different. `description` is still
+provided, however, `vm_type` is set to `qemu`. Additionally, a `fw_type` is
+required to specify whether the image that is provided has a UEFI based
+firmware, or a legacy firmware. If the workload should be booted from an
+image, the image must have already been added to the ciao image service.
+The `image_id` is the UUID of the image, and can be obtained with `ciao-cli
+image list`.
+
+```
+description: "My favorite pet VM"
+vm_type: qemu
+fw_type: legacy
+image_id: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
+```
+
+Workloads may also be specified to boot from volumes created in ciao's volume
+service. To create a workload which boots from an existing volume, leave the
+image_id blank and include a definition for a bootable disk.
+
+```
+description: "My favorite pet VM"
+vm_type: qemu
+fw_type: legacy
+disks:
+- volume_id: "9c858de5-fdd3-42d8-925e-2fdc60768d24"
+  bootable: true
+```
+
+Disks for the workload may be bootable, or attached. To create a new volume
+to be attached to your workload for persistent storage, specify the size
+of your new disk in GigaBytes. Newly created disks may be marked as persistent
+if you wish to persist the disk after the instance has been destroyed.
+
+```
+disks:
+- size: 20
+  persistent: true
+```
+
+To attach a volume that has already been created in the ciao volume service,
+specify the volume_id of the volume to be attached.
+
+```
+disks:
+- volume_id: "9c858de5-fdd3-42d8-925e-2fdc60768d24"
+```
+
+You can specify in the workload definition whether to create a volume
+to either attach or boot from that is cloned from an existing volume or
+image by including a `source` definition.
+
+```
+disks:
+- bootable: true
+  source:
+     service: volume
+     id: "9c858de5-fdd3-42d8-925e-2fdc60768d24"
+```
+
+Valid values for the source `service` field are `image` or `volume`
+
+Workload definitions must also contain default values for resources
+that the workload will need to use when it runs. There are three resources
+which must be specified:
+
+```
+defaults:
+    vcpus: 2
+    mem_mb: 512
+    disk_mb: 1024
+```
+
+Finally, the filename for the cloud config file must be included in the
+workload definition. This file must be readable by ciao-cli.
+
+```
+cloud_init: "fedora_vm.yaml"
+```
+
+## cloud config yaml file
+
+Below is an example ciao cloud config file. ciao cloud config files have a
+cloud-config section, followed by a user data section. The cloud-config section
+must be prefaced by the `---` separator.
+
+```
+---
+#cloud-config
+users:
+  - name: demouser
+    gecos: CIAO Demo User
+    lock-passwd: false
+    passwd: $6$rounds=4096$w9I3hR4g/hu$AnYjaC2DfznbPSG3vxsgtgAS4mJwWBkcR74Y/KHNB5OsfAlA4gpU5j6CHWMOkkt9j.9d7OYJXJ4icXHzKXTAO.
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh-authorized-keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDerQfD+qkb0V0XdQs8SBWqy4sQmqYFP96n/kI4Cq162w4UE8pTxy0ozAPldOvBJjljMvgaNKSAddknkhGcrNUvvJsUcZFm2qkafi32WyBdGFvIc45A+8O7vsxPXgHEsS9E3ylEALXAC3D0eX7pPtRiAbasLlY+VcACRqr3bPDSZTfpCmIkV2334uZD9iwOvTVeR+FjGDqsfju4DyzoAIqpPasE0+wk4Vbog7osP+qvn1gj5kQyusmr62+t0wx+bs2dF5QemksnFOswUrv9PGLhZgSMmDQrRYuvEfIAC7IdN/hfjTn0OokzljBiuWQ4WIIba/7xTYLVujJV65qH3heaSMxJJD7eH9QZs9RdbbdTXMFuJFsHV2OF6wZRp18tTNZZJMqiHZZSndC5WP1WrUo3Au/9a+ighSaOiVddHsPG07C/TOEnr3IrwU7c9yIHeeRFHmcQs9K0+n9XtrmrQxDQ9/mLkfje80Ko25VJ/QpAQPzCKh2KfQ4RD+/PxBUScx/lHIHOIhTSCh57ic629zWgk0coSQDi4MKSa5guDr3cuDvt4RihGviDM6V68ewsl0gh6Z9c0Hw7hU0vky4oxak5AiySiPz0FtsOnAzIL0UON+yMuKzrJgLjTKodwLQ0wlBXu43cD+P8VXwQYeqNSzfrhBnHqsrMf4lTLtc7kDDTcw== ciao@ciao
+...
+```
+
+The above example shows that the user data section is blank, but the `...`
+separator must be present to indicate the end of the cloud-config section.
+Be sure to use a cloud-config that is recognized by the host OS you are using
+for your workload.

--- a/ciao-cli/examples/docker-ubuntu.yaml
+++ b/ciao-cli/examples/docker-ubuntu.yaml
@@ -1,0 +1,5 @@
+---
+#cloud-config
+runcmd:
+  - [ /bin/bash, -c, "while true; do sleep 60; done" ]
+...

--- a/ciao-cli/examples/fedora_cloud.yaml
+++ b/ciao-cli/examples/fedora_cloud.yaml
@@ -1,0 +1,9 @@
+description: "Fedora VM no storage"
+vm_type: qemu
+fw_type: legacy
+image_id: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
+defaults:
+    vcpus: 2
+    mem_mb: 512
+    disk_mb: 1024
+cloud_init: fedora_vm.yaml

--- a/ciao-cli/examples/fedora_cloud_disk.yaml
+++ b/ciao-cli/examples/fedora_cloud_disk.yaml
@@ -1,0 +1,12 @@
+description: "Fedora VM with attached empty storage"
+vm_type: qemu
+fw_type: legacy
+image_id: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
+defaults:
+    vcpus: 2
+    mem_mb: 512
+    disk_mb: 1024
+cloud_init: "fedora_vm.yaml"
+disks:
+- size: 20
+  persistent: true

--- a/ciao-cli/examples/fedora_vm.yaml
+++ b/ciao-cli/examples/fedora_vm.yaml
@@ -1,0 +1,11 @@
+---
+#cloud-config
+users:
+  - name: demouser
+    gecos: CIAO Demo User
+    lock-passwd: false
+    passwd: $6$rounds=4096$w9I3hR4g/hu$AnYjaC2DfznbPSG3vxsgtgAS4mJwWBkcR74Y/KHNB5OsfAlA4gpU5j6CHWMOkkt9j.9d7OYJXJ4icXHzKXTAO.
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh-authorized-keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDerQfD+qkb0V0XdQs8SBWqy4sQmqYFP96n/kI4Cq162w4UE8pTxy0ozAPldOvBJjljMvgaNKSAddknkhGcrNUvvJsUcZFm2qkafi32WyBdGFvIc45A+8O7vsxPXgHEsS9E3ylEALXAC3D0eX7pPtRiAbasLlY+VcACRqr3bPDSZTfpCmIkV2334uZD9iwOvTVeR+FjGDqsfju4DyzoAIqpPasE0+wk4Vbog7osP+qvn1gj5kQyusmr62+t0wx+bs2dF5QemksnFOswUrv9PGLhZgSMmDQrRYuvEfIAC7IdN/hfjTn0OokzljBiuWQ4WIIba/7xTYLVujJV65qH3heaSMxJJD7eH9QZs9RdbbdTXMFuJFsHV2OF6wZRp18tTNZZJMqiHZZSndC5WP1WrUo3Au/9a+ighSaOiVddHsPG07C/TOEnr3IrwU7c9yIHeeRFHmcQs9K0+n9XtrmrQxDQ9/mLkfje80Ko25VJ/QpAQPzCKh2KfQ4RD+/PxBUScx/lHIHOIhTSCh57ic629zWgk0coSQDi4MKSa5guDr3cuDvt4RihGviDM6V68ewsl0gh6Z9c0Hw7hU0vky4oxak5AiySiPz0FtsOnAzIL0UON+yMuKzrJgLjTKodwLQ0wlBXu43cD+P8VXwQYeqNSzfrhBnHqsrMf4lTLtc7kDDTcw== ciao@ciao
+...

--- a/ciao-cli/examples/ubuntu_latest.yaml
+++ b/ciao-cli/examples/ubuntu_latest.yaml
@@ -1,0 +1,8 @@
+description: "Ubuntu latest container"
+vm_type: docker
+image_name: "ubuntu:latest"
+defaults:
+  vcpus: 2
+  mem_mb: 512
+  disk_mb: 80
+cloud_init: "docker-ubuntu.yaml"

--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -291,11 +291,18 @@ func (cmd *workloadCreateCommand) run(args []string) error {
 		fatalf(err.Error())
 	}
 
-	if resp.StatusCode != http.StatusNoContent {
+	if resp.StatusCode != http.StatusCreated {
 		fatalf("Workload creation failed: %s", resp.Status)
 	}
 
-	fmt.Printf("Created new workload: %s\n", opt.Description)
+	var workload types.WorkloadResponse
+
+	err = unmarshalHTTPResponse(resp, &workload)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	fmt.Printf("Created new workload: %s\n", workload.Workload.ID)
 
 	return nil
 }

--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -17,16 +17,27 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
 
+	"github.com/01org/ciao/ciao-controller/api"
+	"github.com/01org/ciao/ciao-controller/types"
 	"github.com/01org/ciao/openstack/compute"
+	"github.com/01org/ciao/payloads"
+
+	"gopkg.in/yaml.v2"
 )
 
 var workloadCommand = &command{
 	SubCommands: map[string]subCommand{
-		"list": new(workloadListCommand),
+		"list":   new(workloadListCommand),
+		"create": new(workloadCreateCommand),
 	},
 }
 
@@ -101,5 +112,190 @@ func (cmd *workloadListCommand) run(args []string) error {
 		fmt.Printf("\tName: %s\n\tUUID:%s\n\tImage UUID: %s\n\tCPUs: %d\n\tMemory: %d MB\n",
 			flavor.Name, flavor.ID, flavor.Disk, flavor.Vcpus, flavor.RAM)
 	}
+	return nil
+}
+
+type workloadCreateCommand struct {
+	Flag     flag.FlagSet
+	yamlFile string
+}
+
+func (cmd *workloadCreateCommand) parseArgs(args []string) []string {
+	cmd.Flag.StringVar(&cmd.yamlFile, "yaml", "", "filename for yaml which describes the workload")
+	cmd.Flag.Usage = func() { cmd.usage() }
+	cmd.Flag.Parse(args)
+	return cmd.Flag.Args()
+}
+
+func (cmd *workloadCreateCommand) usage(...string) {
+	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] workload create [flags]
+
+Create a new workload
+
+The create flags are:
+
+`)
+	cmd.Flag.PrintDefaults()
+	os.Exit(2)
+}
+
+func getCiaoWorkloadsResource() (string, error) {
+	return getCiaoResource("workloads", api.WorkloadsV1)
+}
+
+type source struct {
+	Type types.SourceType `json:"service"`
+	ID   string           `json:"id"`
+}
+
+type disk struct {
+	ID         *string `yaml:"volume_id"`
+	Size       int     `yaml:"size"`
+	Bootable   bool    `yaml:"bootable"`
+	Source     *source `yaml:"source"`
+	Persistent bool    `yaml:"persistent"`
+}
+
+type defaultResources struct {
+	VCPUs  int `yaml:"vcpus"`
+	MemMB  int `yaml:"mem_mb"`
+	DiskMB int `yaml:"disk_mb"`
+}
+
+// we currently only use the first disk due to lack of support
+// in types.Workload for multiple storage resources.
+type workloadOptions struct {
+	Description     string           `yaml:"description"`
+	VMType          string           `yaml:"vm_type"`
+	FWType          string           `yaml:"fw_type"`
+	ImageName       string           `yaml:"image_name"`
+	ImageID         string           `yaml:"image_id"`
+	Defaults        defaultResources `yaml:"defaults"`
+	CloudConfigFile string           `yaml:"cloud_init"`
+	Disks           []disk           `yaml:"disks"`
+}
+
+func optToReq(opt workloadOptions, req *types.Workload) error {
+	b, err := ioutil.ReadFile(opt.CloudConfigFile)
+	if err != nil {
+		return err
+	}
+
+	config := string(b)
+
+	// this is where you'd validate that the options make
+	// sense.
+	req.Description = opt.Description
+	req.VMType = payloads.Hypervisor(opt.VMType)
+	req.FWType = opt.FWType
+	req.ImageName = opt.ImageName
+	req.ImageID = opt.ImageID
+	req.Config = config
+
+	for _, disk := range opt.Disks {
+		res := types.StorageResource{
+			Size:       disk.Size,
+			Bootable:   disk.Bootable,
+			Persistent: disk.Persistent,
+		}
+
+		if disk.ID != nil {
+			res.ID = *disk.ID
+		} else if disk.Size == 0 {
+			// source had better exist.
+			if disk.Source == nil {
+				return errors.New("Invalid workload yaml: disk source may not be nil")
+			}
+
+			res.SourceType = disk.Source.Type
+			res.SourceID = disk.Source.ID
+		} else {
+			if disk.Bootable == true {
+				// you may not request a bootable drive
+				// from an empty source
+				return errors.New("Invalid workload yaml: empty disk source may not be bootable")
+			}
+
+			res.SourceType = types.Empty
+		}
+
+		// due to the fact that types.Workload only supports
+		// one StorageResource, we have to do this for now.
+		req.Storage = &res
+		break
+	}
+
+	// all default resources are required.
+	defaults := opt.Defaults
+
+	r := payloads.RequestedResource{
+		Type:  payloads.VCPUs,
+		Value: defaults.VCPUs,
+	}
+	req.Defaults = append(req.Defaults, r)
+
+	r = payloads.RequestedResource{
+		Type:  payloads.MemMB,
+		Value: defaults.MemMB,
+	}
+	req.Defaults = append(req.Defaults, r)
+
+	r = payloads.RequestedResource{
+		Type:  payloads.DiskMB,
+		Value: defaults.DiskMB,
+	}
+	req.Defaults = append(req.Defaults, r)
+
+	return nil
+}
+
+func (cmd *workloadCreateCommand) run(args []string) error {
+	var opt workloadOptions
+	var req types.Workload
+
+	if cmd.yamlFile == "" {
+		cmd.usage()
+	}
+
+	f, err := ioutil.ReadFile(cmd.yamlFile)
+	if err != nil {
+		fatalf("Unable to read workload config file: %s\n", err)
+	}
+
+	err = yaml.Unmarshal(f, &opt)
+	if err != nil {
+		fatalf("Config file invalid: %s\n", err)
+	}
+
+	err = optToReq(opt, &req)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	body := bytes.NewReader(b)
+
+	url, err := getCiaoWorkloadsResource()
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	ver := api.WorkloadsV1
+
+	resp, err := sendCiaoRequest("POST", url, nil, body, &ver)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		fatalf("Workload creation failed: %s", resp.Status)
+	}
+
+	fmt.Printf("Created new workload: %s\n", opt.Description)
+
 	return nil
 }

--- a/ciao-controller/api/api.go
+++ b/ciao-controller/api/api.go
@@ -440,12 +440,24 @@ func addWorkload(c *Context, w http.ResponseWriter, r *http.Request) (Response, 
 		return errorResponse(err), err
 	}
 
-	err = c.CreateWorkload(req)
+	wl, err := c.CreateWorkload(req)
 	if err != nil {
 		return errorResponse(err), err
 	}
 
-	return Response{http.StatusNoContent, nil}, nil
+	ref := fmt.Sprintf("%s/workloads/%s", c.URL, wl.ID)
+
+	link := types.Link{
+		Rel:  "self",
+		Href: ref,
+	}
+
+	resp := types.WorkloadResponse{
+		Workload: wl,
+		Link:     link,
+	}
+
+	return Response{http.StatusCreated, resp}, nil
 }
 
 // Service is an interface which must be implemented by the ciao API context.
@@ -459,7 +471,7 @@ type Service interface {
 	ListMappedAddresses(tenantID *string) []types.MappedIP
 	MapAddress(poolName *string, instanceID string) error
 	UnMapAddress(ID string) error
-	CreateWorkload(req types.Workload) error
+	CreateWorkload(req types.Workload) (types.Workload, error)
 }
 
 // Context is used to provide the services and current URL to the handlers.

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -48,7 +48,7 @@ var tests = []test{
 		"",
 		"application/text",
 		http.StatusOK,
-		`[{"rel":"pools","href":"/pools","version":"x.ciao.pools.v1","minimum_version":"x.ciao.pools.v1"},{"rel":"external-ips","href":"/external-ips","version":"x.ciao.external-ips.v1","minimum_version":"x.ciao.external-ips.v1"}]`,
+		`[{"rel":"pools","href":"/pools","version":"x.ciao.pools.v1","minimum_version":"x.ciao.pools.v1"},{"rel":"external-ips","href":"/external-ips","version":"x.ciao.external-ips.v1","minimum_version":"x.ciao.external-ips.v1"},{"rel":"workloads","href":"/workloads","version":"x.ciao.workloads.v1","minimum_version":"x.ciao.workloads.v1"}]`,
 	},
 	{
 		"GET",
@@ -137,6 +137,15 @@ var tests = []test{
 		mapExternalIP,
 		`{"pool_name":"apool","instance_id":"validinstanceID"}`,
 		"application/x.ciao.v1.pools",
+		http.StatusNoContent,
+		"null",
+	},
+	{
+		"POST",
+		"/workloads",
+		addWorkload,
+		`{"id":"","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_id":"73a86d7e-93c0-480e-9c41-ab42f69b7799","image_name":"","config":"this will totally work!","defaults":[]}`,
+		"application/x.ciao.v1.workloads",
 		http.StatusNoContent,
 		"null",
 	},
@@ -242,6 +251,10 @@ func (ts testCiaoService) MapAddress(name *string, instanceID string) error {
 }
 
 func (ts testCiaoService) UnMapAddress(string) error {
+	return nil
+}
+
+func (ts testCiaoService) CreateWorkload(req types.Workload) error {
 	return nil
 }
 

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -146,8 +146,8 @@ var tests = []test{
 		addWorkload,
 		`{"id":"","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_id":"73a86d7e-93c0-480e-9c41-ab42f69b7799","image_name":"","config":"this will totally work!","defaults":[]}`,
 		"application/x.ciao.v1.workloads",
-		http.StatusNoContent,
-		"null",
+		http.StatusCreated,
+		`{"workload":{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_id":"73a86d7e-93c0-480e-9c41-ab42f69b7799","image_name":"","config":"this will totally work!","defaults":[],"storage":null},"link":{"rel":"self","href":"/workloads/ba58f471-0735-4773-9550-188e2d012941"}}`,
 	},
 }
 
@@ -254,8 +254,9 @@ func (ts testCiaoService) UnMapAddress(string) error {
 	return nil
 }
 
-func (ts testCiaoService) CreateWorkload(req types.Workload) error {
-	return nil
+func (ts testCiaoService) CreateWorkload(req types.Workload) (types.Workload, error) {
+	req.ID = "ba58f471-0735-4773-9550-188e2d012941"
+	return req, nil
 }
 
 func TestResponse(t *testing.T) {

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -304,3 +304,8 @@ func (db *MemoryDB) deleteMappedIP(ID string) error {
 func (db *MemoryDB) getMappedIPs() map[string]types.MappedIP {
 	return make(map[string]types.MappedIP)
 }
+
+func (db *MemoryDB) updateWorkload(wl workload) error {
+	db.workloads[wl.ID] = &wl
+	return nil
+}

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -15,6 +15,8 @@
 package datastore
 
 import (
+	"fmt"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -953,4 +955,87 @@ func TestSQLiteDBInstanceStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestSQLiteDBUpdateWorkload(t *testing.T) {
+	testConfig := `
+---
+#cloud-config
+users:
+  - name: demouser
+    gecos: CIAO Demo User
+    lock-passwd: false
+    passwd: $6$rounds=4096$w9I3hR4g/hu$AnYjaC2DfznbPSG3vxsgtgAS4mJwWBkcR74Y/KHNB5OsfAlA4gpU5j6CHWMOkkt9j.9d7OYJXJ4icXHzKXTAO.
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh-authorized-keys:
+    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDerQfD+qkb0V0XdQs8SBWqy4sQmqYFP96n/kI4Cq162w4UE8pTxy0ozAPldOvBJjljMvgaNKSAddknkhGcrNUvvJsUcZFm2qkafi32WyBdGFvIc45A+8O7vsxPXgHEsS9E3ylEALXAC3D0eX7pPtRiAbasLlY+VcACRqr3bPDSZTfpCmIkV2334uZD9iwOvTVeR+FjGDqsfju4DyzoAIqpPasE0+wk4Vbog7osP+qvn1gj5kQyusmr62+t0wx+bs2dF5QemksnFOswUrv9PGLhZgSMmDQrRYuvEfIAC7IdN/hfjTn0OokzljBiuWQ4WIIba/7xTYLVujJV65qH3heaSMxJJD7eH9QZs9RdbbdTXMFuJFsHV2OF6wZRp18tTNZZJMqiHZZSndC5WP1WrUo3Au/9a+ighSaOiVddHsPG07C/TOEnr3IrwU7c9yIHeeRFHmcQs9K0+n9XtrmrQxDQ9/mLkfje80Ko25VJ/QpAQPzCKh2KfQ4RD+/PxBUScx/lHIHOIhTSCh57ic629zWgk0coSQDi4MKSa5guDr3cuDvt4RihGviDM6V68ewsl0gh6Z9c0Hw7hU0vky4oxak5AiySiPz0FtsOnAzIL0UON+yMuKzrJgLjTKodwLQ0wlBXu43cD+P8VXwQYeqNSzfrhBnHqsrMf4lTLtc7kDDTcw== ciao@ciao
+...
+	`
+	cpus := payloads.RequestedResource{
+		Type:      payloads.VCPUs,
+		Value:     2,
+		Mandatory: false,
+	}
+
+	mem := payloads.RequestedResource{
+		Type:      payloads.MemMB,
+		Value:     512,
+		Mandatory: false,
+	}
+
+	disk := payloads.RequestedResource{
+		Type:      payloads.DiskMB,
+		Value:     1024,
+		Mandatory: false,
+	}
+
+	storage := types.StorageResource{
+		ID:         "",
+		Persistent: true,
+		Size:       20,
+	}
+
+	w := types.Workload{
+		ID:          uuid.Generate().String(),
+		Description: "testWorkload",
+		FWType:      string(payloads.EFI),
+		VMType:      payloads.QEMU,
+		ImageID:     uuid.Generate().String(),
+		ImageName:   "",
+		Config:      testConfig,
+		Defaults:    []payloads.RequestedResource{cpus, mem, disk},
+		Storage:     &storage,
+	}
+
+	wl := workload{
+		Workload: w,
+		filename: fmt.Sprintf("%s_config.yaml", w.ID),
+	}
+
+	db, err := getPersistentStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// file will be added, so we will want to remove it.
+	filename := fmt.Sprintf("%s/%s", *workloadsPath, wl.filename)
+	defer os.Remove(filename)
+
+	err = db.updateWorkload(wl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wl2, err := db.getWorkloadNoCache(wl.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(wl, *wl2) {
+		fmt.Fprintf(os.Stderr, "got %v\n", wl2)
+		fmt.Fprintf(os.Stderr, "expected %v\n", wl)
+		t.Fatal("Expected workload equality")
+	}
+
+	db.disconnect()
 }

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -80,6 +80,13 @@ type Workload struct {
 	Storage     *StorageResource             `json:"storage"`
 }
 
+// WorkloadResponse will be returned from /workloads apis
+// It provides details on the workload, and references for the client.
+type WorkloadResponse struct {
+	Workload Workload `json:"workload"`
+	Link     Link     `json:"link"`
+}
+
 // Instance contains information about an instance of a workload.
 type Instance struct {
 	ID          string              `json:"instance_id"`

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -43,27 +43,27 @@ const (
 // TBD: should the workload support multiple of these?
 type StorageResource struct {
 	// ID indicates a volumeID. If ID is blank, then it needs to be created.
-	ID string
+	ID string `json:"id"`
 
 	// Bootable indicates whether should the resource be used for booting
-	Bootable bool
+	Bootable bool `json:"bootable"`
 
 	// Persistent indicates whether the storage is temporary
 	// TBD: do we bother to save info about temp storage?
 	//      does it count against quota?
-	Persistent bool
+	Persistent bool `json:"persistent"`
 
 	// Size is the size of the storage to be created if new.
-	Size int
+	Size int `json:"size"`
 
 	// ImageType indicates whether we are making a new resource
 	// based on an image or existing volume.
 	// Needed only for new storage.
-	SourceType SourceType
+	SourceType SourceType `json:"source_type"`
 
 	// SourceID represents the ID of either the image or the volume
 	// that the storage resource is based on.
-	SourceID string
+	SourceID string `json:"source_id"`
 }
 
 // Workload contains resource and configuration information for a user
@@ -71,13 +71,13 @@ type StorageResource struct {
 type Workload struct {
 	ID          string                       `json:"id"`
 	Description string                       `json:"description"`
-	FWType      string                       `json:"-"`
-	VMType      payloads.Hypervisor          `json:"-"`
-	ImageID     string                       `json:"-"`
-	ImageName   string                       `json:"-"`
-	Config      string                       `json:"-"`
-	Defaults    []payloads.RequestedResource `json:"-"`
-	Storage     *StorageResource             `json:"-"`
+	FWType      string                       `json:"fw_type"`
+	VMType      payloads.Hypervisor          `json:"vm_type"`
+	ImageID     string                       `json:"image_id"`
+	ImageName   string                       `json:"image_name"`
+	Config      string                       `json:"config"`
+	Defaults    []payloads.RequestedResource `json:"defaults"`
+	Storage     *StorageResource             `json:"storage"`
 }
 
 // Instance contains information about an instance of a workload.

--- a/ciao-controller/workload.go
+++ b/ciao-controller/workload.go
@@ -116,10 +116,10 @@ func validateWorkloadRequest(req types.Workload) error {
 	return nil
 }
 
-func (c *controller) CreateWorkload(req types.Workload) error {
+func (c *controller) CreateWorkload(req types.Workload) (types.Workload, error) {
 	err := validateWorkloadRequest(req)
 	if err != nil {
-		return err
+		return req, err
 	}
 
 	// create a workload storage resource for this new workload.
@@ -128,7 +128,7 @@ func (c *controller) CreateWorkload(req types.Workload) error {
 		// uuid4.
 		_, err = uuid.Parse(req.ImageID)
 		if err != nil {
-			return err
+			return req, err
 		}
 
 		storage := types.StorageResource{
@@ -144,5 +144,6 @@ func (c *controller) CreateWorkload(req types.Workload) error {
 
 	req.ID = uuid.Generate().String()
 
-	return c.ds.AddWorkload(req)
+	err = c.ds.AddWorkload(req)
+	return req, err
 }

--- a/ciao-controller/workload.go
+++ b/ciao-controller/workload.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/01org/ciao/ciao-controller/types"
+	"github.com/01org/ciao/payloads"
+	"github.com/01org/ciao/ssntp/uuid"
+)
+
+func validateVMWorkload(req types.Workload) error {
+	// FWType must be either EFI or legacy.
+	if req.FWType != string(payloads.EFI) && req.FWType != payloads.Legacy {
+		return types.ErrBadRequest
+	}
+
+	return nil
+}
+
+func validateContainerWorkload(req types.Workload) error {
+	// we should reject anything with ImageID set, but
+	// we'll just ignore it.
+	if req.ImageName == "" {
+		return types.ErrBadRequest
+	}
+
+	return nil
+}
+
+func validateWorkloadStorage(req types.Workload) error {
+	// you may not request a sized volume unless it's empty.
+	if req.Storage.Size > 0 && req.Storage.SourceType != types.Empty {
+		return types.ErrBadRequest
+	}
+
+	// you may not request a bootable empty volume.
+	if req.Storage.Bootable && req.Storage.SourceType == types.Empty {
+		return types.ErrBadRequest
+	}
+
+	if req.Storage.ID != "" {
+		// validate that the id is at least valid
+		// uuid4.
+		_, err := uuid.Parse(req.Storage.ID)
+		if err != nil {
+			return types.ErrBadRequest
+		}
+	} else {
+		if req.Storage.SourceType == types.Empty {
+			// you many not use a source ID with empty.
+			if req.Storage.SourceID != "" {
+				return types.ErrBadRequest
+			}
+		} else {
+			// you must specify an ID with volume/image
+			if req.Storage.SourceID == "" {
+				return types.ErrBadRequest
+			}
+		}
+	}
+
+	return nil
+}
+
+// this is probably an insufficient amount of checking.
+func validateWorkloadRequest(req types.Workload) error {
+	// ID must be blank.
+	if req.ID != "" {
+		return types.ErrBadRequest
+	}
+
+	if req.VMType == payloads.QEMU {
+		err := validateVMWorkload(req)
+		if err != nil {
+			return err
+		}
+	} else {
+		err := validateContainerWorkload(req)
+		if err != nil {
+			return err
+		}
+	}
+
+	if req.ImageID != "" {
+		// validate that the image id is at least valid
+		// uuid4.
+		_, err := uuid.Parse(req.ImageID)
+		if err != nil {
+			return types.ErrBadRequest
+		}
+	}
+
+	if req.Config == "" {
+		return types.ErrBadRequest
+	}
+
+	if req.Storage != nil {
+		err := validateWorkloadStorage(req)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *controller) CreateWorkload(req types.Workload) error {
+	err := validateWorkloadRequest(req)
+	if err != nil {
+		return err
+	}
+
+	// create a workload storage resource for this new workload.
+	if req.ImageID != "" {
+		// validate that the image id is at least valid
+		// uuid4.
+		_, err = uuid.Parse(req.ImageID)
+		if err != nil {
+			return err
+		}
+
+		storage := types.StorageResource{
+			Bootable:   true,
+			Persistent: false,
+			SourceType: types.ImageService,
+			SourceID:   req.ImageID,
+		}
+
+		req.ImageID = ""
+		req.Storage = &storage
+	}
+
+	req.ID = uuid.Generate().String()
+
+	return c.ds.AddWorkload(req)
+}


### PR DESCRIPTION
This set of commits adds support for creating custom workloads in ciao. At the moment because there is no tenant separation for workloads, **this command must be run with admin privileges**. 

There was a lot of complexity around creating the workloads, so I felt it was much simpler to have the user create a text file which describes it and then import that text into cli. I included some examples for workloads in a new directory in cli called "examples". I will add support for specifying entirely on the ciao-cli command line (with the exception of the cloud-config.yaml) in a follow on PR.

A README was included in the examples subdirectory to describe the format required for the workload
definition yaml files.

Fixes: #931 
Fixes: #932 
