### PR TITLE
Fix #1027 - workload yaml parsing

### DIFF
--- a/ciao-cli/examples/fedora_cloud.yaml
+++ b/ciao-cli/examples/fedora_cloud.yaml
@@ -1,9 +1,14 @@
 description: "Fedora VM no storage"
 vm_type: qemu
 fw_type: legacy
-image_id: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
 defaults:
     vcpus: 2
     mem_mb: 512
     disk_mb: 1024
 cloud_init: fedora_vm.yaml
+disks:
+  - source:
+       service: image
+       id: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
+    ephemeral: true
+    bootable: true

--- a/ciao-cli/examples/fedora_cloud_disk.yaml
+++ b/ciao-cli/examples/fedora_cloud_disk.yaml
@@ -1,12 +1,16 @@
 description: "Fedora VM with attached empty storage"
 vm_type: qemu
 fw_type: legacy
-image_id: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
 defaults:
     vcpus: 2
     mem_mb: 512
     disk_mb: 1024
 cloud_init: "fedora_vm.yaml"
 disks:
+- source:
+    service: image
+    id: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
+  bootable: true
+  ephemeral: true
 - size: 20
   ephemeral: true

--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -144,8 +144,8 @@ func getCiaoWorkloadsResource() (string, error) {
 }
 
 type source struct {
-	Type types.SourceType `json:"service"`
-	ID   string           `json:"id"`
+	Type types.SourceType `yaml:"service"`
+	ID   string           `yaml:"id"`
 }
 
 type disk struct {


### PR DESCRIPTION
Fix the parsing of workload storage specified in the .yaml file. When then transition from yaml to json happened the disks struct was omitted resulting the yaml files being incorrectly parsed.

This PR fixes the tags on the struct and updates the examples to explicitly use the source type.

A further PR will remove the image_id functionality as per #988 