### PR TITLE
Add some more unit tests for launcher

### DIFF
--- a/ciao-launcher/image.go
+++ b/ciao-launcher/image.go
@@ -37,6 +37,10 @@ func init() {
 	imagesMap.images = make(map[string]*imageStats)
 }
 
+type imageInspector interface {
+	imageInfo(imagePath string) (int, error)
+}
+
 // Originally this was supposed to be a generic
 // feature which could be used by any virtualisation technology.  However, since
 // we currently only support QEMU and docker and docker doesn't have a way to
@@ -44,7 +48,7 @@ func init() {
 // qemu parameter.  In the future we might add imageInfo back to the virtualiser
 // interface.
 
-func getMinImageSize(vm *qemuV, imagePath string) (minSizeMB int, err error) {
+func getMinImageSize(vm imageInspector, imagePath string) (minSizeMB int, err error) {
 	imagesMap.Lock()
 	info := imagesMap.images[imagePath]
 	if info == nil {

--- a/ciao-launcher/image_test.go
+++ b/ciao-launcher/image_test.go
@@ -33,6 +33,16 @@ func (i *inspector) imageInfo(imagePath string) (int, error) {
 	return 10, nil
 }
 
+// Test GetMinImageSize function
+//
+// Call getMinImageSize 10 times in parallel with the same path.  Call again
+// with the same old path but setting an error.  Call getMinSize 1 more time
+// with the error set but with a new path.
+//
+// The first 10 calls should succeed.  The 11th call with the error set should
+// also succeed as the size for the path is already cached.  The final function
+// call should fail as we have arranged for imageInfo to return an error and
+// we are calling getMinImageSize on a new path.
 func TestGetMinImageSize(t *testing.T) {
 	in := &inspector{}
 	var wg sync.WaitGroup

--- a/ciao-launcher/image_test.go
+++ b/ciao-launcher/image_test.go
@@ -1,0 +1,62 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+type inspector struct {
+	err error
+}
+
+func (i *inspector) imageInfo(imagePath string) (int, error) {
+	if i.err != nil {
+		return 0, i.err
+	}
+	return 10, nil
+}
+
+func TestGetMinImageSize(t *testing.T) {
+	in := &inspector{}
+	var wg sync.WaitGroup
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			size, err := getMinImageSize(in, "")
+			if err != nil || size != 10 {
+				t.Errorf("Unexpected return value from getMinImageSize")
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	in.err = fmt.Errorf("Can't read image")
+	size, err := getMinImageSize(in, "")
+	if err != nil || size != 10 {
+		t.Errorf("Unexpected return value from getMinImageSize")
+	}
+
+	_, err = getMinImageSize(in, "/new/path")
+	if err == nil {
+		t.Errorf("Error expected from getMinImageSize")
+	}
+
+}

--- a/ciao-launcher/instance.go
+++ b/ciao-launcher/instance.go
@@ -411,7 +411,8 @@ DONE:
 }
 
 func startInstanceWithVM(instance string, cfg *vmConfig, wg *sync.WaitGroup, doneCh chan struct{},
-	ac *agentClient, ovsCh chan<- interface{}, vm virtualizer, storageDriver storage.BlockDriver) chan<- interface{} {
+	ac *agentClient, ovsCh chan<- interface{}, vm virtualizer, storageDriver storage.BlockDriver,
+	instancesDir string) chan<- interface{} {
 	id := &instanceData{
 		cmdCh:         make(chan interface{}),
 		instance:      instance,
@@ -445,5 +446,6 @@ func startInstance(instance string, cfg *vmConfig, wg *sync.WaitGroup, doneCh ch
 	} else {
 		vm = &qemuV{}
 	}
-	return startInstanceWithVM(instance, cfg, wg, doneCh, ac, ovsCh, vm, storageDriver)
+	return startInstanceWithVM(instance, cfg, wg, doneCh, ac, ovsCh, vm, storageDriver,
+		instancesDir)
 }

--- a/ciao-launcher/payload_test.go
+++ b/ciao-launcher/payload_test.go
@@ -17,11 +17,151 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/01org/ciao/networking/libsnnet"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/testutil"
 )
+
+var startTests = []struct {
+	payload string
+	config  *vmConfig
+}{
+	{
+		`
+start:
+  requested_resources:
+     - type: vcpus
+       value: 2
+     - type: mem_mb
+       value: 370
+     - type: disk_mb
+       value: 8000
+  instance_uuid: d7d86208-b46c-4465-9018-ee14087d415f
+  tenant_uuid: 67d86208-000-4465-9018-fe14087d415f
+  fw_type: legacy
+  vm_type: qemu
+  networking:
+    vnic_mac: 02:00:e6:f5:af:f9
+    vnic_uuid: 67d86208-b46c-0000-9018-fe14087d415f
+    concentrator_ip: 192.168.42.21
+    concentrator_uuid: 67d86208-b46c-4465-0000-fe14087d415f
+    subnet: 192.168.8.0/21
+    private_ip: 192.168.8.2
+  storage:
+    id: 69e84267-ed01-4738-b15f-b47de06b62e7
+    boot: true
+`,
+		&vmConfig{
+			Cpus:       2,
+			Mem:        370,
+			Disk:       8000,
+			Instance:   "d7d86208-b46c-4465-9018-ee14087d415f",
+			Legacy:     true,
+			VnicMAC:    "02:00:e6:f5:af:f9",
+			VnicIP:     "192.168.8.2",
+			ConcIP:     "192.168.42.21",
+			SubnetIP:   "192.168.8.0/21",
+			TenantUUID: "67d86208-000-4465-9018-fe14087d415f",
+			ConcUUID:   "67d86208-b46c-4465-0000-fe14087d415f",
+			VnicUUID:   "67d86208-b46c-0000-9018-fe14087d415f",
+			SSHPort:    35050,
+			Volumes: []volumeConfig{
+				{
+					"69e84267-ed01-4738-b15f-b47de06b62e7",
+					true,
+				},
+			},
+		},
+	},
+	{
+		"start",
+		nil,
+	},
+	{
+		`
+start:
+  requested_resources:
+     - type: vcpus
+       value: 2
+     - type: mem_mb
+       value: 370
+     - type: disk_mb
+       value: 8000
+  instance_uuid: imnotvalid
+  tenant_uuid: 67d86208-000-4465-9018-fe14087d415f
+  fw_type: legacy
+  networking:
+    vnic_mac: 02:00:e6:f5:af:f9
+    vnic_uuid: 67d86208-b46c-0000-9018-fe14087d415f
+    concentrator_ip: 192.168.42.21
+    concentrator_uuid: 67d86208-b46c-4465-0000-fe14087d415f
+    subnet: 192.168.8.0/21
+    private_ip: 192.168.8.2
+  storage:
+    id: 69e84267-ed01-4738-b15f-b47de06b62e7
+    boot: true
+`,
+		nil,
+	},
+	{
+		`
+start:
+  requested_resources:
+     - type: vcpus
+       value: 2
+     - type: mem_mb
+       value: 370
+     - type: disk_mb
+       value: 8000
+  instance_uuid: d7d86208-b46c-4465-9018-ee14087d415f
+  tenant_uuid: 67d86208-000-4465-9018-fe14087d415f
+  fw_type: imnotvalid
+  networking:
+    vnic_mac: 02:00:e6:f5:af:f9
+    vnic_uuid: 67d86208-b46c-0000-9018-fe14087d415f
+    concentrator_ip: 192.168.42.21
+    concentrator_uuid: 67d86208-b46c-4465-0000-fe14087d415f
+    subnet: 192.168.8.0/21
+    private_ip: 192.168.8.2
+  storage:
+    id: 69e84267-ed01-4738-b15f-b47de06b62e7
+    boot: true
+`,
+		nil,
+	},
+	{
+		`
+start:
+  requested_resources:
+     - type: vcpus
+       value: 2
+     - type: mem_mb
+       value: 370
+     - type: disk_mb
+       value: 8000
+  instance_uuid: d7d86208-b46c-4465-9018-ee14087d415f
+  vm_type: askajajlsj
+  tenant_uuid: 67d86208-000-4465-9018-fe14087d415f
+  fw_type: legacy
+  networking:
+    vnic_mac: 02:00:e6:f5:af:f9
+    vnic_uuid: 67d86208-b46c-0000-9018-fe14087d415f
+    concentrator_ip: 192.168.42.21
+    concentrator_uuid: 67d86208-b46c-4465-0000-fe14087d415f
+    subnet: 192.168.8.0/21
+    private_ip: 192.168.8.2
+  storage:
+    id: 69e84267-ed01-4738-b15f-b47de06b62e7
+    boot: true
+`,
+		nil,
+	},
+}
 
 func TestParseAttachVolumePayload(t *testing.T) {
 	instance, volume, err := parseAttachVolumePayload([]byte(testutil.AttachVolumeYaml))
@@ -60,5 +200,114 @@ func TestParseDetachVolumePayload(t *testing.T) {
 	_, _, err = parseDetachVolumePayload([]byte(testutil.BadDetachVolumeYaml))
 	if err == nil || err.code != payloads.DetachVolumeInvalidData {
 		t.Fatalf("DetachVolumeInvalidData error expected")
+	}
+}
+
+func TestParseStartPayload(t *testing.T) {
+	for i, st := range startTests {
+		cfg, err := parseStartPayload([]byte(st.payload))
+		if st.config == nil {
+			if cfg != nil {
+				t.Errorf("Expected nil config due to bad payload %d", i)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Failed to parse payload %d : %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(cfg, st.config) {
+			t.Errorf("Start payload %d does not match", i)
+		}
+	}
+}
+
+func compareNetEvents(t *testing.T, ev *libsnnet.SsntpEventInfo, eventData *payloads.TenantAddedEvent) {
+	if eventData.AgentUUID != testutil.AgentUUID ||
+		eventData.AgentIP != ev.CnIP ||
+		eventData.TenantUUID != ev.TenantID ||
+		eventData.TenantSubnet != ev.SubnetID ||
+		eventData.ConcentratorUUID != ev.ConcID ||
+		eventData.ConcentratorIP != ev.CnciIP ||
+		eventData.SubnetKey != ev.SubnetKey {
+		t.Errorf("payloads and ssntp events do not match")
+	}
+}
+
+func TestGenerateNetEventPayload(t *testing.T) {
+	ev := &libsnnet.SsntpEventInfo{
+		Event:     libsnnet.SsntpTunAdd,
+		CnciIP:    testutil.CNCIIP,
+		CnIP:      testutil.InstancePrivateIP,
+		Subnet:    testutil.TenantSubnet,
+		TenantID:  testutil.TenantUUID,
+		SubnetID:  "",
+		ConcID:    testutil.CNCIUUID,
+		CnID:      testutil.AgentUUID,
+		SubnetKey: 1,
+	}
+
+	pl, err := generateNetEventPayload(ev, testutil.AgentUUID)
+	if err != nil {
+		t.Fatalf("Failed to generate payload : %v", err)
+	}
+	var eventData payloads.EventTenantAdded
+	err = yaml.Unmarshal(pl, &eventData)
+	if err != nil {
+		t.Fatalf("Unable to unmarshall event : %v", err)
+	}
+
+	compareNetEvents(t, ev, &eventData.TenantAdded)
+
+	ev.Event = libsnnet.SsntpTunDel
+	pl, err = generateNetEventPayload(ev, testutil.AgentUUID)
+	if err != nil {
+		t.Fatalf("Failed to generate payload : %v", err)
+	}
+	var eventData2 payloads.EventTenantRemoved
+	err = yaml.Unmarshal(pl, &eventData2)
+	if err != nil {
+		t.Fatalf("Unable to unmarshall event : %v", err)
+	}
+
+	compareNetEvents(t, ev, &eventData2.TenantRemoved)
+
+	ev.Event = 666
+	_, err = generateNetEventPayload(ev, testutil.AgentUUID)
+	if err == nil {
+		t.Errorf("generateNetEventPayload should have failed on invalid event type")
+	}
+}
+
+func TestParseRestartPayload(t *testing.T) {
+	instance, err := parseRestartPayload([]byte(testutil.RestartYaml))
+	if err != nil {
+		t.Fatalf("Failed to parse restart payload : %v", err.err)
+	}
+	if instance != testutil.InstanceUUID {
+		t.Errorf("Wrong instance UUID.  Expected %s found %s", instance,
+			testutil.InstanceUUID)
+	}
+}
+
+func TestParseDeletePayload(t *testing.T) {
+	instance, err := parseDeletePayload([]byte(testutil.DeleteYaml))
+	if err != nil {
+		t.Fatalf("Failed to parse delete payload : %v", err.err)
+	}
+	if instance != testutil.InstanceUUID {
+		t.Errorf("Wrong instance UUID.  Expected %s found %s", instance,
+			testutil.InstanceUUID)
+	}
+}
+
+func TestParseStopPayload(t *testing.T) {
+	instance, err := parseStopPayload([]byte(testutil.StopYaml))
+	if err != nil {
+		t.Fatalf("Failed to parse stop payload : %v", err.err)
+	}
+	if instance != testutil.InstanceUUID {
+		t.Errorf("Wrong instance UUID.  Expected %s found %s", instance,
+			testutil.InstanceUUID)
 	}
 }

--- a/ciao-launcher/payload_test.go
+++ b/ciao-launcher/payload_test.go
@@ -163,6 +163,13 @@ start:
 	},
 }
 
+// Verify the parseAttachVolumePayload function.
+//
+// The function is passed one valid payload and two invalid payloads.
+//
+// No error should be returned for the valid payload and the returned instance
+// and volume UUIDs should match what is in the payload.  Errors should be
+// returned for the invalid payloads.
 func TestParseAttachVolumePayload(t *testing.T) {
 	instance, volume, err := parseAttachVolumePayload([]byte(testutil.AttachVolumeYaml))
 	if err != nil {
@@ -183,6 +190,13 @@ func TestParseAttachVolumePayload(t *testing.T) {
 	}
 }
 
+// Verify the parseDetachVolumePayload function.
+//
+// The function is passed one valid payload and two invalid payloads.
+//
+// No error should be returned for the valid payload and the returned instance
+// and volume UUIDs should match what is in the payload.  Errors should be
+// returned for the invalid payloads.
 func TestParseDetachVolumePayload(t *testing.T) {
 	instance, volume, err := parseDetachVolumePayload([]byte(testutil.DetachVolumeYaml))
 	if err != nil {
@@ -203,6 +217,13 @@ func TestParseDetachVolumePayload(t *testing.T) {
 	}
 }
 
+// Verify the parseStartPayload function.
+//
+// The function is passed one valid payload and a number of invalid payloads.
+//
+// No error should be returned for the valid payload.  The resulting vmConfig
+// structure should match the handcrafted structure associated with the
+// payload.  The invalid payloads should fail to parse.
 func TestParseStartPayload(t *testing.T) {
 	for i, st := range startTests {
 		cfg, err := parseStartPayload([]byte(st.payload))
@@ -234,6 +255,17 @@ func compareNetEvents(t *testing.T, ev *libsnnet.SsntpEventInfo, eventData *payl
 	}
 }
 
+// Verify that the generateNetEventPayload parses payloads correctly.
+//
+// Two valid payloads are passed to generateNetEventPayload, the first
+// representing a payloads.EventTenantAdded event, the second a
+// payloads.EventTenantRemoved event.  Finally, an event with an invalid
+// id is parsed.
+//
+// Both valid payloads should be parsed correctly and the resulting
+// payloads data structures should have the correct contents.  An
+// error should be generated when parsing the payload with the invalid
+// event id.
 func TestGenerateNetEventPayload(t *testing.T) {
 	ev := &libsnnet.SsntpEventInfo{
 		Event:     libsnnet.SsntpTunAdd,
@@ -279,6 +311,12 @@ func TestGenerateNetEventPayload(t *testing.T) {
 	}
 }
 
+// Check that parseRestartPayload works correctly.
+//
+// Parse a valid restart payload.
+//
+// The payload should parse without any error and the instance UUID in the
+// resulting payloads data structure should be as expected.
 func TestParseRestartPayload(t *testing.T) {
 	instance, err := parseRestartPayload([]byte(testutil.RestartYaml))
 	if err != nil {
@@ -290,6 +328,12 @@ func TestParseRestartPayload(t *testing.T) {
 	}
 }
 
+// Check that parseDeletePayload works correctly.
+//
+// Parse a valid delete payload.
+//
+// The payload should parse without any error and the instance UUID in the
+// resulting payloads data structure should be as expected.
 func TestParseDeletePayload(t *testing.T) {
 	instance, err := parseDeletePayload([]byte(testutil.DeleteYaml))
 	if err != nil {
@@ -301,6 +345,12 @@ func TestParseDeletePayload(t *testing.T) {
 	}
 }
 
+// Check that parseStopPayload works correctly.
+//
+// Parse a valid stop payload.
+//
+// The payload should parse without any error and the instance UUID in the
+// resulting payloads data structure should be as expected.
 func TestParseStopPayload(t *testing.T) {
 	instance, err := parseStopPayload([]byte(testutil.StopYaml))
 	if err != nil {

--- a/ciao-launcher/port_grabber_test.go
+++ b/ciao-launcher/port_grabber_test.go
@@ -1,0 +1,60 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package main
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestPortGrabber(t *testing.T) {
+	ports := make([]int, portGrabberMax-portGrabberStart)
+
+	var wg sync.WaitGroup
+	wg.Add(len(ports))
+	for i := 0; i < len(ports); i++ {
+		go func(i int) {
+			ports[i] = uiPortGrabber.grabPort()
+			if ports[i] == 0 {
+				t.Error("Expected grabPort to return non zero value")
+			}
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+
+	if len(uiPortGrabber.free) != 0 {
+		t.Error("Expected all ports to be allocated")
+	}
+
+	if uiPortGrabber.grabPort() != 0 {
+		t.Error("Expected grabPort to return 0")
+	}
+
+	wg.Add(len(ports))
+	for i := 0; i < len(ports); i++ {
+		go func(port int) {
+			uiPortGrabber.releasePort(port)
+			wg.Done()
+		}(ports[i])
+	}
+	wg.Wait()
+
+	if len(uiPortGrabber.free) != len(ports) {
+		t.Error("Expected no ports to be allocated")
+	}
+}

--- a/ciao-launcher/port_grabber_test.go
+++ b/ciao-launcher/port_grabber_test.go
@@ -21,6 +21,16 @@ import (
 	"testing"
 )
 
+// Test the port grabbing and release code
+//
+// Grab all the available ports concurrently, check that they are all
+// allocated and then release all the ports concurrently.
+//
+// All ports should be grabbed correctly, all ports should be reported
+// to be allocated, i.e., uiPortGrabber.grabPort should return 0, and
+// all ports should be released correctly.  At the end of the test the
+// size of uiPortGrabber.free should equal the maximum number of ports
+// available.
 func TestPortGrabber(t *testing.T) {
 	ports := make([]int, portGrabberMax-portGrabberStart)
 

--- a/ciao-launcher/process_stats.go
+++ b/ciao-launcher/process_stats.go
@@ -27,7 +27,11 @@ import (
 )
 
 func computeProcessMemUsage(pid int) int {
-	smapsPath := path.Join("/proc", fmt.Sprintf("%d", pid), "smaps")
+	mapsPath := path.Join("/proc", fmt.Sprintf("%d", pid), "smaps")
+	return parseProcSmaps(mapsPath)
+}
+
+func parseProcSmaps(smapsPath string) int {
 	smaps, err := os.Open(smapsPath)
 	if err != nil {
 		if glog.V(1) {
@@ -57,6 +61,10 @@ func computeProcessMemUsage(pid int) int {
 
 func computeProcessCPUTime(pid int) int64 {
 	statPath := path.Join("/proc", fmt.Sprintf("%d", pid), "stat")
+	return parseProcStat(statPath)
+}
+
+func parseProcStat(statPath string) int64 {
 	stat, err := os.Open(statPath)
 	if err != nil {
 		if glog.V(1) {

--- a/ciao-launcher/process_stats_test.go
+++ b/ciao-launcher/process_stats_test.go
@@ -101,6 +101,15 @@ var statsTest = []struct {
 	},
 }
 
+// Verify the smaps parser
+//
+// This test passes a number of different test files to the parseProcSmaps
+// function.  Some of the files are valid and some are invalid.  Finally,
+// it calls parseProcSmaps on an invalid path.
+//
+// parseProcSmaps should correctly parse the valid smaps files and return
+// an error when asked to parse the invalid files.  The attempt to call
+// parseProcSmaps on the invalid path should fail.
 func TestParseProcSmaps(t *testing.T) {
 	for _, tst := range smapsTest {
 		f, err := ioutil.TempFile("", "process_stats_test")
@@ -136,6 +145,15 @@ func TestParseProcSmaps(t *testing.T) {
 	}
 }
 
+// Verify the proc parser
+//
+// This test passes a number of different test files to the parseProcStat
+// function.  Some of the files are valid and some are invalid.  Finally,
+// it calls parseProcStat on an invalid path.
+//
+// parseProcStat should correctly parse the valid stat files and return
+// an error when asked to parse the invalid files.  The attempt to call
+// parseProcStat on the invalid path should fail.
 func TestParseProcStat(t *testing.T) {
 	for _, tst := range statsTest {
 		f, err := ioutil.TempFile("", "process_stats_test")

--- a/ciao-launcher/process_stats_test.go
+++ b/ciao-launcher/process_stats_test.go
@@ -1,0 +1,175 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+var smapsTest = []struct {
+	data string
+	res  int
+}{
+	{
+		`
+7fffeb521000-7fffeb523000 r--p 00000000 00:00 0                          [vvar]
+Size:                  8 kB
+Rss:                   0 kB
+Pss:                   8 kB
+`,
+		0,
+	},
+	{`
+7fffeb521000-7fffeb523000 r--p 00000000 00:00 0                          [vvar]
+Size:              10504 kB
+Rss:                   0 kB
+Pss:               10504 kB
+`,
+		10,
+	},
+	{`
+Pss:               10504 kB
+Pss:               10504 kB
+Pss:               10504 kB
+Rss:                   0 kB
+Pss:                   0 kB
+Pss:               10504 kB
+`,
+		41,
+	},
+	{`
+Pss:               10504 kB
+Pss:               asasas kB
+`,
+		10,
+	},
+	{
+		"",
+		00,
+	},
+	{`
+Rss:               10504 kB
+`,
+		0,
+	},
+	{`
+Psst:               10504 kB
+`,
+		0,
+	},
+}
+
+var statsTest = []struct {
+	data string
+	res  int64
+}{
+	{
+		"9017 (emacs) S 1731 9017 1731 34816 1731 4194304 10138 4271 165 0 38 16 3 0 20 0 4 0 2154773 656859136 18106 18446744073709551615 4194304 6539236 140736937569392 140736937564512 140338947582652 0 0 67112960 1535209215 0 0 0 17 1 0 0 12 0 0 8637344 21454848 44126208 140736937575538 140736937575544 140736937575544 140736937578473 0",
+		(38 + 16) * 1000 * 1000 * 1000,
+	},
+	{
+		"9017 (emacs) S 1731 9017 1731 34816 1731 4194304 10138 4271 165 0 38",
+		-1,
+	},
+	{
+		"9017 (emacs) S 1731 9017 1731 34816 1731 4194304 10138 4271 165 0",
+		-1,
+	},
+	{
+		"9017 (emacs) S 1731 9017 1731 34816 1731 4194304 10138 4271 165 0 38 16",
+		(38 + 16) * 1000 * 1000 * 1000,
+	},
+	{
+		"",
+		-1,
+	},
+}
+
+func TestParseProcSmaps(t *testing.T) {
+	for _, tst := range smapsTest {
+		f, err := ioutil.TempFile("", "process_stats_test")
+		if err != nil {
+			t.Errorf("Unable to create tempory file : %v", err)
+			continue
+		}
+		_, err = f.WriteString(tst.data)
+		err2 := f.Close()
+		func() {
+			defer func() {
+				_ = os.RemoveAll(f.Name())
+			}()
+			if err != nil {
+				t.Errorf("Unable to write to tempory file : %v", err)
+				return
+			}
+			if err2 != nil {
+				t.Errorf("Unable to close tempory file : %v", err)
+				return
+			}
+
+			mem := parseProcSmaps(f.Name())
+			if mem != tst.res {
+				t.Errorf("Incorrect value from parseProcSmaps.  Expected %d found %d",
+					mem, tst.res)
+			}
+		}()
+	}
+
+	if parseProcSmaps("") != -1 {
+		t.Errorf("Expected parseProcSmaps to fail when passed invalid path")
+	}
+}
+
+func TestParseProcStat(t *testing.T) {
+	for _, tst := range statsTest {
+		f, err := ioutil.TempFile("", "process_stats_test")
+		if err != nil {
+			t.Errorf("Unable to create tempory file : %v", err)
+			continue
+		}
+		_, err = f.WriteString(tst.data)
+		err2 := f.Close()
+		func() {
+			defer func() {
+				_ = os.RemoveAll(f.Name())
+			}()
+			if err != nil {
+				t.Errorf("Unable to write to tempory file : %v", err)
+				return
+			}
+			if err2 != nil {
+				t.Errorf("Unable to close tempory file : %v", err)
+				return
+			}
+
+			mem := parseProcStat(f.Name())
+			if tst.res != -1 {
+				tst.res /= clockTicksPerSecond
+			}
+			if mem != tst.res {
+				t.Errorf("Incorrect value from parseProcStat.  Expected %d found %d",
+					mem, tst.res)
+			}
+		}()
+	}
+
+	if parseProcStat("") != -1 {
+		t.Errorf("Expected parseProcStat to fail when passed invalid path")
+	}
+}

--- a/ciao-launcher/ssntp.go
+++ b/ciao-launcher/ssntp.go
@@ -31,6 +31,9 @@ type cmdWrapper struct {
 }
 type statusCmd struct{}
 
+// serverConn is an abstract interface representing a connection to
+// a server.  It contains methods to connect to the server and to
+// send information to the server, such as commands or events.
 type serverConn interface {
 	SendError(error ssntp.Error, payload []byte) (int, error)
 	SendEvent(event ssntp.Event, payload []byte) (int, error)
@@ -45,6 +48,8 @@ type serverConn interface {
 	ClusterConfiguration() (payloads.Configure, error)
 }
 
+// ssntpConn is a concrete implementation of serverConn.  It represents
+// a connection to an SSNTP server, i.e., the scheduler.
 type ssntpConn struct {
 	sync.RWMutex
 	ssntp.Client
@@ -63,6 +68,10 @@ func (s *ssntpConn) setStatus(status bool) {
 	s.Unlock()
 }
 
+// agentClient is a structure that serves two purposes.  It holds contains
+// a serverConn object and so can be used to send commands to an SSNTP
+// server.  It also implements the ssntp.ClientNotifier interface and so
+// can be passed to serverConn.Dial.
 type agentClient struct {
 	conn  serverConn
 	cmdCh chan *cmdWrapper

--- a/ciao-launcher/ssntp.go
+++ b/ciao-launcher/ssntp.go
@@ -1,0 +1,172 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package main
+
+import (
+	"sync"
+	"time"
+
+	"github.com/01org/ciao/payloads"
+	"github.com/01org/ciao/ssntp"
+	"github.com/golang/glog"
+)
+
+type cmdWrapper struct {
+	instance string
+	cmd      interface{}
+}
+type statusCmd struct{}
+
+type serverConn interface {
+	SendError(error ssntp.Error, payload []byte) (int, error)
+	SendEvent(event ssntp.Event, payload []byte) (int, error)
+	Dial(config *ssntp.Config, ntf ssntp.ClientNotifier) error
+	SendStatus(status ssntp.Status, payload []byte) (int, error)
+	SendCommand(cmd ssntp.Command, payload []byte) (int, error)
+	Role() ssntp.Role
+	UUID() string
+	Close()
+	isConnected() bool
+	setStatus(status bool)
+	ClusterConfiguration() (payloads.Configure, error)
+}
+
+type ssntpConn struct {
+	sync.RWMutex
+	ssntp.Client
+	connected bool
+}
+
+func (s *ssntpConn) isConnected() bool {
+	s.RLock()
+	defer s.RUnlock()
+	return s.connected
+}
+
+func (s *ssntpConn) setStatus(status bool) {
+	s.Lock()
+	s.connected = status
+	s.Unlock()
+}
+
+type agentClient struct {
+	conn  serverConn
+	cmdCh chan *cmdWrapper
+}
+
+func (client *agentClient) DisconnectNotify() {
+	client.conn.setStatus(false)
+	glog.Warning("disconnected")
+}
+
+func (client *agentClient) ConnectNotify() {
+	client.conn.setStatus(true)
+	client.cmdCh <- &cmdWrapper{"", &statusCmd{}}
+	glog.Info("connected")
+}
+
+func (client *agentClient) StatusNotify(status ssntp.Status, frame *ssntp.Frame) {
+	glog.Infof("STATUS %s", status)
+}
+
+func (client *agentClient) CommandNotify(cmd ssntp.Command, frame *ssntp.Frame) {
+	payload := frame.Payload
+
+	switch cmd {
+	case ssntp.START:
+		start, cn, md := splitYaml(payload)
+		cfg, payloadErr := parseStartPayload(start)
+		if payloadErr != nil {
+			startError := &startError{
+				payloadErr.err,
+				payloads.StartFailureReason(payloadErr.code),
+			}
+			startError.send(client.conn, "")
+			glog.Errorf("Unable to parse YAML: %v", payloadErr.err)
+			return
+		}
+		client.cmdCh <- &cmdWrapper{cfg.Instance, &insStartCmd{cn, md, frame, cfg, time.Now()}}
+	case ssntp.RESTART:
+		instance, payloadErr := parseRestartPayload(payload)
+		if payloadErr != nil {
+			restartError := &restartError{
+				payloadErr.err,
+				payloads.RestartFailureReason(payloadErr.code),
+			}
+			restartError.send(client.conn, "")
+			glog.Errorf("Unable to parse YAML: %v", payloadErr.err)
+			return
+		}
+		client.cmdCh <- &cmdWrapper{instance, &insRestartCmd{}}
+	case ssntp.STOP:
+		instance, payloadErr := parseStopPayload(payload)
+		if payloadErr != nil {
+			stopError := &stopError{
+				payloadErr.err,
+				payloads.StopFailureReason(payloadErr.code),
+			}
+			stopError.send(client.conn, "")
+			glog.Errorf("Unable to parse YAML: %s", payloadErr)
+			return
+		}
+		client.cmdCh <- &cmdWrapper{instance, &insStopCmd{}}
+	case ssntp.DELETE:
+		instance, payloadErr := parseDeletePayload(payload)
+		if payloadErr != nil {
+			deleteError := &deleteError{
+				payloadErr.err,
+				payloads.DeleteFailureReason(payloadErr.code),
+			}
+			deleteError.send(client.conn, "")
+			glog.Errorf("Unable to parse YAML: %s", payloadErr.err)
+			return
+		}
+		client.cmdCh <- &cmdWrapper{instance, &insDeleteCmd{}}
+	case ssntp.AttachVolume:
+		instance, volume, payloadErr := parseAttachVolumePayload(payload)
+		if payloadErr != nil {
+			attachVolumeError := &attachVolumeError{
+				payloadErr.err,
+				payloads.AttachVolumeFailureReason(payloadErr.code),
+			}
+			attachVolumeError.send(client.conn, "", "")
+			glog.Errorf("Unable to parse YAML: %s", payloadErr.err)
+			return
+		}
+		client.cmdCh <- &cmdWrapper{instance, &insAttachVolumeCmd{volume}}
+	case ssntp.DetachVolume:
+		instance, volume, payloadErr := parseDetachVolumePayload(payload)
+		if payloadErr != nil {
+			detachVolumeError := &detachVolumeError{
+				payloadErr.err,
+				payloads.DetachVolumeFailureReason(payloadErr.code),
+			}
+			detachVolumeError.send(client.conn, "", "")
+			glog.Errorf("Unable to parse YAML: %s", payloadErr.err)
+			return
+		}
+		client.cmdCh <- &cmdWrapper{instance, &insDetachVolumeCmd{volume}}
+	}
+}
+
+func (client *agentClient) EventNotify(event ssntp.Event, frame *ssntp.Frame) {
+	glog.Infof("EVENT %s", event)
+}
+
+func (client *agentClient) ErrorNotify(err ssntp.Error, frame *ssntp.Frame) {
+	glog.Infof("ERROR %d", err)
+}

--- a/ciao-launcher/ssntp_test.go
+++ b/ciao-launcher/ssntp_test.go
@@ -1,0 +1,329 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package main
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/01org/ciao/payloads"
+	"github.com/01org/ciao/ssntp"
+	"github.com/01org/ciao/testutil"
+)
+
+type ssntpTestState struct {
+	t       *testing.T
+	status  bool
+	error   ssntp.Error
+	payload []byte
+}
+
+func (v *ssntpTestState) SendError(error ssntp.Error, payload []byte) (int, error) {
+	v.error = error
+	v.payload = payload
+	return len(payload), nil
+}
+
+func (v *ssntpTestState) SendEvent(event ssntp.Event, payload []byte) (int, error) {
+	return 0, nil
+}
+
+func (v *ssntpTestState) Dial(config *ssntp.Config, ntf ssntp.ClientNotifier) error {
+	return nil
+}
+
+func (v *ssntpTestState) SendStatus(status ssntp.Status, payload []byte) (int, error) {
+	return 0, nil
+}
+
+func (v *ssntpTestState) SendCommand(cmd ssntp.Command, payload []byte) (int, error) {
+	return 0, nil
+}
+
+func (v *ssntpTestState) Role() ssntp.Role {
+	return ssntp.AGENT | ssntp.NETAGENT
+}
+
+func (v *ssntpTestState) UUID() string {
+	return testutil.AgentUUID
+}
+
+func (v *ssntpTestState) Close() {
+
+}
+
+func (v *ssntpTestState) isConnected() bool {
+	return true
+}
+
+func (v *ssntpTestState) setStatus(status bool) {
+	v.status = status
+}
+
+func (v *ssntpTestState) ClusterConfiguration() (payloads.Configure, error) {
+	return payloads.Configure{}, nil
+}
+
+func TestAgentClientConnectDisconnectNotify(t *testing.T) {
+	state := &ssntpTestState{}
+	cmdCh := make(chan *cmdWrapper)
+	ac := agentClient{conn: state, cmdCh: cmdCh}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		select {
+		case cmd := <-cmdCh:
+			if _, ok := cmd.cmd.(*statusCmd); !ok {
+				t.Errorf("Unexpected command received.  Expected statusCmd")
+			}
+		case <-time.After(time.Second):
+			t.Errorf("Timedout waiting for cmdCh")
+		}
+		wg.Done()
+	}()
+
+	ac.ConnectNotify()
+	wg.Wait()
+	if !state.status {
+		t.Errorf("Connect Notify did not set agent client state")
+	}
+
+	ac.DisconnectNotify()
+	if state.status {
+		t.Errorf("Connect Notify did not set agent client state")
+	}
+}
+
+func TestAgentClientStatusNotify(t *testing.T) {
+	state := &ssntpTestState{}
+	ac := agentClient{conn: state}
+	ac.StatusNotify(ssntp.CONNECTED, nil)
+}
+
+func TestAgentClientEventNotify(t *testing.T) {
+	state := &ssntpTestState{}
+	ac := agentClient{conn: state}
+	ac.EventNotify(ssntp.TenantAdded, nil)
+}
+
+func TestAgentClientErrorNotify(t *testing.T) {
+	state := &ssntpTestState{}
+	ac := agentClient{conn: state}
+	ac.ErrorNotify(ssntp.InvalidFrameType, nil)
+}
+
+func checkErrorPayload(t *testing.T, ac *agentClient, state *ssntpTestState, cmd ssntp.Command,
+	error ssntp.Error) {
+	state.status = true
+	frame := &ssntp.Frame{Payload: []byte{'h'}}
+	ac.CommandNotify(cmd, frame)
+	if state.error != error {
+		t.Errorf("Expected SSNTP error %d", error)
+	}
+	if len(state.payload) == 0 {
+		t.Errorf("Expected Non empty payload")
+	}
+}
+
+func TestAgentClientStart(t *testing.T) {
+	state := &ssntpTestState{}
+	cmdCh := make(chan *cmdWrapper)
+	ac := agentClient{conn: state, cmdCh: cmdCh}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		select {
+		case cmd := <-cmdCh:
+			if _, ok := cmd.cmd.(*insStartCmd); !ok {
+				t.Errorf("Unexpected command received.  Expected startCmd")
+			}
+			if cmd.instance != testutil.InstanceUUID {
+				t.Errorf("Unexpected instanced.  Expected %s found %s",
+					testutil.InstanceUUID, cmd.instance)
+			}
+		case <-time.After(time.Second):
+			t.Errorf("Timedout waiting for cmdCh")
+		}
+		wg.Done()
+	}()
+
+	frame := &ssntp.Frame{Payload: []byte(testutil.StartYaml)}
+	ac.CommandNotify(ssntp.START, frame)
+	wg.Wait()
+
+	checkErrorPayload(t, &ac, state, ssntp.START, ssntp.StartFailure)
+}
+
+func TestAgentClientRestart(t *testing.T) {
+	state := &ssntpTestState{}
+	cmdCh := make(chan *cmdWrapper)
+	ac := agentClient{conn: state, cmdCh: cmdCh}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		select {
+		case cmd := <-cmdCh:
+			if _, ok := cmd.cmd.(*insRestartCmd); !ok {
+				t.Errorf("Unexpected command received.  Expected restartCmd")
+			}
+			if cmd.instance != testutil.InstanceUUID {
+				t.Errorf("Unexpected instanced.  Expected %s found %s",
+					testutil.InstanceUUID, cmd.instance)
+			}
+		case <-time.After(time.Second):
+			t.Errorf("Timedout waiting for cmdCh")
+		}
+		wg.Done()
+	}()
+
+	frame := &ssntp.Frame{Payload: []byte(testutil.RestartYaml)}
+	ac.CommandNotify(ssntp.RESTART, frame)
+	wg.Wait()
+
+	checkErrorPayload(t, &ac, state, ssntp.RESTART, ssntp.RestartFailure)
+}
+
+func TestAgentClientStop(t *testing.T) {
+	state := &ssntpTestState{}
+	cmdCh := make(chan *cmdWrapper)
+	ac := agentClient{conn: state, cmdCh: cmdCh}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		select {
+		case cmd := <-cmdCh:
+			if _, ok := cmd.cmd.(*insStopCmd); !ok {
+				t.Errorf("Unexpected command received.  Expected stopCmd")
+			}
+			if cmd.instance != testutil.InstanceUUID {
+				t.Errorf("Unexpected instanced.  Expected %s found %s",
+					testutil.InstanceUUID, cmd.instance)
+			}
+		case <-time.After(time.Second):
+			t.Errorf("Timedout waiting for cmdCh")
+		}
+		wg.Done()
+	}()
+
+	frame := &ssntp.Frame{Payload: []byte(testutil.StopYaml)}
+	ac.CommandNotify(ssntp.STOP, frame)
+	wg.Wait()
+
+	checkErrorPayload(t, &ac, state, ssntp.STOP, ssntp.StopFailure)
+}
+
+func TestAgentClientDelete(t *testing.T) {
+	state := &ssntpTestState{}
+	cmdCh := make(chan *cmdWrapper)
+	ac := agentClient{conn: state, cmdCh: cmdCh}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		select {
+		case cmd := <-cmdCh:
+			if _, ok := cmd.cmd.(*insDeleteCmd); !ok {
+				t.Errorf("Unexpected command received.  Expected deleteCmd")
+			}
+			if cmd.instance != testutil.InstanceUUID {
+				t.Errorf("Unexpected instanced.  Expected %s found %s",
+					testutil.InstanceUUID, cmd.instance)
+			}
+		case <-time.After(time.Second):
+			t.Errorf("Timedout waiting for cmdCh")
+		}
+		wg.Done()
+	}()
+
+	frame := &ssntp.Frame{Payload: []byte(testutil.DeleteYaml)}
+	ac.CommandNotify(ssntp.DELETE, frame)
+	wg.Wait()
+
+	checkErrorPayload(t, &ac, state, ssntp.DELETE, ssntp.DeleteFailure)
+}
+
+func TestAgentAttachVolume(t *testing.T) {
+	state := &ssntpTestState{}
+	cmdCh := make(chan *cmdWrapper)
+	ac := agentClient{conn: state, cmdCh: cmdCh}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		select {
+		case cmd := <-cmdCh:
+			if _, ok := cmd.cmd.(*insAttachVolumeCmd); !ok {
+				t.Errorf("Unexpected command received.  Expected attachVolumeCmd")
+			}
+			if cmd.instance != testutil.InstanceUUID {
+				t.Errorf("Unexpected instanced.  Expected %s found %s",
+					testutil.InstanceUUID, cmd.instance)
+			}
+		case <-time.After(time.Second):
+			t.Errorf("Timedout waiting for cmdCh")
+		}
+		wg.Done()
+	}()
+
+	frame := &ssntp.Frame{Payload: []byte(testutil.AttachVolumeYaml)}
+	ac.CommandNotify(ssntp.AttachVolume, frame)
+	wg.Wait()
+
+	checkErrorPayload(t, &ac, state, ssntp.AttachVolume, ssntp.AttachVolumeFailure)
+}
+
+func TestAgentDetachVolume(t *testing.T) {
+	state := &ssntpTestState{}
+	cmdCh := make(chan *cmdWrapper)
+	ac := agentClient{conn: state, cmdCh: cmdCh}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		select {
+		case cmd := <-cmdCh:
+			if _, ok := cmd.cmd.(*insDetachVolumeCmd); !ok {
+				t.Errorf("Unexpected command received.  Expected detachVolumeCmd")
+			}
+			if cmd.instance != testutil.InstanceUUID {
+				t.Errorf("Unexpected instanced.  Expected %s found %s",
+					testutil.InstanceUUID, cmd.instance)
+			}
+		case <-time.After(time.Second):
+			t.Errorf("Timedout waiting for cmdCh")
+		}
+		wg.Done()
+	}()
+
+	frame := &ssntp.Frame{Payload: []byte(testutil.DetachVolumeYaml)}
+	ac.CommandNotify(ssntp.DetachVolume, frame)
+	wg.Wait()
+
+	checkErrorPayload(t, &ac, state, ssntp.DetachVolume, ssntp.DetachVolumeFailure)
+}

--- a/ciao-launcher/ssntp_test.go
+++ b/ciao-launcher/ssntp_test.go
@@ -79,6 +79,14 @@ func (v *ssntpTestState) ClusterConfiguration() (payloads.Configure, error) {
 	return payloads.Configure{}, nil
 }
 
+// Verify the behaviour the ConnectNotify and DisconnectNotify methods
+//
+// Call ConnectNotify and wait for the statusCmd command on the cmdCh.
+// Call DisconnectNotify.
+//
+// After ConnectNotify is callled the status of the ssntpConn should change
+// and a statusCmd command should be received on the cmdCh channel.  Calling
+// DisconnectNotify should change to status.
 func TestAgentClientConnectDisconnectNotify(t *testing.T) {
 	state := &ssntpTestState{}
 	cmdCh := make(chan *cmdWrapper)
@@ -111,18 +119,33 @@ func TestAgentClientConnectDisconnectNotify(t *testing.T) {
 	}
 }
 
+// Test the StatusNotify function
+//
+// We just call the method which at the moment is a NOOP.
+//
+// StatusNotify should not crash.
 func TestAgentClientStatusNotify(t *testing.T) {
 	state := &ssntpTestState{}
 	ac := agentClient{conn: state}
 	ac.StatusNotify(ssntp.CONNECTED, nil)
 }
 
+// Test the EventNotify function
+//
+// We just call the method which at the moment is a NOOP.
+//
+// EventNotify should not crash.
 func TestAgentClientEventNotify(t *testing.T) {
 	state := &ssntpTestState{}
 	ac := agentClient{conn: state}
 	ac.EventNotify(ssntp.TenantAdded, nil)
 }
 
+// Test the ErrorNotify function
+//
+// We just call the method which at the moment is a NOOP.
+//
+// ErrorNotify should not crash.
 func TestAgentClientErrorNotify(t *testing.T) {
 	state := &ssntpTestState{}
 	ac := agentClient{conn: state}
@@ -142,6 +165,14 @@ func checkErrorPayload(t *testing.T, ac *agentClient, state *ssntpTestState, cmd
 	}
 }
 
+// Verify that the agentClient correctly processes ssntp.START
+//
+// Send the ssntp.START command to the agent client with a valid payload,
+// then send another ssntp.START command with an invalid payload.
+//
+// The command with the valid payload should be processed correctly and a
+// insStartCmd should be received on the agent's cmdCh.  The second
+// command with the invalid payload should result in a call to state.SendError.
 func TestAgentClientStart(t *testing.T) {
 	state := &ssntpTestState{}
 	cmdCh := make(chan *cmdWrapper)
@@ -173,6 +204,14 @@ func TestAgentClientStart(t *testing.T) {
 	checkErrorPayload(t, &ac, state, ssntp.START, ssntp.StartFailure)
 }
 
+// Verify that the agentClient correctly processes ssntp.RESTART
+//
+// Send the ssntp.RESTART command to the agent client with a valid payload,
+// then send another ssntp.RESTART command with an invalid payload.
+//
+// The command with the valid payload should be processed correctly and a
+// insRestartCmd should be received on the agent's cmdCh.  The second
+// command with the invalid payload should result in a call to state.SendError.
 func TestAgentClientRestart(t *testing.T) {
 	state := &ssntpTestState{}
 	cmdCh := make(chan *cmdWrapper)
@@ -204,6 +243,14 @@ func TestAgentClientRestart(t *testing.T) {
 	checkErrorPayload(t, &ac, state, ssntp.RESTART, ssntp.RestartFailure)
 }
 
+// Verify that the agentClient correctly processes ssntp.STOP
+//
+// Send the ssntp.STOP command to the agent client with a valid payload,
+// then send another ssntp.STOP command with an invalid payload.
+//
+// The command with the valid payload should be processed correctly and a
+// insStopCmd should be received on the agent's cmdCh.  The second
+// command with the invalid payload should result in a call to state.SendError.
 func TestAgentClientStop(t *testing.T) {
 	state := &ssntpTestState{}
 	cmdCh := make(chan *cmdWrapper)
@@ -235,6 +282,14 @@ func TestAgentClientStop(t *testing.T) {
 	checkErrorPayload(t, &ac, state, ssntp.STOP, ssntp.StopFailure)
 }
 
+// Verify that the agentClient correctly processes ssntp.DELETE
+//
+// Send the ssntp.DELETE command to the agent client with a valid payload,
+// then send another ssntp.DELETE command with an invalid payload.
+//
+// The command with the valid payload should be processed correctly and a
+// insDeleteCmd should be received on the agent's cmdCh.  The second
+// command with the invalid payload should result in a call to state.SendError.
 func TestAgentClientDelete(t *testing.T) {
 	state := &ssntpTestState{}
 	cmdCh := make(chan *cmdWrapper)
@@ -266,6 +321,14 @@ func TestAgentClientDelete(t *testing.T) {
 	checkErrorPayload(t, &ac, state, ssntp.DELETE, ssntp.DeleteFailure)
 }
 
+// Verify that the agentClient correctly processes ssntp.AttachVolume
+//
+// Send the ssntp.AttachVolume command to the agent client with a valid payload,
+// then send another ssntp.AttachVolume command with an invalid payload.
+//
+// The command with the valid payload should be processed correctly and a
+// insAttachVolumeCmd should be received on the agent's cmdCh.  The second
+// command with the invalid payload should result in a call to state.SendError.
 func TestAgentAttachVolume(t *testing.T) {
 	state := &ssntpTestState{}
 	cmdCh := make(chan *cmdWrapper)
@@ -297,6 +360,14 @@ func TestAgentAttachVolume(t *testing.T) {
 	checkErrorPayload(t, &ac, state, ssntp.AttachVolume, ssntp.AttachVolumeFailure)
 }
 
+// Verify that the agentClient correctly processes ssntp.DetachVolume
+//
+// Send the ssntp.DetachVolume command to the agent client with a valid payload,
+// then send another ssntp.DetachVolume command with an invalid payload.
+//
+// The command with the valid payload should be processed correctly and a
+// insDetachVolumeCmd should be received on the agent's cmdCh.  The second
+// command with the invalid payload should result in a call to state.SendError.
 func TestAgentDetachVolume(t *testing.T) {
 	state := &ssntpTestState{}
 	cmdCh := make(chan *cmdWrapper)

--- a/ciao-launcher/vmconfig.go
+++ b/ciao-launcher/vmconfig.go
@@ -75,7 +75,7 @@ func (cfg *vmConfig) save(instanceDir string) error {
 	cfgFile, err := os.OpenFile(cfgFilePath, os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		glog.Errorf("Unable to create state file %v", err)
-		panic(err)
+		return err
 	}
 
 	enc := gob.NewEncoder(cfgFile)


### PR DESCRIPTION
Tests have been added for

- image.go
- ssntp.go
- port_grabber.go
- payload.go
- process_stats.go

A bug has also been fixed that led to some of the existing unit tests failing if launcher was not run as root and the /var/lib/ciao/instances directory did not exist.