### PR TITLE
small certificate related cleanups

### DIFF
--- a/ciao-cert/README.md
+++ b/ciao-cert/README.md
@@ -139,3 +139,23 @@ Wrong certificate or missing/mismatched role OID
 If this is observed, insure your client certificates are created with the
 correct roles as indicated above, and your client binaries are run with
 configuration using the correct certificate.
+
+### Certificate signed by unknown authority
+
+Ciao cluster certificates are signed by a common certificate authority
+(CA).  The above documentation example creates a trust anchor CA with
+the ```-anchor```, but you can also use a pre-existing one via the
+```-anchor-cert``` option.
+
+Either way, for ciao components to correctly operate, the CA's
+certificate must be in the system trust store on each host running a
+ciao component.  If it is not, you will see cluster log messages, eg:
+```
+x509: certificate signed by unknown authority
+```
+and the cluster will not form.
+
+Depending on your linux distribution, golang runtime, and local IT
+policies, the correct way to add your cluster's CA certificate to
+your cluster systems' trust stores will vary.  Consult your applicable
+documentation.

--- a/ciao-cert/README.md
+++ b/ciao-cert/README.md
@@ -123,3 +123,19 @@ For host:       ciao-ctl.intel.com
 For IP:         192.168.1.118
 Private key:    RSA PRIVATE KEY
 ```
+
+## Dealing with certificate issues
+
+### Role mismatches
+
+Ciao cluster certificates implement a role base access control (RBAC) system of
+cluster membership.  If a ciao cluster client attempts access using a
+certificate whose embedded role does not match the SSNTP client connection
+indicated role, the access will be disallowed.  The cluster logs will show
+a message, eg:
+```
+Wrong certificate or missing/mismatched role OID
+```
+If this is observed, insure your client certificates are created with the
+correct roles as indicated above, and your client binaries are run with
+configuration using the correct certificate.

--- a/ssntp/ssntp.go
+++ b/ssntp/ssntp.go
@@ -1068,7 +1068,7 @@ func GetOIDsFromRole(role Role) ([]asn1.ObjectIdentifier, error) {
 }
 
 func verifyRole(conn interface{}, role Role) (bool, error) {
-	var oidError = fmt.Errorf("**** TEMPORARY WARNING ****\n*** Wrong certificate or missing/mismatched role OID ***\nIn order to fix this, use the -role option when generating your certificates with the ciao-cert tool")
+	var oidError = fmt.Errorf("Wrong certificate or missing/mismatched role OID")
 	switch tlsConn := conn.(type) {
 	case *tls.Conn:
 		state := tlsConn.ConnectionState()


### PR DESCRIPTION
Over the past weeks I've bumped into a few little oddities around certs and am just doing some cleanup in response.  This PR simplifies an old and very verbose error message and incrementally extends documentation.