### PR TITLE
ciao-cli: Validate image file exists when adding a new image.

### DIFF
--- a/ciao-cli/image.go
+++ b/ciao-cli/image.go
@@ -97,6 +97,11 @@ func (cmd *imageAddCommand) run(args []string) error {
 		return errors.New("Missing required -file parameter")
 	}
 
+	_, err := os.Stat(cmd.file)
+	if err != nil {
+		fatalf("Could not open %s [%s]\n", cmd.file, err)
+	}
+
 	client, err := imageServiceClient(*identityUser, *identityPassword, *tenantID)
 	if err != nil {
 		fatalf("Could not get Image service client [%s]\n", err)


### PR DESCRIPTION
Add an image validation in the imageAddCommand function.
If the image/path does not exists it will exit right after, preventing
image creation in the image service.

Fixes https://github.com/01org/ciao/issues/874
