### PR TITLE
Enhance workload storage verification

### DIFF
--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -200,6 +200,10 @@ func optToReq(opt workloadOptions, req *types.Workload) error {
 			Ephemeral: disk.Ephemeral,
 		}
 
+		if disk.Source != nil && disk.Source.Type == "" {
+			disk.Source.Type = types.Empty
+		}
+
 		if disk.ID != nil {
 			res.ID = *disk.ID
 		} else if disk.Size == 0 {

--- a/ciao-controller/workload.go
+++ b/ciao-controller/workload.go
@@ -75,16 +75,9 @@ func validateWorkloadStorage(req types.Workload) error {
 				return types.ErrBadRequest
 			}
 		} else {
-			if req.Storage[i].SourceType == types.Empty {
-				// you many not use a source ID with empty.
-				if req.Storage[i].SourceID != "" {
-					return types.ErrBadRequest
-				}
-			} else {
-				// you must specify an ID with volume/image
-				if req.Storage[i].SourceID == "" {
-					return types.ErrBadRequest
-				}
+			// you may only use no source id with empty type
+			if req.Storage[i].SourceType != types.Empty {
+				return types.ErrBadRequest
 			}
 		}
 


### PR DESCRIPTION
Enhance the verification code used to verify storage specification in the workload definition at both a ciao-cli and ciao-controller level.

As part of this PR ciao-controller now expects and explicit source type which ciao-cli will now provide.

Fixes: #1026 