### PR TITLE
ciao-controller: Support multiple storage resources per workload

### DIFF
--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -191,6 +191,7 @@ func optToReq(opt workloadOptions, req *types.Workload) error {
 	req.ImageName = opt.ImageName
 	req.ImageID = opt.ImageID
 	req.Config = config
+	req.Storage = []types.StorageResource{}
 
 	for _, disk := range opt.Disks {
 		res := types.StorageResource{
@@ -219,10 +220,7 @@ func optToReq(opt workloadOptions, req *types.Workload) error {
 			res.SourceType = types.Empty
 		}
 
-		// due to the fact that types.Workload only supports
-		// one StorageResource, we have to do this for now.
-		req.Storage = &res
-		break
+		req.Storage = append(req.Storage, res)
 	}
 
 	// all default resources are required.

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -1250,7 +1250,7 @@ func TestStorageConfig(t *testing.T) {
 	}
 
 	// a temporary in memory filesystem?
-	s := &types.StorageResource{
+	s := types.StorageResource{
 		ID:         "",
 		Bootable:   true,
 		Ephemeral:  false,
@@ -1258,7 +1258,7 @@ func TestStorageConfig(t *testing.T) {
 		SourceID:   info.Name(),
 	}
 
-	wls[0].Storage = s
+	wls[0].Storage = []types.StorageResource{s}
 
 	id := uuid.Generate()
 
@@ -1268,7 +1268,7 @@ func TestStorageConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wls[0].Storage = nil
+	wls[0].Storage = []types.StorageResource{}
 }
 
 func createTestVolume(tenantID string, size int, t *testing.T) string {

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -359,12 +359,14 @@ func newConfig(ctl *controller, wl *types.Workload, instanceID string, tenantID 
 	}
 
 	// handle storage resources in workload definition
-	if wl.Storage != nil {
-		workloadStorage, err := getStorage(ctl, *wl.Storage, tenantID, instanceID)
-		if err != nil {
-			return config, err
+	if len(wl.Storage) > 0 {
+		for i := range wl.Storage {
+			workloadStorage, err := getStorage(ctl, wl.Storage[i], tenantID, instanceID)
+			if err != nil {
+				return config, err
+			}
+			storage = append(storage, workloadStorage)
 		}
-		storage = append(storage, workloadStorage)
 	}
 
 	// hardcode persistence until changes can be made to workload

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -120,7 +120,7 @@ type persistentStore interface {
 	getBatchFrameStatistics(label string) (stats []types.BatchFrameStat, err error)
 
 	// storage interfaces
-	getWorkloadStorage(ID string) (*types.StorageResource, error)
+	getWorkloadStorage(ID string) ([]types.StorageResource, error)
 	getAllBlockData() (map[string]types.BlockData, error)
 	addBlockData(data types.BlockData) error
 	updateBlockData(data types.BlockData) error

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -241,8 +241,8 @@ func (db *MemoryDB) getBatchFrameStatistics(label string) ([]types.BatchFrameSta
 	return nil, nil
 }
 
-func (db *MemoryDB) getWorkloadStorage(ID string) (*types.StorageResource, error) {
-	return nil, nil
+func (db *MemoryDB) getWorkloadStorage(ID string) ([]types.StorageResource, error) {
+	return []types.StorageResource{}, nil
 }
 
 func (db *MemoryDB) getAllBlockData() (map[string]types.BlockData, error) {

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -1000,7 +1000,7 @@ users:
 		ImageName:   "",
 		Config:      testConfig,
 		Defaults:    []payloads.RequestedResource{cpus, mem, disk},
-		Storage:     &storage,
+		Storage:     []types.StorageResource{storage},
 	}
 
 	wl := workload{

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -80,7 +80,7 @@ type Workload struct {
 	ImageName   string                       `json:"image_name"`
 	Config      string                       `json:"config"`
 	Defaults    []payloads.RequestedResource `json:"defaults"`
-	Storage     *StorageResource             `json:"storage"`
+	Storage     []StorageResource            `json:"storage"`
 }
 
 // WorkloadResponse will be returned from /workloads apis


### PR DESCRIPTION
A prerequisite of converting a running instance to a workload is being
able to support multiple types.StorageResource per workload.  This
change enables that.

Creating a workload from fedora_cloud_disk.yaml and then creating an
instance from that now shows two volumes created.

Fixes: #945

Signed-off-by: Rob Bradford <robert.bradford@intel.com>