### PR TITLE
Populate the image size based off of ceph

### DIFF
--- a/_release/bat/storage_bat/ceph_test.go
+++ b/_release/bat/storage_bat/ceph_test.go
@@ -48,6 +48,31 @@ func TestCreateBlockDevice(t *testing.T) {
 	}
 }
 
+// Test creating a sized ceph backed block device.
+//
+// TestCreateSizedBlockDevice creates a block device of a fixed size, checking
+// for errors and then checks that the size is a expected.
+func TestCreateSizedBlockDevice(t *testing.T) {
+	device, err := driver.CreateBlockDevice("", "", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blockSize, err := driver.GetBlockDeviceSize(device.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if blockSize != 1*1024*1024*1024 {
+		t.Fatalf("Unexpected block size (%v): expected: %v got: %v", device.ID, 1*1024*1024*1024, blockSize)
+	}
+
+	err = driver.DeleteBlockDevice(device.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // Check copying a ceph backed block device works
 //
 // TestCopyBlockDevice creates a block device containing some random data,

--- a/ciao-controller/openstack_image.go
+++ b/ciao-controller/openstack_image.go
@@ -76,6 +76,7 @@ func (is ImageService) CreateImage(req image.CreateImageRequest) (image.DefaultR
 	}
 
 	glog.Infof("Image %v created", id)
+	size := int(i.Size)
 	return image.DefaultResponse{
 		Status:     image.Queued,
 		CreatedAt:  i.CreateTime,
@@ -89,10 +90,12 @@ func (is ImageService) CreateImage(req image.CreateImageRequest) (image.DefaultR
 		File:       fmt.Sprintf("/v2/images/%s/file", i.ID),
 		Schema:     "/v2/schemas/image",
 		Name:       &i.Name,
+		Size:       &size,
 	}, nil
 }
 
 func createImageResponse(img imageDatastore.Image) (image.DefaultResponse, error) {
+	size := int(img.Size)
 	return image.DefaultResponse{
 		Status:     img.State.Status(),
 		CreatedAt:  img.CreateTime,
@@ -106,6 +109,7 @@ func createImageResponse(img imageDatastore.Image) (image.DefaultResponse, error
 		File:       fmt.Sprintf("/v2/images/%s/file", img.ID),
 		Schema:     "/v2/schemas/image",
 		Name:       &img.Name,
+		Size:       &size,
 	}, nil
 }
 

--- a/ciao-image/datastore/ceph.go
+++ b/ciao-image/datastore/ceph.go
@@ -78,3 +78,12 @@ func (c *Ceph) Delete(ID string) error {
 	}
 	return nil
 }
+
+// GetImageSize returns the size, in bytes, of the block device
+func (c *Ceph) GetImageSize(ID string) (uint64, error) {
+	imageSize, err := c.BlockDriver.GetBlockDeviceSize(ID)
+	if err != nil {
+		return 0, fmt.Errorf("Error getting image size: %v", err)
+	}
+	return imageSize, nil
+}

--- a/ciao-image/datastore/datastore.go
+++ b/ciao-image/datastore/datastore.go
@@ -84,6 +84,7 @@ type Image struct {
 	Name       string
 	CreateTime time.Time
 	Type       Type
+	Size       uint64
 }
 
 // DataStore is the image data storage interface.
@@ -111,4 +112,5 @@ type MetaDataStore interface {
 type RawDataStore interface {
 	Write(ID string, body io.Reader) error
 	Delete(ID string) error
+	GetImageSize(ID string) (uint64, error)
 }

--- a/ciao-image/datastore/noop.go
+++ b/ciao-image/datastore/noop.go
@@ -32,6 +32,11 @@ func (n *Noop) Delete(id string) error {
 	return nil
 }
 
+// GetImageSize is the noop image implementation of image size querying
+func (n *Noop) GetImageSize(ID string) (uint64, error) {
+	return 0, nil
+}
+
 // Get is the noop image metadata get an image implementation.
 // It drops data.
 func (n *Noop) Get(id string) (Image, error) {

--- a/ciao-image/datastore/posix.go
+++ b/ciao-image/datastore/posix.go
@@ -67,3 +67,15 @@ func (p *Posix) Delete(ID string) error {
 
 	return err
 }
+
+// GetImageSize obtains the image size from the underlying filesystem
+func (p *Posix) GetImageSize(ID string) (uint64, error) {
+	imageName := path.Join(p.MountPoint, ID)
+
+	fi, err := os.Stat(imageName)
+	imageSize := uint64(fi.Size())
+	if err != nil {
+		return 0, fmt.Errorf("Error getting image size: %v", err)
+	}
+	return imageSize, nil
+}

--- a/ciao-image/datastore/store.go
+++ b/ciao-image/datastore/store.go
@@ -176,6 +176,12 @@ func (s *ImageStore) UploadImage(ID string, body io.Reader) error {
 		if err != nil {
 			img.State = Killed
 		}
+
+		img.Size, err = s.rawDs.GetImageSize(ID)
+		if err != nil {
+			img.State = Killed
+			return err
+		}
 	}
 
 	if err == nil {

--- a/ciao-launcher/docker_test.go
+++ b/ciao-launcher/docker_test.go
@@ -91,6 +91,10 @@ func (s dockerTestStorage) CopyBlockDevice(volumeUUID string) (storage.BlockDevi
 	return storage.BlockDevice{}, nil
 }
 
+func (s dockerTestStorage) GetBlockDeviceSize(volumeUUID string) (uint64, error) {
+	return 0, nil
+}
+
 // Checks that the logic of the code that mounts and unmounts ceph volumes in
 // docker containers.
 //

--- a/ciao-storage/block.go
+++ b/ciao-storage/block.go
@@ -34,6 +34,7 @@ type BlockDriver interface {
 	UnmapVolumeFromNode(volumeUUID string) error
 	GetVolumeMapping() (map[string][]string, error)
 	CopyBlockDevice(string) (BlockDevice, error)
+	GetBlockDeviceSize(volumeUUID string) (uint64, error)
 }
 
 // BlockDevice contains information about a block devices.

--- a/ciao-storage/noop.go
+++ b/ciao-storage/noop.go
@@ -56,6 +56,11 @@ func (d *NoopDriver) DeleteBlockDeviceSnapshot(volumeUUID string, snapshotID str
 	return nil
 }
 
+// GetBlockDeviceSize pretends to return the number of bytes used by the block device
+func (d *NoopDriver) GetBlockDeviceSize(volumeUUID string) (uint64, error) {
+	return 0, nil
+}
+
 // MapVolumeToNode pretends to map a volume to a local device on a node.
 func (d *NoopDriver) MapVolumeToNode(volumeUUID string) (string, error) {
 	dNum := atomic.AddInt64(&d.deviceNum, 1)


### PR DESCRIPTION
Query the image size from rbd and populate that into the datastore. From the datastore populate the openstack image API datastructures.

Fixes: #959 
