### PR TITLE
[NOT FOR MERGING] ciao-launcher: Only unmap explicitly mapped volumes and improve logging

### DIFF
--- a/ciao-launcher/attachvolume_instance.go
+++ b/ciao-launcher/attachvolume_instance.go
@@ -81,7 +81,7 @@ func processAttachVolume(storageDriver storage.BlockDriver, monitorCh chan inter
 		}
 	}
 
-	cfg.Volumes = append(cfg.Volumes, volumeConfig{UUID: volumeUUID})
+	cfg.Volumes = append(cfg.Volumes, volumeConfig{UUID: volumeUUID, UnmapRequired: true})
 
 	err := cfg.save(instanceDir)
 	if err != nil {

--- a/ciao-launcher/instance.go
+++ b/ciao-launcher/instance.go
@@ -349,12 +349,19 @@ func (id *instanceData) unmapVolumes() {
 
 	for _, v := range id.cfg.Volumes {
 
-		// UnmapVolumeFromNode might fail if it's mapped to multiple
-		// instances on the same node.  We don't treat this as an
-		// error for now.
+		// Only try and unmap volumes that were explicitly mapped
+		// when they were attached.
+		if !v.UnmapRequired {
+			glog.Infof("Skipping unmapping volume: %v", v.UUID)
+			continue
+		}
 
+		// UnmapVolumeFromNode might fail if it's mapped to multiple
+		// instances on the same node.  Log as a warning for now.
 		if err := id.storageDriver.UnmapVolumeFromNode(v.UUID); err == nil {
 			glog.Infof("Unmapping volume %s", v.UUID)
+		} else {
+			glog.Warningf("Error unmapping volume: %v", err)
 		}
 	}
 }

--- a/ciao-launcher/payload_test.go
+++ b/ciao-launcher/payload_test.go
@@ -74,6 +74,7 @@ start:
 				{
 					"69e84267-ed01-4738-b15f-b47de06b62e7",
 					true,
+					false,
 				},
 			},
 		},

--- a/ciao-launcher/vmconfig.go
+++ b/ciao-launcher/vmconfig.go
@@ -25,8 +25,9 @@ import (
 )
 
 type volumeConfig struct {
-	UUID     string
-	Bootable bool
+	UUID          string
+	Bootable      bool
+	UnmapRequired bool
 }
 
 type vmConfig struct {


### PR DESCRIPTION
The cfg.Volumes slice contains all the volumes used by the instance -
both those that have been attached after boot and those specified on the
qemu command line.

The volumes specified on the command line will be unmapped by qemu when
it is terminated and so those do not need to be explicitly unmapped.

This patch stores a boolean in the volumeConfig struct indicating if the
volume should be unmapped.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>