### PR TITLE
ciao-launcher: Add some more docker unit tests

### DIFF
--- a/ciao-launcher/container_manager.go
+++ b/ciao-launcher/container_manager.go
@@ -1,0 +1,38 @@
+/*
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+*/
+
+package main
+
+import (
+	"io"
+
+	"github.com/docker/engine-api/client"
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/container"
+	"github.com/docker/engine-api/types/network"
+	"golang.org/x/net/context"
+)
+
+type containerManager interface {
+	ImageList(context.Context, types.ImageListOptions) ([]types.Image, error)
+	ImagePull(context.Context, types.ImagePullOptions, client.RequestPrivilegeFunc) (io.ReadCloser, error)
+	ContainerCreate(context.Context, *container.Config, *container.HostConfig,
+		*network.NetworkingConfig, string) (types.ContainerCreateResponse, error)
+	ContainerRemove(context.Context, types.ContainerRemoveOptions) error
+	ContainerStart(context.Context, string) error
+	ContainerInspectWithRaw(context.Context, string, bool) (types.ContainerJSON, []byte, error)
+	ContainerStats(context.Context, string, bool) (io.ReadCloser, error)
+}

--- a/ciao-launcher/docker.go
+++ b/ciao-launcher/docker.go
@@ -160,7 +160,7 @@ func (d *docker) downloadBackingImage() error {
 	}
 
 	if err != nil && err != io.EOF {
-		glog.Errorf("Unable to download image %v\n", err)
+		glog.Errorf("Unable to download image : %v\n", err)
 		return err
 	}
 

--- a/ciao-launcher/docker.go
+++ b/ciao-launcher/docker.go
@@ -67,7 +67,7 @@ type docker struct {
 	prevSampleTime time.Time
 	storageDriver  storage.BlockDriver
 	mount          mounter
-	cli            *client.Client
+	cli            containerManager
 }
 
 type mounter interface {

--- a/ciao-launcher/docker.go
+++ b/ciao-launcher/docker.go
@@ -44,11 +44,6 @@ import (
 
 const volumesDir = "volumes"
 
-var dockerClient struct {
-	sync.Mutex
-	cli *client.Client
-}
-
 type dockerMounter struct{}
 
 func (m dockerMounter) Mount(source, destination string) error {


### PR DESCRIPTION
This PR adds the following new unit tests for docker

- TestDockerCheckBackingImage
- TestDockerDownloadBackingImage
- TestDockerDeleteImage
- TestDockerCreateImage

A new interface, containerManager was added to facilitate these new tests.  It allows us to replace the docker client object with an object of our choosing.