### PR TITLE
ciao-launcher: Add more docker unit tests

### DIFF
--- a/ciao-launcher/container_manager.go
+++ b/ciao-launcher/container_manager.go
@@ -33,6 +33,9 @@ type containerManager interface {
 		*network.NetworkingConfig, string) (types.ContainerCreateResponse, error)
 	ContainerRemove(context.Context, types.ContainerRemoveOptions) error
 	ContainerStart(context.Context, string) error
+	ContainerInspect(context.Context, string) (types.ContainerJSON, error)
 	ContainerInspectWithRaw(context.Context, string, bool) (types.ContainerJSON, []byte, error)
 	ContainerStats(context.Context, string, bool) (io.ReadCloser, error)
+	ContainerKill(context.Context, string, string) error
+	ContainerWait(context.Context, string) (int, error)
 }


### PR DESCRIPTION
This commit adds the following new docker unit tests:

- TestDockerCreateImageFail
- TestDockerCreateImageWithVolumes
- TestDockerCreateImageWithResources
- TestDockerMonitorVM
- TestDockerMonitorVMClose
- TestDockerStats

It improves launcher's unit test coverage to 52.6%.

Partial fix for issue #1

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>