### PR TITLE
Minor datastore/database cleanups

### DIFF
--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -112,9 +112,9 @@ type persistentStore interface {
 	removeInstance(instanceID string) (err error)
 
 	// interfaces related to statistics
-	addNodeStatDB(stat payloads.Stat) (err error)
+	addNodeStat(stat payloads.Stat) (err error)
 	getNodeSummary() (Summary []*types.NodeSummary, err error)
-	addInstanceStatsDB(stats []payloads.InstanceStat, nodeID string) (err error)
+	addInstanceStats(stats []payloads.InstanceStat, nodeID string) (err error)
 	addFrameStat(stat payloads.FrameTrace) (err error)
 	getBatchFrameSummary() (stats []types.BatchFrameSummary, err error)
 	getBatchFrameStatistics(label string) (stats []types.BatchFrameStat, err error)
@@ -1221,7 +1221,7 @@ func (ds *Datastore) addNodeStat(stat payloads.Stat) error {
 
 	ds.nodeLastStatLock.Unlock()
 
-	return ds.db.addNodeStatDB(stat)
+	return ds.db.addNodeStat(stat)
 }
 
 var tenantUsagePeriodMinutes float64 = 5
@@ -1363,7 +1363,7 @@ func (ds *Datastore) addInstanceStats(stats []payloads.InstanceStat, nodeID stri
 		ds.updateStorageAttachments(stat.InstanceUUID, stat.Volumes)
 	}
 
-	return ds.db.addInstanceStatsDB(stats, nodeID)
+	return ds.db.addInstanceStats(stats, nodeID)
 }
 
 // GetTenantCNCISummary retrieves information about a given CNCI id, or all CNCIs

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -93,15 +93,15 @@ type persistentStore interface {
 
 	// interfaces related to workloads
 	getCNCIWorkloadID() (id string, err error)
-	getWorkloadNoCache(id string) (*workload, error)
-	getWorkloadsNoCache() ([]*workload, error)
+	getWorkload(id string) (*workload, error)
+	getWorkloads() ([]*workload, error)
 	updateWorkload(wl workload) error
 
 	// interfaces related to tenants
 	addLimit(tenantID string, resourceID int, limit int) (err error)
 	addTenant(id string, MAC string) (err error)
-	getTenantNoCache(id string) (t *tenant, err error)
-	getTenantsNoCache() ([]*tenant, error)
+	getTenant(id string) (t *tenant, err error)
+	getTenants() ([]*tenant, error)
 	updateTenant(t *tenant) (err error)
 	releaseTenantIP(tenantID string, subnetInt int, rest int) (err error)
 	claimTenantIP(tenantID string, subnetInt int, rest int) (err error)
@@ -432,7 +432,7 @@ func (ds *Datastore) getTenant(id string) (*tenant, error) {
 		return t, nil
 	}
 
-	return ds.db.getTenantNoCache(id)
+	return ds.db.getTenant(id)
 }
 
 // GetTenant returns details about a tenant referenced by the uuid
@@ -477,7 +477,7 @@ func (ds *Datastore) getWorkload(id string) (*workload, error) {
 		return wl, nil
 	}
 
-	return ds.db.getWorkloadNoCache(id)
+	return ds.db.getWorkload(id)
 }
 
 // GetWorkload returns details about a specific workload referenced by id
@@ -504,7 +504,7 @@ func (ds *Datastore) getWorkloads() ([]*workload, error) {
 	}
 	ds.workloadsLock.RUnlock()
 
-	return ds.db.getWorkloadsNoCache()
+	return ds.db.getWorkloads()
 }
 
 // GetWorkloads returns all known tenant workloads
