### PR TITLE
Networking: Add explicit allow rules for Ciao Traffic

### DIFF
--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -8,7 +8,8 @@ sudo killall ciao-controller
 sudo killall ciao-launcher
 sleep 2
 sudo "$ciao_gobin"/ciao-launcher --alsologtostderr -v 3 --hard-reset
-sudo ip link del ciao_eth
+sudo iptables -D FORWARD -p all -i ciao_br -j ACCEPT
+sudo ip link del ciao_br
 sudo pkill -F /tmp/dnsmasq.ciaovlan.pid
 sudo docker rm -v -f keystone
 sudo docker rm -v -f ceph-demo
@@ -16,3 +17,4 @@ sudo rm /etc/ceph/*
 sudo rm -rf /var/lib/ciao/ciao-image
 sudo docker network rm $(sudo docker network ls --filter driver=ciao -q)
 sudo rm -r ~/local/mysql/
+sudo rm -f /var/lib/ciao/networking/docker_plugin.db

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ciao_host=$(hostname)
 ciao_ip=$(hostname -i)
-ciao_interface=ciao_eth
+ciao_bridge=ciao_br
 ciao_vlan_ip=198.51.100.1
 ciao_vlan_subnet=${ciao_vlan_ip}/24
 ciao_vlan_brdcast=198.51.100.255
@@ -483,14 +483,15 @@ fi
 
 # Set macvlan interface
 if [ -x "$(command -v ip)" ]; then
-    sudo ip link del "$ciao_interface"
-    sudo ip link add name "$ciao_interface" type bridge
-    sudo ip link add link "$ciao_interface" name ciaovlan type macvlan mode bridge
+    sudo ip link del "$ciao_bridge"
+    sudo ip link add name "$ciao_bridge" type bridge
+    sudo iptables -A FORWARD -p all -i "$ciao_bridge" -j ACCEPT
+    sudo ip link add link "$ciao_bridge" name ciaovlan type macvlan mode bridge
     sudo ip addr add "$ciao_vlan_subnet" brd "$ciao_vlan_brdcast" dev ciaovlan
     sudo ip link set dev ciaovlan up
     sudo ip -d link show ciaovlan
-    sudo ip link set dev "$ciao_interface" up
-    sudo ip -d link show "$ciao_interface"
+    sudo ip link set dev "$ciao_bridge" up
+    sudo ip -d link show "$ciao_bridge"
 else
     echo 'ip command is not supported'
 fi


### PR DESCRIPTION
Latest version of docker (1.13+) adds a default deny rule
for all forwarded traffic if docker enables ip forwarding.

If docker already finds ip forwarding enabled on the system
it will leave the firewall setup untouched and only append
rules at the very top.

The ciao traffic that traverses the bridges gets impacted by
this as the bridge traffic is also subject to iptables rules
as the following rules are enabled

bridge-nf-call-arptables
bridge-nf-call-iptables
bridge-nf-call-ip6tables

To fix this 
- Add explicit allow rules for Single VM Ciao Traffic
- Add explicit allow rules for Ciao traffic on compute nodes.

This also fixes the TLS issues observed in the bare metal single machine setup

Fixes #1064 #1065 

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>