### PR TITLE
.gitignore: ignore vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 *~
 _DeploymentAndDistroPackaging/ansible/admin-ciaorc
 _DeploymentAndDistroPackaging/ansible/ceph/


### PR DESCRIPTION
Previous to this commit, `git status` shows vim swap files (*.swp) as
untracked files, which can lead to being added accidentally in commits.

This commit makes git to ignore those files, reducing the changes of add
them by accident.

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>