### PR TITLE
Remove (unused) local disk specification

### DIFF
--- a/ciao-cli/examples/README.md
+++ b/ciao-cli/examples/README.md
@@ -99,14 +99,13 @@ disks:
 Valid values for the source `service` field are `image` or `volume`
 
 Workload definitions must also contain default values for resources
-that the workload will need to use when it runs. There are three resources
+that the workload will need to use when it runs. There are two resources
 which must be specified:
 
 ```
 defaults:
     vcpus: 2
     mem_mb: 512
-    disk_mb: 1024
 ```
 
 Finally, the filename for the cloud config file must be included in the

--- a/ciao-cli/examples/fedora_cloud.yaml
+++ b/ciao-cli/examples/fedora_cloud.yaml
@@ -4,7 +4,6 @@ fw_type: legacy
 defaults:
     vcpus: 2
     mem_mb: 512
-    disk_mb: 1024
 cloud_init: fedora_vm.yaml
 disks:
   - source:

--- a/ciao-cli/examples/fedora_cloud_disk.yaml
+++ b/ciao-cli/examples/fedora_cloud_disk.yaml
@@ -4,7 +4,6 @@ fw_type: legacy
 defaults:
     vcpus: 2
     mem_mb: 512
-    disk_mb: 1024
 cloud_init: "fedora_vm.yaml"
 disks:
 - source:

--- a/ciao-cli/examples/ubuntu_latest.yaml
+++ b/ciao-cli/examples/ubuntu_latest.yaml
@@ -4,5 +4,4 @@ image_name: "ubuntu:latest"
 defaults:
   vcpus: 2
   mem_mb: 512
-  disk_mb: 80
 cloud_init: "docker-ubuntu.yaml"

--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -157,9 +157,8 @@ type disk struct {
 }
 
 type defaultResources struct {
-	VCPUs  int `yaml:"vcpus"`
-	MemMB  int `yaml:"mem_mb"`
-	DiskMB int `yaml:"disk_mb"`
+	VCPUs int `yaml:"vcpus"`
+	MemMB int `yaml:"mem_mb"`
 }
 
 // we currently only use the first disk due to lack of support
@@ -265,12 +264,6 @@ func optToReq(opt workloadOptions, req *types.Workload) error {
 	r = payloads.RequestedResource{
 		Type:  payloads.MemMB,
 		Value: defaults.MemMB,
-	}
-	req.Defaults = append(req.Defaults, r)
-
-	r = payloads.RequestedResource{
-		Type:  payloads.DiskMB,
-		Value: defaults.DiskMB,
 	}
 	req.Defaults = append(req.Defaults, r)
 

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -979,12 +979,6 @@ users:
 		Mandatory: false,
 	}
 
-	disk := payloads.RequestedResource{
-		Type:      payloads.DiskMB,
-		Value:     1024,
-		Mandatory: false,
-	}
-
 	storage := types.StorageResource{
 		ID:        "",
 		Ephemeral: false,
@@ -999,7 +993,7 @@ users:
 		ImageID:     uuid.Generate().String(),
 		ImageName:   "",
 		Config:      testConfig,
-		Defaults:    []payloads.RequestedResource{cpus, mem, disk},
+		Defaults:    []payloads.RequestedResource{cpus, mem},
 		Storage:     []types.StorageResource{storage},
 	}
 

--- a/ciao-controller/tables/resources.csv
+++ b/ciao-controller/tables/resources.csv
@@ -1,5 +1,4 @@
 1, instances
 2, vcpus
 3, mem_mb
-4, disk_mb
 5, network_node

--- a/ciao-launcher/README.md
+++ b/ciao-launcher/README.md
@@ -174,10 +174,6 @@ Actually, this is sort of an odd situation as the START command partially succee
 ciao-launcher returns an error code, but the instance has been created and could be booted a
 later stage via RESTART.
 
-If the user specifies a size for disk_mb that is smaller than the virtual size of the
-backing image, launcher ignores the user specified value and creates an image for the
-instance whose virtual size matches that size of the chosen backing image.
-
 ciao-launcher only supports persistent instances at the moment.  Any VM instances created
 by the START command are persistent, i.e., the persistence YAML field is currently
 ignored.

