### PR TITLE
openstack: retrieve tenant from token when absent from mux

### DIFF
--- a/openstack/identity/identity_test.go
+++ b/openstack/identity/identity_test.go
@@ -60,7 +60,7 @@ type test struct {
 var tests = []test{
 	{fmt.Sprintf("/v2/%s/volumes", testutil.ComputeUser), "/v2/{tenant}/volumes", validServices, validAdmins, 200},
 	{"/v2.1/tenants", "/v2.1/tenants", validServices, validAdmins, 200},
-	{"/v2.1/tenants", "/v2.1/tenants", validServices, invalidAdmins, 401},
+	{"/v2.1/tenants", "/v2.1/tenants", validServices, invalidAdmins, 200},
 	{fmt.Sprintf("/v2/%s/volumes", testutil.ComputeUser), "/v2/{tenant}/volumes", invalidServices, invalidAdmins, 401},
 	{fmt.Sprintf("/v2/%s/volumes", testutil.ComputeUser), "/v2/{tenant}/volumes", anyOldComputeServices, invalidAdmins, 200},
 	{fmt.Sprintf("/v2/%s/volumes", "unknowntenantid"), "/v2/{tenant}/volumes", validServices, invalidAdmins, 401},


### PR DESCRIPTION
when validating token, tenant is obtained from mux.Vars of the
request, on certain cases (such as the image service) the tenant
variable it's absent due to not being specified in the endpoint URI,
this makes ciao to believe we're requesting operation as an admin when
that's not true.

This commit tries to get tenant from token if no tenant is obtained from
mux.Vars

Closes #866 

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>