### PR TITLE
Networking: cnci-agent: Persist network state across reboots/migration

### DIFF
--- a/networking/ciao-cnci-agent/database.go
+++ b/networking/ciao-cnci-agent/database.go
@@ -17,36 +17,196 @@
 package main
 
 import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/01org/ciao/database"
 	"github.com/01org/ciao/payloads"
 	"github.com/golang/glog"
 )
 
-//Will implement a simple database to persist state across
+// cnciDatabase
+type cnciDatabase struct {
+	database.DbProvider //Database used to persist the CNCI state
+	SubnetMap
+	PublicIPMap
+}
+
+const (
+	tableSubnetMap   = "SubnetMap"
+	tablePublicIPMap = "PublicIPMap"
+)
+
+//dbCfg controls plugin data base attributes
+//these may be overridden by the caller if needed
+var dbCfg = struct {
+	Name    string
+	DataDir string
+	DbFile  string
+	Timeout time.Duration
+}{
+	Name:    "ciao cnci agent",
+	DataDir: "/var/lib/ciao/networking",
+	DbFile:  "docker_plugin.db",
+	Timeout: 1 * time.Second,
+}
+
+//SubnetMap maintains the list of active subnets across all compute nodes
+//that are handled by this CNCI
+type SubnetMap struct {
+	sync.Mutex
+	m map[string]*payloads.TenantAddedEvent //index: Agent IP + Subnet UUID
+}
+
+//NewTable creates a new map
+func (d *SubnetMap) NewTable() {
+	d.m = make(map[string]*payloads.TenantAddedEvent)
+}
+
+//Name provides the name of the map
+func (d *SubnetMap) Name() string {
+	return tableSubnetMap
+}
+
+//NewElement allocates and returns an subnet value
+func (d *SubnetMap) NewElement() interface{} {
+	return &payloads.TenantAddedEvent{}
+}
+
+//Add adds a value to the map with the specified key
+func (d *SubnetMap) Add(k string, v interface{}) error {
+	val, ok := v.(*payloads.TenantAddedEvent)
+	if !ok {
+		return fmt.Errorf("Invalid value type %t", v)
+	}
+	d.m[k] = val
+	return nil
+}
+
+//PublicIPMap maintains the list of active Public IP handled by this CNCI
+type PublicIPMap struct {
+	sync.Mutex
+	m map[string]*payloads.PublicIPCommand //index: PublicIP
+}
+
+//NewTable creates a new map
+func (d *PublicIPMap) NewTable() {
+	d.m = make(map[string]*payloads.PublicIPCommand)
+}
+
+//Name provides the name of the map
+func (d *PublicIPMap) Name() string {
+	return tablePublicIPMap
+}
+
+//NewElement allocates and returns an subnet value
+func (d *PublicIPMap) NewElement() interface{} {
+	return &payloads.PublicIPCommand{}
+}
+
+//Add adds a value to the map with the specified key
+func (d *PublicIPMap) Add(k string, v interface{}) error {
+	val, ok := v.(*payloads.PublicIPCommand)
+	if !ok {
+		return fmt.Errorf("Invalid value type %t", v)
+	}
+	d.m[k] = val
+	return nil
+}
+
+func dbInit() (*cnciDatabase, error) {
+	db := &cnciDatabase{}
+	db.DbProvider = database.NewBoltDBProvider()
+	db.SubnetMap.m = make(map[string]*payloads.TenantAddedEvent)
+	db.PublicIPMap.m = make(map[string]*payloads.PublicIPCommand)
+
+	if err := db.DbInit(dbCfg.DataDir, dbCfg.DbFile); err != nil {
+		return nil, err
+	}
+	if err := db.DbTableRebuild(&db.SubnetMap); err != nil {
+		return nil, err
+	}
+	if err := db.DbTableRebuild(&db.PublicIPMap); err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+//Will implement a simple database API to persist state across
 //restarts of the host/VM
+//The data base is updated to reflect desired state vs current
+//state. This ensures that a restart of the CNCI will result
+//in the desired state vs what is present on the current
+//CNCI instance. Hence if a particular network command fails
+//assuming it passes consistency checks, then on the restart of
+//the CNCI the command may succeed.
+func dbProcessCommand(db *cnciDatabase, cmd interface{}) {
 
-func dbProcessCommand(client *agentClient, cmd *cmdWrapper) {
-
-	switch netCmd := cmd.cmd.(type) {
+	switch netCmd := cmd.(type) {
 
 	case *payloads.EventTenantAdded:
 
 		c := &netCmd.TenantAdded
-		glog.Infof("Tenant Added %v", c)
+
+		db.SubnetMap.Lock()
+		defer db.SubnetMap.Unlock()
+
+		glog.Infof("database: Tenant Added %v", c)
+
+		key := c.AgentUUID + c.TenantSubnet
+		db.SubnetMap.m[key] = c
+
+		if err := db.DbAdd(tableSubnetMap, key, db.SubnetMap.m[key]); err != nil {
+			glog.Errorf("Unable to update db %v", err)
+		}
 
 	case *payloads.EventTenantRemoved:
 
 		c := &netCmd.TenantRemoved
-		glog.Infof("Tenant Removed %v", c)
+
+		db.SubnetMap.Lock()
+		defer db.SubnetMap.Unlock()
+
+		glog.Infof("database: Tenant Removed %v", c)
+
+		key := c.AgentUUID + c.TenantSubnet
+		delete(db.SubnetMap.m, key)
+
+		if err := db.DbDelete(tableSubnetMap, key); err != nil {
+			glog.Errorf("Unable to update db %v", err)
+		}
 
 	case *payloads.CommandAssignPublicIP:
 
 		c := &netCmd.AssignIP
-		glog.Infof("Assign IP %v", c)
+		db.PublicIPMap.Lock()
+		defer db.PublicIPMap.Unlock()
+
+		glog.Infof("database: Assign IP %v", c)
+
+		key := c.PublicIP
+		db.PublicIPMap.m[key] = c
+
+		if err := db.DbAdd(tablePublicIPMap, key, db.PublicIPMap.m[key]); err != nil {
+			glog.Errorf("Unable to update db %v", err)
+		}
 
 	case *payloads.CommandReleasePublicIP:
 
 		c := &netCmd.ReleaseIP
-		glog.Infof("Release IP %v", c)
+
+		db.PublicIPMap.Lock()
+		defer db.PublicIPMap.Unlock()
+
+		glog.Infof("database: Release IP %v", c)
+
+		key := c.PublicIP
+		delete(db.PublicIPMap.m, key)
+
+		if err := db.DbDelete(tablePublicIPMap, key); err != nil {
+			glog.Errorf("Unable to update db %v", err)
+		}
 
 	default:
 		glog.Errorf("Processing unknown command %v", netCmd)


### PR DESCRIPTION
Add support to the CNCI agent to save the state of the CNCI
network setup to the boot disk. The network state is recovered
by replaying the commands. This allows for potential migration
to a new implemenation of the command if the cnci agent is
upgraded.

This allows the CNCI agent to recover its state if the CNCI
is rebooted or migrated to a different network node.

Includes a test case where the CNCI is rebooted by sshing into it
as a stand in for migration, and the network setup is re validated.

Also added a commit to use the errors package.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>