### PR TITLE
Add ciao-webui support to ciao-down and Single VM

### DIFF
--- a/ciao-launcher/docker_network.go
+++ b/ciao-launcher/docker_network.go
@@ -38,7 +38,7 @@ func createDockerVnic(vnicCfg *libsnnet.VnicConfig) (*libsnnet.Vnic, *libsnnet.S
 	dockerNetworkLock.Lock()
 	defer dockerNetworkLock.Unlock()
 	vnic, event, info, err := cnNet.CreateVnic(vnicCfg)
-	if info.CNContainerEvent != libsnnet.ContainerNetworkAdd || err != nil {
+	if err != nil || info.CNContainerEvent != libsnnet.ContainerNetworkAdd {
 		return vnic, event, info, err
 	}
 

--- a/testutil/ciao-down/README.md
+++ b/testutil/ciao-down/README.md
@@ -48,9 +48,7 @@ An example of ciao-down prepare is given below:
 
 ```
 $ ./ciao-down prepare
-Checking environment
-Installing host dependencies
-OS Detected: ubuntu
+Booting VM with 7 GB RAM and 4 cpus
 Booting VM : [OK]
 Downloading Go : [OK]
 Unpacking Go : [OK]
@@ -60,13 +58,17 @@ Retrieving updated list of packages : [OK]
 Upgrading : [OK]
 Installing Docker : [OK]
 Installing GCC : [OK]
+Installing Make : [OK]
 Installing QEMU : [OK]
 Installing xorriso : [OK]
 Installing ceph-common : [OK]
 Installing Openstack client : [OK]
+Updating NodeJS sources : [OK]
+Installing NodeJS : [OK]
 Auto removing unused components : [OK]
 Building ciao : [OK]
 Installing Go development utils : [OK]
+Retrieving ciao-webui  : [OK]
 Pulling ceph/demo : [OK]
 Pulling clearlinux/keystone : [OK]
 Downloading Fedora-Cloud-Base-24-1.2.x86_64.qcow2 : [OK]
@@ -87,6 +89,25 @@ example,
 ciao-down prepare --cpus 2 -mem 2
 
 Creates and boots a VM with 2 VCPUs and 2 GB of RAM.
+
+In addition to downloading and building the ciao source code, ciao-down also
+downloads the code for ciao's ui, ciao-webui.  By default it will place the
+source in a local directory in $HOME/ciao-webui.  However, if you are modifying
+the code of the webui it is convenient to have the code shared between your host
+machine and the ciao-down VM.  This can be achieved using the --ui-path.  This
+option takes a path to the location on your host machine where the UI code is
+stored.  This path gets mounted to the same location inside the VM, allowing you to
+modify the sources on your host and compile inside the VM.  For example,
+
+ciao-down prepare --with-ui $HOME/src/ciao-webui
+
+will create a new ciao-down VM in which the $HOME/src/ciao-webui folder on
+your host will be mounted at $HOME/src/ciao-webui.
+
+Note that if the directory passed to --with-ui option already contains a
+git repo, ciao-down will perform no action other than to mount the directory
+in the guest VM.  It will not try to clone the repo or update it.  It assumes
+that the directory already contains the webui code.
 
 ### delete
 


### PR DESCRIPTION
This PR adds ciao-webui support to ciao-down and Single VM.   In short ciao-down installs and configures node and downloads the ciao-webui repo into a directory shared with the host.  Single VM creates a configuration file that contains all the information the webui needs to talk to the Single VM ciao instance.

We also fix a bug which causes a launcher crash when container creation fails due to a network error.