### PR TITLE
Fix glog dependencies

### DIFF
--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -38,6 +38,7 @@ import (
 	image "github.com/01org/ciao/ciao-image/client"
 	storage "github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/clogger/gloginterface"
+	"github.com/01org/ciao/database"
 	"github.com/01org/ciao/openstack/block"
 	"github.com/01org/ciao/openstack/compute"
 	osIdentity "github.com/01org/ciao/openstack/identity"
@@ -157,6 +158,8 @@ func main() {
 	if *cephID == "" {
 		*cephID = clusterConfig.Configure.Storage.CephID
 	}
+
+	database.Logger = gloginterface.CiaoGlogLogger{}
 
 	logger := gloginterface.CiaoGlogLogger{}
 	osprepare.Bootstrap(context.TODO(), logger)

--- a/ciao-image/datastore/store.go
+++ b/ciao-image/datastore/store.go
@@ -19,6 +19,8 @@ import (
 	"io"
 	"sync"
 
+	"github.com/01org/ciao/clogger/gloginterface"
+	"github.com/01org/ciao/database"
 	"github.com/01org/ciao/openstack/image"
 )
 
@@ -68,6 +70,8 @@ type ImageStore struct {
 func (s *ImageStore) Init(rawDs RawDataStore, metaDs MetaDataStore) error {
 	s.metaDs = metaDs
 	s.rawDs = rawDs
+
+	database.Logger = gloginterface.CiaoGlogLogger{}
 
 	return nil
 }

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/01org/ciao/clogger/gloginterface"
+	"github.com/01org/ciao/networking/libsnnet"
 	"github.com/01org/ciao/osprepare"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp"
@@ -630,6 +631,8 @@ func main() {
 	if simulate == false && getLock() != nil {
 		os.Exit(1)
 	}
+
+	libsnnet.Logger = gloginterface.CiaoGlogLogger{}
 
 	if err := initLogger(); err != nil {
 		log.Fatalf("Unable to initialise logs: %v", err)

--- a/database/boltdb.go
+++ b/database/boltdb.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/boltdb/bolt"
-	"github.com/golang/glog"
 )
 
 // BoltDB database structure
@@ -92,7 +91,7 @@ func (db *BoltDB) DbTableRebuild(table DbTable) error {
 			if err := gob.NewDecoder(vr).Decode(val); err != nil {
 				return fmt.Errorf("Decode Error: %v %v %v", string(k), string(v), err)
 			}
-			glog.Infof("%v key=%v, value=%v\n", table, string(k), val)
+			Logger.Infof("%v key=%v, value=%v\n", table, string(k), val)
 
 			return table.Add(string(k), val)
 		})
@@ -104,9 +103,9 @@ func (db *BoltDB) DbTableRebuild(table DbTable) error {
 // DbTablesInit initializes list of tables in Bolt
 func (db *BoltDB) DbTablesInit(tables []string) (err error) {
 
-	glog.Info("dbInit Tables")
+	Logger.Infof("dbInit Tables")
 	for i, table := range tables {
-		glog.Infof("table[%v] := %v, %v", i, table, []byte(table))
+		Logger.Infof("table[%v] := %v, %v", i, table, []byte(table))
 	}
 
 	err = db.DB.Update(func(tx *bolt.Tx) error {
@@ -120,7 +119,7 @@ func (db *BoltDB) DbTablesInit(tables []string) (err error) {
 	})
 
 	if err != nil {
-		glog.Errorf("Table creation error %v", err)
+		Logger.Errorf("Table creation error %v", err)
 	}
 
 	return err
@@ -133,7 +132,7 @@ func (db *BoltDB) DbAdd(table string, key string, value interface{}) (err error)
 		var v bytes.Buffer
 
 		if err := gob.NewEncoder(&v).Encode(value); err != nil {
-			glog.Errorf("Encode Error: %v %v", err, value)
+			Logger.Errorf("Encode Error: %v %v", err, value)
 			return err
 		}
 

--- a/database/logger.go
+++ b/database/logger.go
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package database
+
+import (
+	"github.com/01org/ciao/clogger"
+)
+
+// Logger is a global variable exported to be set by the package importing
+// database package, in order to let it decide which logger it wants to use.
+var Logger = clogger.CiaoLog(clogger.CiaoNullLogger{})

--- a/networking/ciao-cnci-agent/client.go
+++ b/networking/ciao-cnci-agent/client.go
@@ -32,6 +32,8 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/01org/ciao/clogger/gloginterface"
+	"github.com/01org/ciao/networking/libsnnet"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp"
 
@@ -425,6 +427,8 @@ func main() {
 	}
 
 	flag.Parse()
+
+	libsnnet.Logger = gloginterface.CiaoGlogLogger{}
 
 	if err := initLogger(); err != nil {
 		log.Fatalf("Unable to initialise logs: %v", err)

--- a/networking/libsnnet/docker_plugin.go
+++ b/networking/libsnnet/docker_plugin.go
@@ -745,6 +745,8 @@ func DockerHandler(d *DockerPlugin,
 
 //NewDockerPlugin instantiates a new Docker Plugin instance
 func NewDockerPlugin() *DockerPlugin {
+	database.Logger = Logger
+
 	return &DockerPlugin{
 		DbProvider: database.NewBoltDBProvider(),
 	}

--- a/networking/libsnnet/docker_plugin.go
+++ b/networking/libsnnet/docker_plugin.go
@@ -33,7 +33,6 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/docker/libnetwork/drivers/remote/api"
 	ipamapi "github.com/docker/libnetwork/ipams/remote/api"
-	"github.com/golang/glog"
 	"github.com/gorilla/mux"
 )
 
@@ -237,14 +236,14 @@ type DockerPlugin struct {
 
 func sendResponse(resp interface{}, w http.ResponseWriter) {
 	rb, err := json.Marshal(resp)
-	glog.Infof("Sending response := %v, %v", resp, err)
+	Logger.Infof("Sending response := %v, %v", resp, err)
 	fmt.Fprintf(w, "%s", rb)
 	return
 }
 
 func getBody(r *http.Request) ([]byte, error) {
 	body, err := ioutil.ReadAll(r.Body)
-	glog.Infof("URL [%s] Body [%s] Error [%v]", r.URL.Path[1:], string(body), err)
+	Logger.Infof("URL [%s] Body [%s] Error [%v]", r.URL.Path[1:], string(body), err)
 	return body, err
 }
 
@@ -313,7 +312,7 @@ func handlerCreateNetwork(d *DockerPlugin, w http.ResponseWriter, r *http.Reques
 	}
 
 	if err := d.DbAdd(tableNetworkMap, req.NetworkID, d.DockerNwMap.m[req.NetworkID]); err != nil {
-		glog.Errorf("Unable to update db %v", err)
+		Logger.Errorf("Unable to update db %v", err)
 	}
 
 	sendResponse(resp, w)
@@ -336,7 +335,7 @@ func handlerDeleteNetwork(d *DockerPlugin, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	glog.Infof("Delete Network := %v", req.NetworkID)
+	Logger.Infof("Delete Network := %v", req.NetworkID)
 
 	/* Actual network delete would have already been done in ciao
 	   Remove the UUID to bridge mapping in cache and in the
@@ -346,7 +345,7 @@ func handlerDeleteNetwork(d *DockerPlugin, w http.ResponseWriter, r *http.Reques
 	bridge := d.DockerNwMap.m[req.NetworkID].Bridge
 	delete(d.DockerNwMap.m, req.NetworkID)
 	if err := d.DbDelete(tableNetworkMap, req.NetworkID); err != nil {
-		glog.Errorf("Unable to update db %v %v", bridge, err)
+		Logger.Errorf("Unable to update db %v %v", bridge, err)
 	}
 	d.DockerNwMap.Unlock()
 
@@ -449,7 +448,7 @@ func handlerCreateEndpoint(d *DockerPlugin, w http.ResponseWriter, r *http.Reque
 	}
 
 	if err := d.DbAdd(tableEndPointMap, req.EndpointID, d.DockerEpMap.m[req.EndpointID]); err != nil {
-		glog.Errorf("Unable to update db %v", err)
+		Logger.Errorf("Unable to update db %v", err)
 	}
 
 	sendResponse(resp, w)
@@ -476,7 +475,7 @@ func handlerDeleteEndpoint(d *DockerPlugin, w http.ResponseWriter, r *http.Reque
 	//ID := d.DockerEpMap.m[req.EndpointID].ID
 	delete(d.DockerEpMap.m, req.EndpointID)
 	if err := d.DbDelete(tableEndPointMap, req.EndpointID); err != nil {
-		glog.Errorf("Unable to update db %v", err)
+		Logger.Errorf("Unable to update db %v", err)
 	}
 	d.DockerEpMap.Unlock()
 
@@ -487,9 +486,9 @@ func handlerDeleteEndpoint(d *DockerPlugin, w http.ResponseWriter, r *http.Reque
 		vnic, err := NewContainerVnic(ID)
 		if err != nil {
 			if err := vnic.GetDevice(); err != nil {
-				glog.Errorf("Link has not been deleted %v", err)
+				Logger.Errorf("Link has not been deleted %v", err)
 				if err := vnic.Destroy(); err != nil {
-					glog.Errorf("Unable to delete link %v", err)
+					Logger.Errorf("Unable to delete link %v", err)
 				}
 			}
 		}
@@ -842,10 +841,10 @@ func (d *DockerPlugin) Start() error {
 
 	d.wg.Add(1)
 	go func() {
-		glog.Infof("Starting HTTP Server")
+		Logger.Infof("Starting HTTP Server")
 		err := d.Server.Serve(d.listener)
 		if err != nil {
-			glog.Errorf("Unable to start HTTP Server [%v]", err)
+			Logger.Errorf("Unable to start HTTP Server [%v]", err)
 		}
 		d.wg.Done()
 	}()
@@ -863,7 +862,7 @@ func (d *DockerPlugin) Stop() error {
 		return fmt.Errorf("Unable to shutdown http server: %v", err)
 	}
 	d.wg.Wait()
-	glog.Info("Docker plugin has shut down")
+	Logger.Infof("Docker plugin has shut down")
 	return nil
 }
 

--- a/networking/libsnnet/logger.go
+++ b/networking/libsnnet/logger.go
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package libsnnet
+
+import (
+	"github.com/01org/ciao/clogger"
+)
+
+// Logger is a global variable exported to be set by the package importing
+// libsnnet package, in order to let it decide which logger it wants to use.
+var Logger = clogger.CiaoLog(clogger.CiaoNullLogger{})

--- a/networking/libsnnet/tests/cncicli/cncicli.go
+++ b/networking/libsnnet/tests/cncicli/cncicli.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 
+	"github.com/01org/ciao/clogger/gloginterface"
 	"github.com/01org/ciao/networking/libsnnet"
 )
 
@@ -67,6 +68,8 @@ func main() {
 	cnciIDIn := flag.String("cnciuuid", "cnciuuid", "CNCI UUID")
 
 	flag.Parse()
+
+	libsnnet.Logger = gloginterface.CiaoGlogLogger{}
 
 	cnci := &libsnnet.Cnci{
 		ID: *cnciIDIn,

--- a/networking/libsnnet/tests/cncli/cncli.go
+++ b/networking/libsnnet/tests/cncli/cncli.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 
+	"github.com/01org/ciao/clogger/gloginterface"
 	"github.com/01org/ciao/networking/libsnnet"
 )
 
@@ -120,6 +121,8 @@ func main() {
 	cnIDIn := flag.String("cnuuid", "cnuuid", "CN UUID")
 
 	flag.Parse()
+
+	libsnnet.Logger = gloginterface.CiaoGlogLogger{}
 
 	cn, err := initCn(*nwIn, *cnIDIn)
 	if err != nil {

--- a/networking/libsnnet/tests/docker/plugin/plugin.go
+++ b/networking/libsnnet/tests/docker/plugin/plugin.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/01org/ciao/clogger/gloginterface"
 	"github.com/01org/ciao/networking/libsnnet"
 	"github.com/01org/ciao/ssntp/uuid"
 	"github.com/boltdb/bolt"
@@ -789,6 +790,8 @@ func initDb() error {
 
 func main() {
 	flag.Parse()
+
+	libsnnet.Logger = gloginterface.CiaoGlogLogger{}
 
 	if err := initDb(); err != nil {
 		libsnnet.Logger.Errorf("db init failed, quitting [%v]", err)

--- a/networking/libsnnet/tests/parallel/parallel_test.go
+++ b/networking/libsnnet/tests/parallel/parallel_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/01org/ciao/clogger/gloginterface"
 	"github.com/01org/ciao/networking/libsnnet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -545,4 +546,10 @@ func TestDockerNetNone_Serial(t *testing.T) {
 //Test is expected to pass
 func TestDockerNetDocker_Serial(t *testing.T) {
 	DockerSerial(netDockerDefault, t)
+}
+
+func TestMain(m *testing.M) {
+	libsnnet.Logger = gloginterface.CiaoGlogLogger{}
+
+	os.Exit(m.Run())
 }


### PR DESCRIPTION
glog is a very useful library used by many projects. Because libsnnet package (and database implicitly) is intended to be used from external packages, we cannot rely on a vendored version of glog. This PR allows the calling package define its own clogger, and pass it to imported packages. In case nothing is defined, nothing will be printed because the default implementation of clogger is CiaoNullLogger, generating nothing.