### PR TITLE
SingleVM: Use templates to get SSH IP

### DIFF
--- a/testutil/singlevm/verify.sh
+++ b/testutil/singlevm/verify.sh
@@ -195,7 +195,8 @@ container_2=`sudo docker ps -q -l`
 retry=0
 until [ $retry -ge 6 ]
 do
-	ssh_ip=$("$ciao_gobin"/ciao-cli instance list --workload=e35ed972-c46c-4aad-a1e7-ef103ae079a2 --detail |  grep "SSH IP:" | sed 's/^.*SSH IP: //' | head -1)
+	ssh_ip=""
+	ssh_ip=$("$ciao_gobin"/ciao-cli instance list --workload=e35ed972-c46c-4aad-a1e7-ef103ae079a2 -f='{{if gt (len .) 0}}{{(index . 0).SSHIP}}{{end}}')
 
 	if [ "$ssh_ip" == "" ] 
 	then


### PR DESCRIPTION
Use templates to retrieve the SSH IP vs bash command pipeline. This enables more efficient execution.
This change moves all of verify.sh to use templates in all places where it is possible to do so.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>