### PR TITLE
bat: Enable static analysis on BAT tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,14 @@ script:
    - go list ./... | grep -v github.com/01org/ciao/vendor | xargs go list -f '{{.Dir}}' | xargs gocyclo -over 15
    - go list ./... | grep -v github.com/01org/ciao/vendor | xargs go list -f '{{.Dir}}' | xargs -L 1 ineffassign
    - go list ./... | grep -v github.com/01org/ciao/vendor | xargs go list -f '{{.Dir}}' | xargs gofmt -s -l | wc -l | xargs -I % bash -c "test % -eq 0"
+   - cd _release/bat
+   - go list ./... | xargs -t go vet
+   - go list ./... | xargs -tL 1 golint -set_exit_status
+   - go list ./... | xargs go list -f '{{.Dir}}/*.go' | xargs -I % bash -c "misspell -error %"
+   - go list ./... | xargs go list -f '{{.Dir}}' | xargs gocyclo -over 15
+   - go list ./... | xargs go list -f '{{.Dir}}' | xargs -L 1 ineffassign
+   - go list ./... | xargs go list -f '{{.Dir}}' | xargs gofmt -s -l | wc -l | xargs -I % bash -c "test % -eq 0"
+   - cd ../..
    - sudo mkdir -p /var/lib/ciao/instances
    - sudo mkdir -p /var/lib/ciao/data/controller/{workloads,tables}
    - sudo chmod 0777 -R /var/lib/ciao

--- a/_release/bat/base_bat/base_bat.go
+++ b/_release/bat/base_bat/base_bat.go
@@ -14,5 +14,5 @@
 // limitations under the License.
 //
 
-// base_bat is a placeholder package for the basic BAT tests.
-package base_bat
+// Package basebat is a placeholder package for the basic BAT tests.
+package basebat

--- a/_release/bat/base_bat/base_bat_test.go
+++ b/_release/bat/base_bat/base_bat_test.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package base_bat
+package basebat
 
 import (
 	"context"
@@ -47,7 +47,7 @@ func TestGetTenants(t *testing.T) {
 //
 // Retrieve the cluster status.
 //
-// Cluster status is retrived successfully, the cluster contains more than one
+// Cluster status is retrieved successfully, the cluster contains more than one
 // node and all nodes are ready.
 func TestGetClusterStatus(t *testing.T) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
@@ -215,7 +215,7 @@ func TestGetCNCIs(t *testing.T) {
 // valid.  Finally, delete the instances.
 //
 // Instances should be created and scheduled.  Information about the
-// instances should be sucessfully retrieved and this information should
+// instances should be successfully retrieved and this information should
 // contain valid fields.
 func TestGetAllInstances(t *testing.T) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
@@ -312,7 +312,7 @@ func TestDeleteAllInstances(t *testing.T) {
 }
 
 // TestMain ensures that all instances have been deleted when the tests finish.
-// The individual tests do try to clean up after themsevles but there's always
+// The individual tests do try to clean up after themselves but there's always
 // the chance that a bug somewhere in ciao could lead to something not getting
 // deleted.
 func TestMain(m *testing.M) {

--- a/_release/bat/image_bat/image_bat.go
+++ b/_release/bat/image_bat/image_bat.go
@@ -14,5 +14,5 @@
 // limitations under the License.
 //
 
-// image_bat is a placeholder package for the image service BAT tests.
-package image_bat
+// Package imagebat is a placeholder package for the image service BAT tests.
+package imagebat

--- a/_release/bat/image_bat/image_bat_test.go
+++ b/_release/bat/image_bat/image_bat_test.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-package image_bat
+package imagebat
 
 import (
 	"context"

--- a/_release/bat/storage_bat/ceph_test.go
+++ b/_release/bat/storage_bat/ceph_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage_bat
+package storagebat
 
 import (
 	"os"

--- a/_release/bat/storage_bat/storage_bat.go
+++ b/_release/bat/storage_bat/storage_bat.go
@@ -14,5 +14,5 @@
 // limitations under the License.
 //
 
-// storage_bat is a placeholder package for storage related BAT tests.
-package storage_bat
+// Package storagebat is a placeholder package for storage related BAT tests.
+package storagebat

--- a/_release/bat/storage_bat/storage_bat_test.go
+++ b/_release/bat/storage_bat/storage_bat_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage_bat
+package storagebat
 
 import (
 	"context"
@@ -109,7 +109,7 @@ func checkBootedVolume(ctx context.Context, t *testing.T, tenant, instanceID str
 // ciao-cli, retrieve information about the volume, delete the instance and
 // check that the volume has also been deleted.
 //
-// The instance should be created succesfully.  It should have one volume attached.
+// The instance should be created successfully.  It should have one volume attached.
 // The status of the volume should be in-use.  The volume should be deleted with
 // the instance.
 func TestBootFromVolume(t *testing.T) {
@@ -146,7 +146,7 @@ func TestBootFromVolume(t *testing.T) {
 // Boot a VM which has no data volumes attached and stop the instance.  Check
 // the status of the bootable volume.  Delete the instance.
 //
-// The instance should be created succesfully.  It should have one volume attached.
+// The instance should be created successfully.  It should have one volume attached.
 // The status of the volume should be in-use.
 func TestStoppedInstance(t *testing.T) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
@@ -593,8 +593,8 @@ func TestDoubleAttach(t *testing.T) {
 // Boot a VM which has no data volumes attached and stop the instance.  Create
 // and attach a volume.  Delete the instance and the volume.
 //
-// The instance should be created and stopped succesfully.  The volume should be
-// created and attached succesfully.  The volume and instance should be deleted
+// The instance should be created and stopped successfully.  The volume should be
+// created and attached successfully.  The volume and instance should be deleted
 // without error.
 func TestAttachToStoppedInstance(t *testing.T) {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)


### PR DESCRIPTION
The static analysis tools were not executed on the BAT tests as they
are stored in the _release folder.  This commit ensures that the tests
do get run on the BAT test code.

Enabling the tools revealed some errors.  This commit also adresses these
failures.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>