@@ -630,7 +630,7 @@ func (ds *Datastore) getTenants() ([]*tenant, error) {
 
 	ds.tenantsLock.RUnlock()
 
-	return ds.db.getTenantsNoCache()
+	return ds.db.getTenants()
 }
 
 // GetAllTenants returns all the tenants from the datastore.

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -174,7 +174,7 @@ func BenchmarkGetTenantNoCache(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_, err = ds.db.getTenantNoCache(tuuid)
+		_, err = ds.db.getTenant(tuuid)
 		if err != nil {
 			b.Error(err)
 		}

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -134,7 +134,7 @@ func (db *MemoryDB) getCNCIWorkloadID() (string, error) {
 	return "", fmt.Errorf("CNCI not found")
 }
 
-func (db *MemoryDB) getWorkloadNoCache(id string) (*workload, error) {
+func (db *MemoryDB) getWorkload(id string) (*workload, error) {
 	workload, ok := db.workloads[id]
 	if !ok {
 		return nil, fmt.Errorf("Workload %s not found", id)
@@ -142,7 +142,7 @@ func (db *MemoryDB) getWorkloadNoCache(id string) (*workload, error) {
 	return workload, nil
 }
 
-func (db *MemoryDB) getWorkloadsNoCache() ([]*workload, error) {
+func (db *MemoryDB) getWorkloads() ([]*workload, error) {
 	var workloads []*workload
 	for _, wl := range db.workloads {
 		workloads = append(workloads, wl)
@@ -168,7 +168,7 @@ func (db *MemoryDB) addTenant(id string, MAC string) error {
 	return nil
 }
 
-func (db *MemoryDB) getTenantNoCache(id string) (*tenant, error) {
+func (db *MemoryDB) getTenant(id string) (*tenant, error) {
 	tenant, ok := db.tenants[id]
 	if !ok {
 		return nil, fmt.Errorf("Tenant %s not found", id)
@@ -176,7 +176,7 @@ func (db *MemoryDB) getTenantNoCache(id string) (*tenant, error) {
 	return tenant, nil
 }
 
-func (db *MemoryDB) getTenantsNoCache() ([]*tenant, error) {
+func (db *MemoryDB) getTenants() ([]*tenant, error) {
 	var tenants []*tenant
 	for _, t := range db.tenants {
 		tenants = append(tenants, t)

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -213,7 +213,7 @@ func (db *MemoryDB) addInstance(instance *types.Instance) error {
 	return nil
 }
 
-func (db *MemoryDB) removeInstance(instanceID string) error {
+func (db *MemoryDB) deleteInstance(instanceID string) error {
 	return nil
 }
 
@@ -249,7 +249,7 @@ func (db *MemoryDB) getAllBlockData() (map[string]types.BlockData, error) {
 	return db.blockDevices, nil
 }
 
-func (db *MemoryDB) createBlockData(data types.BlockData) error {
+func (db *MemoryDB) addBlockData(data types.BlockData) error {
 	return nil
 }
 
@@ -265,7 +265,7 @@ func (db *MemoryDB) getTenantDevices(tenantID string) (map[string]types.BlockDat
 	return nil, nil
 }
 
-func (db *MemoryDB) createStorageAttachment(a types.StorageAttachment) error {
+func (db *MemoryDB) addStorageAttachment(a types.StorageAttachment) error {
 	return nil
 }
 
@@ -277,7 +277,7 @@ func (db *MemoryDB) deleteStorageAttachment(ID string) error {
 	return nil
 }
 
-func (db *MemoryDB) createPool(pool types.Pool) error {
+func (db *MemoryDB) addPool(pool types.Pool) error {
 	return nil
 }
 
@@ -293,7 +293,7 @@ func (db *MemoryDB) getAllPools() map[string]types.Pool {
 	return make(map[string]types.Pool)
 }
 
-func (db *MemoryDB) createMappedIP(m types.MappedIP) error {
+func (db *MemoryDB) addMappedIP(m types.MappedIP) error {
 	return nil
 }
 

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -217,7 +217,7 @@ func (db *MemoryDB) removeInstance(instanceID string) error {
 	return nil
 }
 
-func (db *MemoryDB) addNodeStatDB(stat payloads.Stat) error {
+func (db *MemoryDB) addNodeStat(stat payloads.Stat) error {
 	return nil
 }
 
@@ -225,7 +225,7 @@ func (db *MemoryDB) getNodeSummary() ([]*types.NodeSummary, error) {
 	return nil, nil
 }
 
-func (db *MemoryDB) addInstanceStatsDB(stats []payloads.InstanceStat, nodeID string) error {
+func (db *MemoryDB) addInstanceStats(stats []payloads.InstanceStat, nodeID string) error {
 	return nil
 }
 

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -1799,7 +1799,7 @@ func (ds *sqliteDB) addInstance(instance *types.Instance) error {
 	return ds.addUsage(instance.ID, instance.Usage)
 }
 
-func (ds *sqliteDB) removeInstance(instanceID string) error {
+func (ds *sqliteDB) deleteInstance(instanceID string) error {
 	datastore := ds.getTableDB("instances")
 
 	ds.dbLock.Lock()
@@ -2414,7 +2414,7 @@ func (ds *sqliteDB) getAllBlockData() (map[string]types.BlockData, error) {
 	return devices, nil
 }
 
-func (ds *sqliteDB) createBlockData(data types.BlockData) error {
+func (ds *sqliteDB) addBlockData(data types.BlockData) error {
 	ds.dbLock.Lock()
 	err := ds.create("block_data", data.ID, data.TenantID, data.Size, string(data.State), data.CreateTime.Format(time.RFC3339Nano), data.Name, data.Description)
 	ds.dbLock.Unlock()
@@ -2471,7 +2471,7 @@ func (ds *sqliteDB) deleteBlockData(ID string) error {
 	return err
 }
 
-func (ds *sqliteDB) createStorageAttachment(a types.StorageAttachment) error {
+func (ds *sqliteDB) addStorageAttachment(a types.StorageAttachment) error {
 	datastore := ds.getTableDB("attachments")
 
 	ds.dbLock.Lock()
@@ -2554,7 +2554,7 @@ func (ds *sqliteDB) deleteStorageAttachment(ID string) error {
 }
 
 // this is here just for readability.
-func (ds *sqliteDB) createPool(pool types.Pool) error {
+func (ds *sqliteDB) addPool(pool types.Pool) error {
 	return ds.updatePool(pool)
 }
 
@@ -2851,7 +2851,7 @@ func (ds *sqliteDB) getPoolAddresses(poolID string) ([]types.ExternalIP, error) 
 	return IPs, nil
 }
 
-func (ds *sqliteDB) createMappedIP(m types.MappedIP) error {
+func (ds *sqliteDB) addMappedIP(m types.MappedIP) error {
 	datastore := ds.getTableDB("mapped_ips")
 
 	ds.dbLock.Lock()

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -1872,7 +1872,7 @@ func (ds *sqliteDB) addUsage(instanceID string, usage map[string]int) error {
 	return nil
 }
 
-func (ds *sqliteDB) addNodeStatDB(stat payloads.Stat) error {
+func (ds *sqliteDB) addNodeStat(stat payloads.Stat) error {
 	datastore := ds.getTableDB("node_statistics")
 
 	ds.tdbLock.Lock()
@@ -1897,7 +1897,7 @@ func (ds *sqliteDB) addNodeStatDB(stat payloads.Stat) error {
 	return err
 }
 
-func (ds *sqliteDB) addInstanceStatsDB(stats []payloads.InstanceStat, nodeID string) error {
+func (ds *sqliteDB) addInstanceStats(stats []payloads.InstanceStat, nodeID string) error {
 	datastore := ds.getTableDB("instance_statistics")
 
 	ds.tdbLock.Lock()

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -942,7 +942,7 @@ func (ds *sqliteDB) getCNCIWorkloadID() (string, error) {
 	return ID, nil
 }
 
-func (ds *sqliteDB) getConfigNoCache(ID string) (string, error) {
+func (ds *sqliteDB) getConfig(ID string) (string, error) {
 	var configFile string
 
 	db := ds.getTableDB("workload_template")
@@ -1155,7 +1155,7 @@ func (ds *sqliteDB) addTenant(ID string, MAC string) error {
 	return err
 }
 
-func (ds *sqliteDB) getTenantNoCache(ID string) (*tenant, error) {
+func (ds *sqliteDB) getTenant(ID string) (*tenant, error) {
 	query := `SELECT	tenants.id,
 				tenants.name,
 				tenants.cnci_id,
@@ -1205,7 +1205,7 @@ func (ds *sqliteDB) getTenantNoCache(ID string) (*tenant, error) {
 	return t, err
 }
 
-func (ds *sqliteDB) getWorkloadNoCache(id string) (*workload, error) {
+func (ds *sqliteDB) getWorkload(id string) (*workload, error) {
 	datastore := ds.db
 
 	query := `SELECT id,
@@ -1232,7 +1232,7 @@ func (ds *sqliteDB) getWorkloadNoCache(id string) (*workload, error) {
 
 	work.VMType = payloads.Hypervisor(VMType)
 
-	work.Config, err = ds.getConfigNoCache(id)
+	work.Config, err = ds.getConfig(id)
 	if err != nil {
 		return nil, err
 	}
@@ -1250,7 +1250,7 @@ func (ds *sqliteDB) getWorkloadNoCache(id string) (*workload, error) {
 	return work, nil
 }
 
-func (ds *sqliteDB) getWorkloadsNoCache() ([]*workload, error) {
+func (ds *sqliteDB) getWorkloads() ([]*workload, error) {
 	var workloads []*workload
 
 	datastore := ds.db
@@ -1281,7 +1281,7 @@ func (ds *sqliteDB) getWorkloadsNoCache() ([]*workload, error) {
 			return nil, err
 		}
 
-		wl.Config, err = ds.getConfigNoCache(wl.ID)
+		wl.Config, err = ds.getConfig(wl.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -1309,7 +1309,7 @@ func (ds *sqliteDB) getWorkloadsNoCache() ([]*workload, error) {
 func (ds *sqliteDB) updateWorkload(w workload) error {
 	db := ds.getTableDB("workload_template")
 
-	workloads, err := ds.getWorkloadsNoCache()
+	workloads, err := ds.getWorkloads()
 	if err != nil {
 		return err
 	}
@@ -1402,7 +1402,7 @@ func (ds *sqliteDB) updateTenant(t *tenant) error {
 	return err
 }
 
-func (ds *sqliteDB) getTenantsNoCache() ([]*tenant, error) {
+func (ds *sqliteDB) getTenants() ([]*tenant, error) {
 	var tenants []*tenant
 
 	datastore := ds.getTableDB("tenants")

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -854,12 +854,12 @@ func (ds *sqliteDB) Connect(persistentURI string, transientURI string) error {
 		},
 	})
 
-	datastore, err := ds.sqliteConnect(transientURI, persistentURI, pSQLLiteConfig)
+	db, err := ds.sqliteConnect(transientURI, persistentURI, pSQLLiteConfig)
 	if err != nil {
 		return err
 	}
 
-	ds.db = datastore
+	ds.db = db
 	ds.dbName = persistentURI
 
 	sql.Register(persistentURI, &sqlite3.SQLiteDriver{
@@ -870,12 +870,12 @@ func (ds *sqliteDB) Connect(persistentURI string, transientURI string) error {
 		},
 	})
 
-	datastore, err = ds.sqliteConnect(persistentURI, transientURI, pSQLLiteConfig)
+	tdb, err := ds.sqliteConnect(persistentURI, transientURI, pSQLLiteConfig)
 	if err != nil {
 		return err
 	}
 
-	ds.tdb = datastore
+	ds.tdb = tdb
 	ds.tdbName = transientURI
 
 	return err

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -74,7 +74,7 @@ func TestSQLiteDBGetTenantDevices(t *testing.T) {
 		CreateTime:  time.Now(),
 	}
 
-	err = db.createBlockData(data)
+	err = db.addBlockData(data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestSQLiteDBGetTenantWithStorage(t *testing.T) {
 		CreateTime:  time.Now(),
 	}
 
-	err = db.createBlockData(data)
+	err = db.addBlockData(data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func TestSQLiteDBGetAllBlockData(t *testing.T) {
 		CreateTime:  time.Now(),
 	}
 
-	err = db.createBlockData(data)
+	err = db.addBlockData(data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +197,7 @@ func TestSQLiteDBDeleteBlockData(t *testing.T) {
 		CreateTime:  time.Now(),
 	}
 
-	err = db.createBlockData(data)
+	err = db.addBlockData(data)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,7 +233,7 @@ func TestSQLiteDBGetAllStorageAttachments(t *testing.T) {
 		Ephemeral:  false,
 	}
 
-	err = db.createStorageAttachment(a)
+	err = db.addStorageAttachment(a)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +260,7 @@ func TestSQLiteDBGetAllStorageAttachments(t *testing.T) {
 		Ephemeral:  true,
 	}
 
-	err = db.createStorageAttachment(b)
+	err = db.addStorageAttachment(b)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -307,7 +307,7 @@ func TestCreatePool(t *testing.T) {
 		Name: "test",
 	}
 
-	err = db.createPool(pool)
+	err = db.addPool(pool)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -336,7 +336,7 @@ func TestUpdatePool(t *testing.T) {
 		Name: "test",
 	}
 
-	err = db.createPool(pool)
+	err = db.addPool(pool)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -373,7 +373,7 @@ func TestDeletePool(t *testing.T) {
 		Name: "test",
 	}
 
-	err = db.createPool(pool)
+	err = db.addPool(pool)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -417,7 +417,7 @@ func TestCreateSubnet(t *testing.T) {
 		Name: "test",
 	}
 
-	err = db.createPool(pool)
+	err = db.addPool(pool)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -474,7 +474,7 @@ func TestDeleteSubnet(t *testing.T) {
 
 	pool.Subnets = append(pool.Subnets, subnet)
 
-	err = db.createPool(pool)
+	err = db.addPool(pool)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -521,7 +521,7 @@ func TestCreateAddress(t *testing.T) {
 
 	pool.IPs = append(pool.IPs, IP)
 
-	err = db.createPool(pool)
+	err = db.addPool(pool)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -562,7 +562,7 @@ func TestDeleteAddress(t *testing.T) {
 
 	pool.IPs = append(pool.IPs, IP)
 
-	err = db.createPool(pool)
+	err = db.addPool(pool)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -620,7 +620,7 @@ func TestCreateMappedIP(t *testing.T) {
 		Name: "test",
 	}
 
-	err = db.createPool(pool)
+	err = db.addPool(pool)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -635,7 +635,7 @@ func TestCreateMappedIP(t *testing.T) {
 		PoolName:   pool.Name,
 	}
 
-	err = db.createMappedIP(m)
+	err = db.addMappedIP(m)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -678,7 +678,7 @@ func TestDeleteMappedIP(t *testing.T) {
 		Name: "test",
 	}
 
-	err = db.createPool(pool)
+	err = db.addPool(pool)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -693,7 +693,7 @@ func TestDeleteMappedIP(t *testing.T) {
 		PoolName:   pool.Name,
 	}
 
-	err = db.createMappedIP(m)
+	err = db.addMappedIP(m)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -126,7 +126,7 @@ func TestSQLiteDBGetTenantWithStorage(t *testing.T) {
 	}
 
 	// make sure our query works.
-	tenant, err := db.getTenantNoCache(data.TenantID)
+	tenant, err := db.getTenant(data.TenantID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -724,7 +724,7 @@ func TestSQLiteDBGetAllWorkloads(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wls, err := db.getWorkloadsNoCache()
+	wls, err := db.getWorkloads()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -734,7 +734,7 @@ func TestSQLiteDBGetAllWorkloads(t *testing.T) {
 	}
 
 	for _, wl := range wls {
-		wl2, err := db.getWorkloadNoCache(wl.ID)
+		wl2, err := db.getWorkload(wl.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -755,7 +755,7 @@ func createTestTenant(db persistentStore, t *testing.T) *tenant {
 		t.Fatal(err)
 	}
 
-	tn, err := db.getTenantNoCache(tid)
+	tn, err := db.getTenant(tid)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -775,7 +775,7 @@ func TestSQLiteDBTestTenants(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tns, err := db.getTenantsNoCache()
+	tns, err := db.getTenants()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -787,7 +787,7 @@ func TestSQLiteDBTestTenants(t *testing.T) {
 	_ = createTestTenant(db, t)
 	_ = createTestTenant(db, t)
 
-	tns, err = db.getTenantsNoCache()
+	tns, err = db.getTenants()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -797,7 +797,7 @@ func TestSQLiteDBTestTenants(t *testing.T) {
 	}
 
 	for _, tn := range tns {
-		tn2, err := db.getTenantNoCache(tn.ID)
+		tn2, err := db.getTenant(tn.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1026,7 +1026,7 @@ users:
 		t.Fatal(err)
 	}
 
-	wl2, err := db.getWorkloadNoCache(wl.ID)
+	wl2, err := db.getWorkload(wl.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -946,7 +946,7 @@ func TestSQLiteDBInstanceStats(t *testing.T) {
 
 	nodeID := uuid.Generate().String()
 
-	err = db.addInstanceStatsDB(stats, nodeID)
+	err = db.addInstanceStats(stats, nodeID)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
In #921 I mention a few areas where the database code can be tidied-up from my previous digs into that code. This PR addresses some of the easiest changes via automated renames.