### PR TITLE
networking: libsnnet: Make API more explicit and get existing VNIC device by name

### DIFF
--- a/networking/libsnnet/vnic.go
+++ b/networking/libsnnet/vnic.go
@@ -17,6 +17,7 @@
 package libsnnet
 
 import (
+	"fmt"
 	"net"
 	"strings"
 	"syscall"
@@ -69,10 +70,12 @@ func (v *Vnic) PeerName() string {
 	if strings.HasPrefix(v.LinkName, prefixVnicHost) {
 		return strings.Replace(v.LinkName, prefixVnicHost, prefixVnicCont, 1)
 	}
+
 	if strings.HasPrefix(v.LinkName, prefixVnicCont) {
 		return strings.Replace(v.LinkName, prefixVnicCont, prefixVnicHost, 1)
 	}
-	return ""
+
+	return fmt.Sprintf("%s_peer", v.LinkName)
 }
 
 // GetDevice is used to associate with an existing VNIC provided it satisfies
@@ -387,14 +390,8 @@ func (v *Vnic) SetHardwareAddr(addr net.HardwareAddr) error {
 		/* Set by QEMU. */
 	case TenantContainer:
 		/* Need to set the MAC on the container side */
-		peerVeth := &netlink.Veth{
-			LinkAttrs: netlink.LinkAttrs{
-				Name: v.PeerName(),
-			},
-			PeerName: v.LinkName,
-		}
-		if err := netlink.LinkSetHardwareAddr(peerVeth, addr); err != nil {
-			return netError(v, "link set peer mtu %v", err)
+		if err := netlink.LinkSetHardwareAddr(v.Link, addr); err != nil {
+			return netError(v, "link set hardware addr %v", err)
 		}
 	}
 

--- a/networking/libsnnet/vnic_test.go
+++ b/networking/libsnnet/vnic_test.go
@@ -184,6 +184,52 @@ func TestVnicContainer_GetDevice(t *testing.T) {
 	performVnicOps(true, assert, vnic)
 }
 
+//Test ability to attach to an existing VNIC
+//
+//Tests the ability to attach to an existing
+//VNIC and perform all VNIC operations on it
+//
+//Test is expected to pass
+func TestVnic_GetDeviceByName(t *testing.T) {
+	assert := assert.New(t)
+	vnic1, _ := NewVnic("testvnic")
+	vnic1.LinkName = "testiface"
+
+	assert.Nil(vnic1.Create())
+	vnic, _ := NewVnic("testvnic")
+
+	assert.Nil(vnic.GetDeviceByName("testiface"))
+	assert.NotEqual(vnic.InterfaceName(), "")
+	assert.Equal(vnic.InterfaceName(), vnic1.InterfaceName())
+	assert.NotEqual(vnic1.PeerName(), "")
+	assert.Equal(vnic1.PeerName(), vnic.PeerName())
+
+	performVnicOps(true, assert, vnic)
+}
+
+//Test ability to attach to an existing Container VNIC
+//
+//Tests the ability to attach to an existing
+//VNIC and perform all VNIC operations on it
+//
+//Test is expected to pass
+func TestVnicContainer_GetDeviceByName(t *testing.T) {
+	assert := assert.New(t)
+
+	vnic1, err := NewContainerVnic("testvnic")
+	assert.Nil(err)
+	vnic1.LinkName = "testiface"
+
+	err = vnic1.Create()
+	assert.Nil(err)
+
+	vnic, err := NewContainerVnic("testvnic")
+	assert.Nil(err)
+
+	assert.Nil(vnic.GetDeviceByName("testiface"))
+	performVnicOps(true, assert, vnic)
+}
+
 //Tests VNIC attach to a bridge
 //
 //Tests all interactions between VNIC and Bridge


### PR DESCRIPTION
libsnnet API lets us get an existing VNIC device only from its alias. Because this
API is used externally by other project such as virtcontainers, there are cases where
no alias is set for an existing interface, and we want to be able to retrieve a VNIC
object from this existing interface.

This PR duplicates the existing GetDevice() to provide a new GetDeviceByName, relying
on netlink LinkByName function. It builds a VNIC object according to the information found
for the related link name.

The API SetHardwareAddr() was implicitely creating a Vnic peer related
to the current Vnic, and it was setting the hardware address for this peer.
It was a very specific case for Ciao but we want more explicit things now
that libsnnet is used externally from other projects.

This PR simplifies SetHardwareAddr() function and adds the complexity
in the Ciao's calling code instead.

Also, it returns a default peer name in case the link name does not fit the
expected prefixes. It is needed because in case you set manually the link
name, you will get a creation error. Indeed, the peer name will be "", and
it will be impossible to create a link with that name.
