### PR TITLE
ciao-controller: Make instance storage override workload storage

### DIFF
--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -359,8 +359,8 @@ func newConfig(ctl *controller, wl *types.Workload, instanceID string, tenantID 
 		userData.Hostname = "cnci-" + tenantID
 	}
 
-	// handle storage resources in workload definition
-	if wl.Storage != nil {
+	// if no instance volumes specified, use those in workload
+	if len(volumes) == 0 && wl.Storage != nil {
 		workloadStorage, err := getStorage(ctl, *wl.Storage, tenantID, instanceID)
 		if err != nil {
 			return config, err


### PR DESCRIPTION
The specification of any per-instance storage should override the
workload storage specification.

With this change if any volumes are specified at instance creation the
workload storage information is not used.

Fixes: #974

Signed-off-by: Rob Bradford <robert.bradford@intel.com>