### PR TITLE
ciao-cli: Remove non-supported image download and modify

### DIFF
--- a/ciao-cli/image.go
+++ b/ciao-cli/image.go
@@ -43,12 +43,10 @@ const imageTemplateDesc = `struct {
 
 var imageCommand = &command{
 	SubCommands: map[string]subCommand{
-		"add":      new(imageAddCommand),
-		"show":     new(imageShowCommand),
-		"list":     new(imageListCommand),
-		"download": new(imageDownloadCommand),
-		"delete":   new(imageDeleteCommand),
-		"modify":   new(imageModifyCommand),
+		"add":    new(imageAddCommand),
+		"show":   new(imageShowCommand),
+		"list":   new(imageListCommand),
+		"delete": new(imageDeleteCommand),
 	},
 }
 


### PR DESCRIPTION
CIAO image service is not currently supporting image ``download``
and ``modify``. We may enable it later. For now, we need to remove
these options in order to avoid confusion.

Signed-off-by: Obed N Munoz <obed.n.munoz@intel.com>