### PR TITLE
Populate volume size

### DIFF
--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -169,7 +169,6 @@ func addBlockDevice(c *controller, tenant string, instanceID string, device stor
 	// a block device is bootable.
 	data := types.BlockData{
 		BlockDevice: device,
-		Size:        s.Size,
 		CreateTime:  time.Now(),
 		TenantID:    tenant,
 		Name:        fmt.Sprintf("Storage for instance: %s", instanceID),

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -1346,7 +1346,6 @@ func TestAttachVolumeFailure(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    newTenant.ID,
 		CreateTime:  time.Now(),
@@ -1403,7 +1402,6 @@ func TestDetachVolumeFailure(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    newTenant.ID,
 		CreateTime:  time.Now(),
@@ -1495,7 +1493,6 @@ func TestAddBlockDevice(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    newTenant.ID,
 		CreateTime:  time.Now(),
@@ -1537,7 +1534,6 @@ func TestDeleteBlockDevice(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    newTenant.ID,
 		CreateTime:  time.Now(),
@@ -1585,7 +1581,6 @@ func TestUpdateBlockDevice(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    newTenant.ID,
 		CreateTime:  time.Now(),
@@ -1649,7 +1644,6 @@ func TestUpdateBlockDeviceErr(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    newTenant.ID,
 		CreateTime:  time.Now(),
@@ -1674,7 +1668,6 @@ func TestCreateStorageAttachment(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    tenant.ID,
 		CreateTime:  time.Now(),
@@ -1736,7 +1729,6 @@ func TestUpdateStorageAttachmentExisting(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    tenant.ID,
 		CreateTime:  time.Now(),
@@ -1804,7 +1796,6 @@ func TestUpdateStorageAttachmentNotExisting(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    tenant.ID,
 		CreateTime:  time.Now(),
@@ -1848,7 +1839,6 @@ func TestUpdateStorageAttachmentDeleted(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    tenant.ID,
 		CreateTime:  time.Now(),
@@ -1903,7 +1893,6 @@ func TestGetStorageAttachment(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    tenant.ID,
 		CreateTime:  time.Now(),
@@ -1960,7 +1949,6 @@ func TestGetStorageAttachmentError(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    tenant.ID,
 		CreateTime:  time.Now(),
@@ -2003,7 +1991,6 @@ func TestDeleteStorageAttachment(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    tenant.ID,
 		CreateTime:  time.Now(),
@@ -2070,7 +2057,6 @@ func TestDeleteStorageAttachmentError(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    tenant.ID,
 		CreateTime:  time.Now(),
@@ -2142,7 +2128,6 @@ func TestGetVolumeAttachments(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    tenant.ID,
 		CreateTime:  time.Now(),

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -68,7 +68,6 @@ func TestSQLiteDBGetTenantDevices(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    uuid.Generate().String(),
 		CreateTime:  time.Now(),
@@ -114,7 +113,6 @@ func TestSQLiteDBGetTenantWithStorage(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    tenantID,
 		CreateTime:  time.Now(),
@@ -155,7 +153,6 @@ func TestSQLiteDBGetAllBlockData(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    uuid.Generate().String(),
 		CreateTime:  time.Now(),
@@ -191,7 +188,6 @@ func TestSQLiteDBDeleteBlockData(t *testing.T) {
 
 	data := types.BlockData{
 		BlockDevice: blockDevice,
-		Size:        0,
 		State:       types.Available,
 		TenantID:    uuid.Generate().String(),
 		CreateTime:  time.Now(),

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -71,7 +71,6 @@ func (c *controller) CreateVolume(tenant string, req block.RequestedVolume) (blo
 	// you should modify BlockData to include a "bootable" flag.
 	data := types.BlockData{
 		BlockDevice: bd,
-		Size:        req.Size,
 		CreateTime:  time.Now(),
 		TenantID:    tenant,
 		State:       types.Available,

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -258,7 +258,6 @@ const (
 type BlockData struct {
 	storage.BlockDevice
 	TenantID    string     // the tenant who owns this volume
-	Size        int        // size in GB
 	State       BlockState // status of
 	CreateTime  time.Time  // when we created the volume
 	Name        string     // a human readable name for this volume

--- a/ciao-storage/block.go
+++ b/ciao-storage/block.go
@@ -47,5 +47,5 @@ type BlockDevice struct {
 	Local     bool   // local (ephemeral) or volume service backed
 	Swap      bool   // linux swap device (attempt swapon via cloudinit)
 	Tag       string // arbitrary text identifier
-	Size      int    // gigabyte size for autocreation
+	Size      int    // size in GiB
 }

--- a/ciao-storage/noop.go
+++ b/ciao-storage/noop.go
@@ -29,7 +29,7 @@ type NoopDriver struct {
 
 // CreateBlockDevice pretends to create a block device.
 func (d *NoopDriver) CreateBlockDevice(volumeUUID string, image string, size int) (BlockDevice, error) {
-	return BlockDevice{ID: uuid.Generate().String()}, nil
+	return BlockDevice{ID: uuid.Generate().String(), Size: size}, nil
 }
 
 // CreateBlockDeviceFromSnapshot pretends to create a block device snapshot


### PR DESCRIPTION
Populate the volume size in GiB when creating volumes via all mechanisms. Push the responsibility for setting the size on storage.BlockDevice to the backend.