### PR TITLE
controller: Fix race condition in confirmTenant

### DIFF
--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -1822,6 +1822,7 @@ func TestMain(m *testing.M) {
 	server = testutil.StartTestServer()
 
 	ctl = new(controller)
+	ctl.tenantReadiness = make(map[string]*tenantConfirmMemo)
 	ctl.ds = new(datastore.Datastore)
 
 	ctl.BlockDriver = func() storage.BlockDriver {

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -50,14 +50,21 @@ import (
 	"github.com/gorilla/mux"
 )
 
+type tenantConfirmMemo struct {
+	ch  chan struct{}
+	err error
+}
+
 type controller struct {
 	storage.BlockDriver
 
-	client controllerClient
-	ds     *datastore.Datastore
-	id     *identity
-	image  image.Client
-	apiURL string
+	client              controllerClient
+	ds                  *datastore.Datastore
+	id                  *identity
+	image               image.Client
+	apiURL              string
+	tenantReadiness     map[string]*tenantConfirmMemo
+	tenantReadinessLock sync.Mutex
 }
 
 var singleMachine = flag.Bool("single", false, "Enable single machine test")
@@ -109,6 +116,7 @@ func main() {
 	var err error
 
 	ctl := new(controller)
+	ctl.tenantReadiness = make(map[string]*tenantConfirmMemo)
 	ctl.ds = new(datastore.Datastore)
 
 	ctl.image = image.Client{MountPoint: *imagesPath}


### PR DESCRIPTION
This commit ensures that confirmTenant is only successfully called once
for each tenant during any invocation of controller.  The problem is
that confirmTenant is not re-entrant and yet was called by multiple
go routines simulataneously.  This mean that a ciao cluster could be
broken by two commands issued simultaneously on a new tenant.

The tricky thing about fixing this bug is that we cannot really protect
the whole function with a mutex.  The function is potentially very slow
as it optionally needs to wait for a CNCI to launch.  Using a critical
section for the entire function would result in commands for existing
tenants being blocked while a CNCI was launched for a new tenant, which
wouldn't be great.

The fix works by introducing tenant specific channels that provide
synchronisation points for individual tenants.  These channels are
stored in a global map.  This map requires a lock, but the lock only
needs to be held for a short period of time, the time taken to
read or write something to the map.  Thus the act of launching a
CNCI on a tenant blocks only commands on that tenant and not commands
destined for other tenants.

The fix assumes that tenants do not get deleted, and if they do, that
their UUIDs do not get re-used.

Fixes #1007

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>