--- a/ciao-launcher/payload.go
+++ b/ciao-launcher/payload.go
@@ -146,7 +146,7 @@ func parseStartPayload(data []byte) (*vmConfig, *payloadError) {
 	}
 	legacy := fwType == payloads.Legacy
 
-	var disk, cpus, mem int
+	var cpus, mem int
 	var networkNode bool
 	container, image, err := parseVMTtype(start)
 	if err != nil {
@@ -159,8 +159,6 @@ func parseStartPayload(data []byte) (*vmConfig, *payloadError) {
 			cpus = start.RequestedResources[i].Value
 		case payloads.MemMB:
 			mem = start.RequestedResources[i].Value
-		case payloads.DiskMB:
-			disk = start.RequestedResources[i].Value
 		case payloads.NetworkNode:
 			networkNode = start.RequestedResources[i].Value != 0
 		}
@@ -186,7 +184,6 @@ func parseStartPayload(data []byte) (*vmConfig, *payloadError) {
 
 	return &vmConfig{Cpus: cpus,
 		Mem:         mem,
-		Disk:        disk,
 		Instance:    instance,
 		Image:       image,
 		Legacy:      legacy,

--- a/ciao-launcher/payload_test.go
+++ b/ciao-launcher/payload_test.go
@@ -39,8 +39,6 @@ start:
        value: 2
      - type: mem_mb
        value: 370
-     - type: disk_mb
-       value: 8000
   instance_uuid: d7d86208-b46c-4465-9018-ee14087d415f
   tenant_uuid: 67d86208-000-4465-9018-fe14087d415f
   fw_type: legacy
@@ -59,7 +57,6 @@ start:
 		&vmConfig{
 			Cpus:       2,
 			Mem:        370,
-			Disk:       8000,
 			Instance:   "d7d86208-b46c-4465-9018-ee14087d415f",
 			Legacy:     true,
 			VnicMAC:    "02:00:e6:f5:af:f9",
@@ -90,8 +87,6 @@ start:
        value: 2
      - type: mem_mb
        value: 370
-     - type: disk_mb
-       value: 8000
   instance_uuid: imnotvalid
   tenant_uuid: 67d86208-000-4465-9018-fe14087d415f
   fw_type: legacy
@@ -116,8 +111,6 @@ start:
        value: 2
      - type: mem_mb
        value: 370
-     - type: disk_mb
-       value: 8000
   instance_uuid: d7d86208-b46c-4465-9018-ee14087d415f
   tenant_uuid: 67d86208-000-4465-9018-fe14087d415f
   fw_type: imnotvalid
@@ -142,8 +135,6 @@ start:
        value: 2
      - type: mem_mb
        value: 370
-     - type: disk_mb
-       value: 8000
   instance_uuid: d7d86208-b46c-4465-9018-ee14087d415f
   vm_type: askajajlsj
   tenant_uuid: 67d86208-000-4465-9018-fe14087d415f

--- a/ciao-launcher/start_test.go
+++ b/ciao-launcher/start_test.go
@@ -35,8 +35,6 @@ runcmd:
        value: 2
      - type: mem_mb
        value: 256
-     - type: disk_mb
-       value: 80000
   instance_uuid: 67d86208-b46c-4465-9018-fe14087d415f
   image_uuid: b286cd45-7d0c-4525-a140-4db6c95e41fa
 `

--- a/ciao-launcher/tests/examples/start_efi.yaml
+++ b/ciao-launcher/tests/examples/start_efi.yaml
@@ -5,8 +5,6 @@ start:
        value: 2
      - type: mem_mb
        value: 256
-     - type: disk_mb
-       value: 80000
   instance_uuid: 67d86208-b46c-4465-9018-fe14087d415
   tenant_uuid: 67d86208-000-4465-9018-fe14087d415f
   image_uuid: clear-1ff6bf3883708a56446d863f20c810c99b3aea6f

--- a/ciao-launcher/tests/examples/start_legacy.yaml
+++ b/ciao-launcher/tests/examples/start_legacy.yaml
@@ -5,8 +5,6 @@ start:
        value: 2
      - type: mem_mb
        value: 370
-     - type: disk_mb
-       value: 8000
   instance_uuid: d7d86208-b46c-4465-9018-fe14087d415f
   tenant_uuid: 67d86208-000-4465-9018-fe14087d415f
   image_uuid: b286cd45-7d0c-4525-a140-4db6c95e41fa

--- a/ciao-launcher/tests/examples/start_legacy_volume.yaml
+++ b/ciao-launcher/tests/examples/start_legacy_volume.yaml
@@ -5,8 +5,6 @@ start:
        value: 2
      - type: mem_mb
        value: 370
-     - type: disk_mb
-       value: 8000
   instance_uuid: d7d86208-b46c-4465-9018-fe14087d415f
   tenant_uuid: 67d86208-000-4465-9018-fe14087d415f
   image_uuid: b286cd45-7d0c-4525-a140-4db6c95e41fa

--- a/ciao-launcher/tests/examples/start_legacy_volume_boot.yaml
+++ b/ciao-launcher/tests/examples/start_legacy_volume_boot.yaml
@@ -5,8 +5,6 @@ start:
        value: 2
      - type: mem_mb
        value: 370
-     - type: disk_mb
-       value: 8000
   instance_uuid: d7d86208-b46c-4465-9018-ee14087d415f
   tenant_uuid: 67d86208-000-4465-9018-fe14087d415f
   fw_type: legacy

--- a/ciao-launcher/tests/examples/start_nn.yaml
+++ b/ciao-launcher/tests/examples/start_nn.yaml
@@ -8,8 +8,6 @@ start:
        value: 2
      - type: mem_mb
        value: 256
-     - type: disk_mb
-       value: 80000
      - type: network_node
        value: 1
   instance_uuid: 67d86208-b46c-4465-0000-fe14087d415f

--- a/ciao-launcher/tests/examples/stress/efi.sh
+++ b/ciao-launcher/tests/examples/stress/efi.sh
@@ -15,8 +15,6 @@ start:
        value: 1
      - type: mem_mb
        value: 128
-     - type: disk_mb
-       value: 8000
   instance_uuid: 67d86208-b46c-4465-9018-fe14087d$i
   tenant_uuid: 67d86208-000-4465-9018-fe14087d415f
   image_uuid: clear-5590-cloud-supernova.qcow

--- a/ciao-launcher/tests/examples/stress/legacy.sh
+++ b/ciao-launcher/tests/examples/stress/legacy.sh
@@ -15,8 +15,6 @@ start:
        value: 2
      - type: mem_mb
        value: 370
-     - type: disk_mb
-       value: 8000
   instance_uuid: d7d86208-b46c-4465-9018-fe14087d4$i
   tenant_uuid: 67d86208-000-4465-9018-fe14087d415f
   image_uuid: b286cd45-7d0c-4525-a140-4db6c95e41fa

--- a/ciao-scheduler/scheduler_internal_test.go
+++ b/ciao-scheduler/scheduler_internal_test.go
@@ -136,14 +136,8 @@ func createStartWorkload(vCpus int, memMB int, diskMB int) *payloads.Start {
 		Value:     memMB,
 		Mandatory: true,
 	}
-	reqDisk := payloads.RequestedResource{
-		Type:      "disk_mb",
-		Value:     diskMB,
-		Mandatory: true,
-	}
 	work.Start.RequestedResources = append(work.Start.RequestedResources, reqVcpus)
 	work.Start.RequestedResources = append(work.Start.RequestedResources, reqMem)
-	work.Start.RequestedResources = append(work.Start.RequestedResources, reqDisk)
 
 	//TODO: add EstimatedResources
 

--- a/payloads/restart_test.go
+++ b/payloads/restart_test.go
@@ -43,11 +43,6 @@ func TestRestartMarshal(t *testing.T) {
 		Value:     4096,
 		Mandatory: true,
 	}
-	reqDisk := RequestedResource{
-		Type:      "disk_mb",
-		Value:     10000,
-		Mandatory: true,
-	}
 	estVcpus := EstimatedResource{
 		Type:  "vcpus",
 		Value: 1,
@@ -56,10 +51,7 @@ func TestRestartMarshal(t *testing.T) {
 		Type:  "mem_mb",
 		Value: 128,
 	}
-	estDisk := EstimatedResource{
-		Type:  "disk_mb",
-		Value: 4096,
-	}
+
 	var cmd Restart
 	cmd.Restart.TenantUUID = testutil.TenantUUID
 	cmd.Restart.InstanceUUID = testutil.InstanceUUID
@@ -67,10 +59,8 @@ func TestRestartMarshal(t *testing.T) {
 	cmd.Restart.WorkloadAgentUUID = testutil.AgentUUID
 	cmd.Restart.RequestedResources = append(cmd.Restart.RequestedResources, reqVcpus)
 	cmd.Restart.RequestedResources = append(cmd.Restart.RequestedResources, reqMem)
-	cmd.Restart.RequestedResources = append(cmd.Restart.RequestedResources, reqDisk)
 	cmd.Restart.EstimatedResources = append(cmd.Restart.EstimatedResources, estVcpus)
 	cmd.Restart.EstimatedResources = append(cmd.Restart.EstimatedResources, estMem)
-	cmd.Restart.EstimatedResources = append(cmd.Restart.EstimatedResources, estDisk)
 	cmd.Restart.FWType = EFI
 	cmd.Restart.InstancePersistence = Host
 

--- a/payloads/start.go
+++ b/payloads/start.go
@@ -64,10 +64,6 @@ const (
 	// in MBs
 	MemMB = "mem_mb"
 
-	// DiskMB indicates that a resource struct specifies a quantity of disk
-	// space in MBs
-	DiskMB = "disk_mb"
-
 	// NetworkNode indicates that a resource struct specifies whether the
 	// command in which it is embedded applies to a network node.
 	NetworkNode = "network_node"

--- a/payloads/start_test.go
+++ b/payloads/start_test.go
@@ -43,11 +43,6 @@ func TestStartMarshal(t *testing.T) {
 		Value:     4096,
 		Mandatory: true,
 	}
-	reqDisk := RequestedResource{
-		Type:      "disk_mb",
-		Value:     10000,
-		Mandatory: true,
-	}
 	estVcpus := EstimatedResource{
 		Type:  "vcpus",
 		Value: 1,
@@ -56,10 +51,7 @@ func TestStartMarshal(t *testing.T) {
 		Type:  "mem_mb",
 		Value: 128,
 	}
-	estDisk := EstimatedResource{
-		Type:  "disk_mb",
-		Value: 4096,
-	}
+
 	var cmd Start
 	cmd.Start.TenantUUID = testutil.TenantUUID
 	cmd.Start.InstanceUUID = testutil.InstanceUUID
@@ -67,10 +59,8 @@ func TestStartMarshal(t *testing.T) {
 	cmd.Start.DockerImage = testutil.DockerImage
 	cmd.Start.RequestedResources = append(cmd.Start.RequestedResources, reqVcpus)
 	cmd.Start.RequestedResources = append(cmd.Start.RequestedResources, reqMem)
-	cmd.Start.RequestedResources = append(cmd.Start.RequestedResources, reqDisk)
 	cmd.Start.EstimatedResources = append(cmd.Start.EstimatedResources, estVcpus)
 	cmd.Start.EstimatedResources = append(cmd.Start.EstimatedResources, estMem)
-	cmd.Start.EstimatedResources = append(cmd.Start.EstimatedResources, estDisk)
 	cmd.Start.FWType = EFI
 	cmd.Start.InstancePersistence = Host
 	cmd.Start.VMType = QEMU

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -132,16 +132,11 @@ const StartYaml = `start:
   - type: mem_mb
     value: 4096
     mandatory: true
-  - type: disk_mb
-    value: 10000
-    mandatory: true
   estimated_resources:
   - type: vcpus
     value: 1
   - type: mem_mb
     value: 128
-  - type: disk_mb
-    value: 4096
   networking:
     vnic_mac: ""
     vnic_uuid: ""
@@ -217,16 +212,11 @@ const RestartYaml = `restart:
   - type: mem_mb
     value: 4096
     mandatory: true
-  - type: disk_mb
-    value: 10000
-    mandatory: true
   estimated_resources:
   - type: vcpus
     value: 1
   - type: mem_mb
     value: 128
-  - type: disk_mb
-    value: 4096
   networking:
     vnic_mac: ""
     vnic_uuid: ""


### PR DESCRIPTION
Now that VM storage is ceph backed and we currently have no implementation plan for local storage for VMs this payload/workload member has no meaning.

For containers we also do not currently use this value.

There for clarity for users remove this from the workload specification and for consistency remove from the payload specification too