### PR TITLE
Updates to ciao-down

### DIFF
--- a/testutil/ciao-down/cloudinit.go
+++ b/testutil/ciao-down/cloudinit.go
@@ -213,6 +213,7 @@ runcmd:
  - sudo -u {{.User}} git config --global user.email {{.GitEmail}}
  - {{template "CHECK" .}}
 {{end}}
+%s
  - curl -X PUT -d "FINISHED" 10.0.2.2:{{.HTTPServerPort}}
 
 users:

--- a/testutil/ciao-down/vm.go
+++ b/testutil/ciao-down/vm.go
@@ -198,6 +198,7 @@ func manageInstallation(ctx context.Context, instanceDir string, ws *workspace) 
 		if qemuShutdown {
 			ctx, cancelFn := context.WithTimeout(context.Background(), time.Second)
 			_ = qmp.ExecuteQuit(ctx)
+			<-disconnectedCh
 			cancelFn()
 		}
 		qmp.Shutdown()


### PR DESCRIPTION
There are two updates:

1. Fix a couple of race conditions that prevent the prepare command from removing an instance in case of error or cancellation.
2. Add a new option, -runcmd, that can be used to provide an additional set of instructions for cloud-init to run when setting up the vm.  These instructions augment the setup work that ciao-down does to setup ciao itself.