### PR TITLE
ciao-controller: fix bug in workload validation

### DIFF
--- a/ciao-controller/workload.go
+++ b/ciao-controller/workload.go
@@ -74,7 +74,9 @@ func validateWorkloadStorage(req types.Workload) error {
 			if req.Storage[i].SourceType != types.Empty {
 				return types.ErrBadRequest
 			}
-		} else {
+		}
+
+		if req.Storage[i].SourceID == "" {
 			// you may only use no source id with empty type
 			if req.Storage[i].SourceType != types.Empty {
 				return types.ErrBadRequest


### PR DESCRIPTION
Fix a bug in the workload validation that improperly returned
BadRequest when Storage.ID == "" and Storage.SourceType != Empty.
What we really wanted to do was check if Storage.SourceID was "".

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>