### PR TITLE
ciao-launcher: Wait for virtualizer to terminate

### DIFF
--- a/ciao-launcher/instance.go
+++ b/ciao-launcher/instance.go
@@ -223,6 +223,11 @@ func (id *instanceData) deleteCommand(cmd *insDeleteCmd) bool {
 	if id.monitorCh != nil {
 		glog.Infof("Powerdown %s before deleting", id.instance)
 		id.monitorCh <- virtualizerStopCmd{}
+		select {
+		case <-id.monitorCloseCh:
+		case <-time.After(time.Second * 10):
+			glog.Warningf("Timeout (10s) waiting for virtualizer to terminate")
+		}
 		id.vm.lostVM()
 	}
 

--- a/ciao-launcher/instance_test.go
+++ b/ciao-launcher/instance_test.go
@@ -303,6 +303,7 @@ func (v *instanceTestState) deleteInstance(t *testing.T, ovsCh chan interface{},
 				t.Errorf("Invalid monitor command found %t, expected virtualizerStopCmd", monCmd)
 				return false
 			}
+			close(v.monitorClosedCh)
 		case <-time.After(time.Second):
 			t.Error("Timed out waiting for ovsStatsUpdateCmd")
 			return false


### PR DESCRIPTION
After requesting that the virtualizer (e.g. qemu) to stop wait on the
channel monitoring the domain socket used to communicate with the
virtualizer.  This allows us to identify when the virtualizer has
finished and the next step of the cleanup can begin.

This addresses #1009 by not trying to unmap volumes that are still in
use by the running qemu process.

Fixes: #1009

Signed-off-by: Rob Bradford <robert.bradford@intel.com>