### PR TITLE
Single VM : Exit on cleanup

### DIFF
--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -102,6 +102,7 @@ trap ctrl_c INT
 function ctrl_c() {
     echo "Trapped CTRL-C, performing cleanup"
     cleanup
+    exit 1
 }
 
 usage="$(basename "$0") [--download] The script will download dependencies if needed. Specifying --download will force download the dependencies even if they are cached locally"


### PR DESCRIPTION
setup.sh was cleaning up but not exiting after the user had pressed CTRL-C,
which created a weird situation in which setup.sh would pause the ciao
bring up, delete all the work it had done, and then resume the bring up from
an inconsistent state.

Fixes #953

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>