### PR TITLE
Quotas and Limits Phase 1

### DIFF
--- a/_release/bat/README.md
+++ b/_release/bat/README.md
@@ -8,6 +8,7 @@ the following sub folders.
 .
 ├── base_bat     - Basic tests that verify that the cluster is functional
 ├── image_bat    - BAT tests for the image service
+├── quotas_bat   - Quota related BAT tests
 ├── storage_bat  - Storage related BAT tests
 ```
 

--- a/_release/bat/quotas_bat/quotas_bat.go
+++ b/_release/bat/quotas_bat/quotas_bat.go
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package quotasbat is a placeholder package for the basic BAT tests.
+package quotasbat

--- a/_release/bat/quotas_bat/quotas_bat_test.go
+++ b/_release/bat/quotas_bat/quotas_bat_test.go
@@ -1,0 +1,98 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package quotasbat is a placeholder package for the basic BAT tests.
+package quotasbat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/01org/ciao/bat"
+)
+
+const standardTimeout = time.Second * 300
+
+func findQuota(qds []bat.QuotaDetails, name string) *bat.QuotaDetails {
+	for i := range qds {
+		if qds[i].Name == name {
+			return &qds[i]
+		}
+	}
+	return nil
+}
+
+func restoreQuotas(ctx context.Context, tenantID string, origQuotas []bat.QuotaDetails, currentQuotas []bat.QuotaDetails) error {
+	for i := range currentQuotas {
+		qd := findQuota(origQuotas, currentQuotas[i].Name)
+		if qd != nil && qd.Value != currentQuotas[i].Value {
+			err := bat.UpdateQuota(ctx, "", tenantID, qd.Name, qd.Value)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Test getting and setting quotas
+//
+// Tests retrieving and setting quotas.
+//
+// Gets the current quotas, sets several, gets them again checks they've
+// changed, restores the original and checks the restoration.
+func TestQuotas(t *testing.T) {
+	qn := "tenant-vcpu-quota"
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+
+	tenants, err := bat.GetUserTenants(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(tenants) < 1 {
+		t.Fatal("Expected user to have access to at least one tenant")
+	}
+
+	tenantID := tenants[0].ID
+	origQuotas, err := bat.ListQuotas(ctx, tenantID, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = bat.UpdateQuota(ctx, "", tenantID, qn, "10")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updatedQuotas, err := bat.ListQuotas(ctx, tenantID, "")
+	if err != nil {
+		t.Error(err)
+	}
+
+	qd := findQuota(updatedQuotas, qn)
+	if qd.Value != "10" {
+		t.Error("Quota not expected value")
+	}
+
+	err = restoreQuotas(ctx, tenantID, origQuotas, updatedQuotas)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/bat/compute.go
+++ b/bat/compute.go
@@ -229,6 +229,21 @@ func GetAllTenants(ctx context.Context) ([]*Tenant, error) {
 	return tenants, nil
 }
 
+// GetUserTenants retrieves a list of all the tenants the current user has
+// access to. An error will be returned if the following environment variables
+// are not set; CIAO_IDENTITY, CIAO_CONTROLLER, CIAO_USERNAME, CIAO_PASSWORD.
+func GetUserTenants(ctx context.Context) ([]*Tenant, error) {
+	var tenants []*Tenant
+
+	args := []string{"tenant", "list", "-f", "{{tojson .}}"}
+	err := RunCIAOCLIJS(ctx, "", args, &tenants)
+	if err != nil {
+		return nil, err
+	}
+
+	return tenants, nil
+}
+
 // GetInstance returns an Instance structure that contains information
 // about a specific instance.  The informaion is retrieved by calling
 // ciao-cli show --instance.  An error will be returned if the following

--- a/bat/compute.go
+++ b/bat/compute.go
@@ -117,7 +117,7 @@ func RunCIAOCLI(ctx context.Context, tenant string, args []string) ([]byte, erro
 	}
 
 	if tenant != "" {
-		args = append([]string{"-tenant", tenant}, args...)
+		args = append([]string{"-tenant-id", tenant}, args...)
 	}
 
 	data, err := exec.CommandContext(ctx, "ciao-cli", args...).Output()
@@ -163,7 +163,7 @@ func RunCIAOCLIAsAdmin(ctx context.Context, tenant string, args []string) ([]byt
 	}
 
 	if tenant != "" {
-		args = append([]string{"-tenant", tenant}, args...)
+		args = append([]string{"-tenant-id", tenant}, args...)
 	}
 
 	env := os.Environ()

--- a/bat/quotas.go
+++ b/bat/quotas.go
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package bat
+
+import "context"
+
+// QuotaDetails holds quota information returned by ListQuotas()
+type QuotaDetails struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	Usage string `json:"usage"`
+}
+
+// ListQuotas returns the quotas by calling "ciao-cli quotas list". If a
+// forTenantID is specified then it is run as an admin and the quotas for the
+// the specified tenant will be returned. Otherwise it will provide the quotas
+// for the current tenant.
+func ListQuotas(ctx context.Context, tenantID string, forTenantID string) ([]QuotaDetails, error) {
+	var qds []QuotaDetails
+	var err error
+	if forTenantID == "" {
+		args := []string{"quotas", "list", "-f", "{{tojson .}}"}
+		err = RunCIAOCLIJS(ctx, tenantID, args, &qds)
+	} else {
+		args := []string{"quotas", "list", "-for-tenant", forTenantID, "-f", "{{tojson .}}"}
+		err = RunCIAOCLIAsAdminJS(ctx, tenantID, args, &qds)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return qds, nil
+}
+
+// UpdateQuota updates the provided named quota for the provided tenant (using
+// forTenantID) to the desired value.
+func UpdateQuota(ctx context.Context, tenantID string, forTenantID string, name string, value string) error {
+	args := []string{"quotas", "update", "-for-tenant", forTenantID, "-name", name, "-value", value}
+
+	_, err := RunCIAOCLIAsAdmin(ctx, tenantID, args)
+
+	return err
+}

--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -94,6 +94,7 @@ var commands = map[string]subCommand{
 	"volume":      volumeCommand,
 	"pool":        poolCommand,
 	"external-ip": externalIPCommand,
+	"quotas":      quotasCommand,
 }
 
 var scopedToken string

--- a/ciao-cli/quotas.go
+++ b/ciao-cli/quotas.go
@@ -1,0 +1,218 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/01org/ciao/ciao-controller/api"
+	"github.com/01org/ciao/ciao-controller/types"
+)
+
+var quotasCommand = &command{
+	SubCommands: map[string]subCommand{
+		"update": new(quotasUpdateCommand),
+		"list":   new(quotasListCommand),
+	},
+}
+
+type quotasUpdateCommand struct {
+	Flag     flag.FlagSet
+	name     string
+	value    string
+	tenantID string
+}
+
+func getCiaoQuotasResource() (string, error) {
+	return getCiaoResource("tenants", api.TenantsV1)
+}
+
+func (cmd *quotasUpdateCommand) usage(...string) {
+	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] quotas update [flags]
+
+Updates the quota entry for the supplied tenant
+
+The update flags are:
+
+`)
+	cmd.Flag.PrintDefaults()
+	os.Exit(2)
+}
+
+func (cmd *quotasUpdateCommand) parseArgs(args []string) []string {
+	cmd.Flag.StringVar(&cmd.name, "name", "", "Name of quota or limit")
+	cmd.Flag.StringVar(&cmd.value, "value", "", "Value of quota or limit")
+	cmd.Flag.StringVar(&cmd.tenantID, "for-tenant", "", "Tenant to update quota for")
+	cmd.Flag.Usage = func() { cmd.usage() }
+	cmd.Flag.Parse(args)
+	return cmd.Flag.Args()
+}
+
+func (cmd *quotasUpdateCommand) run(args []string) error {
+	if cmd.name == "" {
+		errorf("Missing required -name parameter")
+		cmd.usage()
+	}
+
+	if cmd.value == "" {
+		errorf("Missing required -value parameter")
+		cmd.usage()
+	}
+
+	if cmd.tenantID == "" {
+		errorf("Missing required -for-tenant parameter")
+		cmd.usage()
+	}
+	var v int
+	if cmd.value == "unlimited" {
+		v = -1
+	} else {
+		var err error
+		v, err = strconv.Atoi(cmd.value)
+		if err != nil {
+			fatalf(err.Error())
+		}
+	}
+
+	req := types.QuotaUpdateRequest{
+		Quotas: []types.QuotaDetails{{
+			Name:  cmd.name,
+			Value: v,
+		}},
+	}
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	body := bytes.NewReader(b)
+
+	url, err := getCiaoQuotasResource()
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	ver := api.TenantsV1
+
+	url = fmt.Sprintf("%s/%s/quotas", url, cmd.tenantID)
+	resp, err := sendCiaoRequest("PUT", url, nil, body, &ver)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		fatalf("Update quotas failed: %s", resp.Status)
+	}
+
+	fmt.Printf("Update quotas succeeded\n")
+
+	return nil
+}
+
+type quotasListCommand struct {
+	Flag     flag.FlagSet
+	template string
+	tenantID string
+}
+
+func (cmd *quotasListCommand) usage(...string) {
+	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] quotas list [flags]
+
+Show all quotas for current tenant or supplied tenant if admin
+
+The list flags are:
+
+`)
+	cmd.Flag.PrintDefaults()
+	fmt.Fprintf(os.Stderr, `
+The template passed to the -f option operates on a 
+
+%s`,
+		generateUsageUndecorated([]types.QuotaDetails{}))
+	fmt.Fprintln(os.Stderr, templateFunctionHelp)
+
+	os.Exit(2)
+}
+
+func (cmd *quotasListCommand) parseArgs(args []string) []string {
+	cmd.Flag.Usage = func() { cmd.usage() }
+	cmd.Flag.StringVar(&cmd.tenantID, "for-tenant", "", "Tenant to get quotas for")
+	cmd.Flag.StringVar(&cmd.template, "f", "", "Template used to format output")
+	cmd.Flag.Parse(args)
+	return cmd.Flag.Args()
+}
+
+// change this command to return different output depending
+// on the privilege level of user. Check privilege, then
+// if not privileged, build non-privileged URL.
+func (cmd *quotasListCommand) run(args []string) error {
+	url, err := getCiaoQuotasResource()
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	if cmd.tenantID != "" {
+		url = fmt.Sprintf("%s/%s/quotas", url, cmd.tenantID)
+	} else {
+		url = fmt.Sprintf("%s/quotas", url)
+	}
+	ver := api.TenantsV1
+
+	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		fatalf("Getting quotas failed: %s", resp.Status)
+	}
+
+	var results types.QuotaListResponse
+	err = unmarshalHTTPResponse(resp, &results)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	if cmd.template != "" {
+		return outputToTemplate("quotas-list", cmd.template, results.Quotas)
+	}
+
+	fmt.Printf("Quotas for tenant: %s\n", cmd.tenantID)
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+	for _, qd := range results.Quotas {
+		fmt.Fprintf(w, "%s:\t", qd.Name)
+		if strings.Contains(qd.Name, "quota") {
+			fmt.Fprintf(w, "%d of ", qd.Usage)
+		}
+		if qd.Value == -1 {
+			fmt.Fprint(w, "unlimited\n")
+		} else {
+			fmt.Fprintf(w, "%d\n", qd.Value)
+		}
+	}
+	w.Flush()
+	return nil
+}

--- a/ciao-cli/quotas.go
+++ b/ciao-cli/quotas.go
@@ -71,6 +71,10 @@ func (cmd *quotasUpdateCommand) parseArgs(args []string) []string {
 }
 
 func (cmd *quotasUpdateCommand) run(args []string) error {
+	if !checkPrivilege() {
+		errorf("Updating quotas is only available for privileged users")
+	}
+
 	if cmd.name == "" {
 		errorf("Missing required -name parameter")
 		cmd.usage()
@@ -177,6 +181,9 @@ func (cmd *quotasListCommand) run(args []string) error {
 	if cmd.tenantID != "" {
 		url = fmt.Sprintf("%s/%s/quotas", url, cmd.tenantID)
 	} else {
+		if !checkPrivilege() {
+			errorf("Listing quotas for other tenants is for privileged users only")
+		}
 		url = fmt.Sprintf("%s/quotas", url)
 	}
 	ver := api.TenantsV1

--- a/ciao-controller/api/api.go
+++ b/ciao-controller/api/api.go
@@ -505,7 +505,6 @@ func listQuotas(c *Context, w http.ResponseWriter, r *http.Request) (Response, e
 	}
 
 	var resp types.QuotaListResponse
-
 	resp.Quotas = c.ListQuotas(tenantID)
 
 	return Response{http.StatusOK, resp}, nil
@@ -531,7 +530,10 @@ func updateQuotas(c *Context, w http.ResponseWriter, r *http.Request) (Response,
 		return errorResponse(err), err
 	}
 
-	return Response{http.StatusCreated, nil}, nil
+	var resp types.QuotaListResponse
+	resp.Quotas = c.ListQuotas(tenantID)
+
+	return Response{http.StatusCreated, resp}, nil
 }
 
 // Service is an interface which must be implemented by the ciao API context.

--- a/ciao-controller/api/api.go
+++ b/ciao-controller/api/api.go
@@ -38,6 +38,9 @@ const (
 
 	// WorkloadsV1 is the content-type string for v1 of our workloads resource
 	WorkloadsV1 = "x.ciao.workloads.v1"
+
+	// TenantsV1 is the content-type string for v1 of our tenants resource
+	TenantsV1 = "x.ciao.tenants.v1"
 )
 
 // HTTPErrorData represents the HTTP response body for
@@ -176,6 +179,21 @@ func listResources(c *Context, w http.ResponseWriter, r *http.Request) (Response
 		link.Href = fmt.Sprintf("%s/workloads", c.URL)
 	} else {
 		link.Href = fmt.Sprintf("%s/%s/workloads", c.URL, tenantID)
+	}
+
+	links = append(links, link)
+
+	// for the "tenants" resource
+	link = types.APILink{
+		Rel:        "tenants",
+		Version:    TenantsV1,
+		MinVersion: TenantsV1,
+	}
+
+	if !ok {
+		link.Href = fmt.Sprintf("%s/tenants", c.URL)
+	} else {
+		link.Href = fmt.Sprintf("%s/%s/tenants", c.URL, tenantID)
 	}
 
 	links = append(links, link)
@@ -478,6 +496,44 @@ func addWorkload(c *Context, w http.ResponseWriter, r *http.Request) (Response, 
 	return Response{http.StatusCreated, resp}, nil
 }
 
+func listQuotas(c *Context, w http.ResponseWriter, r *http.Request) (Response, error) {
+	vars := mux.Vars(r)
+	tenantID, ok := vars["tenant"]
+
+	if !ok {
+		tenantID = vars["for_tenant"]
+	}
+
+	var resp types.QuotaListResponse
+
+	resp.Quotas = c.ListQuotas(tenantID)
+
+	return Response{http.StatusOK, resp}, nil
+}
+
+func updateQuotas(c *Context, w http.ResponseWriter, r *http.Request) (Response, error) {
+	vars := mux.Vars(r)
+	tenantID := vars["for_tenant"]
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	var req types.QuotaUpdateRequest
+	err = json.Unmarshal(body, &req)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	err = c.UpdateQuotas(tenantID, req.Quotas)
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	return Response{http.StatusCreated, nil}, nil
+}
+
 // Service is an interface which must be implemented by the ciao API context.
 type Service interface {
 	AddPool(name string, subnet *string, ips []string) (types.Pool, error)
@@ -490,6 +546,8 @@ type Service interface {
 	MapAddress(poolName *string, instanceID string) error
 	UnMapAddress(ID string) error
 	CreateWorkload(req types.Workload) (types.Workload, error)
+	ListQuotas(tenantID string) []types.QuotaDetails
+	UpdateQuotas(tenantID string, qds []types.QuotaDetails) error
 }
 
 // Context is used to provide the services and current URL to the handlers.
@@ -593,5 +651,21 @@ func Routes(config Config) *mux.Router {
 	route = r.Handle("/{tenant:[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[8|9|aA|bB][a-f0-9]{3}-?[a-f0-9]{12}}/workloads", Handler{context, addWorkload})
 	route.Methods("POST")
 	route.HeadersRegexp("Content-Type", matchContent)
+
+	// tenant quotas
+	matchContent = fmt.Sprintf("application/(%s|json)", TenantsV1)
+
+	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}/tenants/quotas", Handler{context, listQuotas})
+	route.Methods("GET")
+	route.HeadersRegexp("Content-Type", matchContent)
+
+	route = r.Handle("/tenants/{for_tenant:"+uuid.UUIDRegex+"}/quotas", Handler{context, listQuotas})
+	route.Methods("GET")
+	route.HeadersRegexp("Content-Type", matchContent)
+
+	route = r.Handle("/tenants/{for_tenant:"+uuid.UUIDRegex+"}/quotas", Handler{context, updateQuotas})
+	route.Methods("PUT")
+	route.HeadersRegexp("Content-Type", matchContent)
+
 	return r
 }

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -48,7 +48,7 @@ var tests = []test{
 		"",
 		"application/text",
 		http.StatusOK,
-		`[{"rel":"pools","href":"/pools","version":"x.ciao.pools.v1","minimum_version":"x.ciao.pools.v1"},{"rel":"external-ips","href":"/external-ips","version":"x.ciao.external-ips.v1","minimum_version":"x.ciao.external-ips.v1"},{"rel":"workloads","href":"/workloads","version":"x.ciao.workloads.v1","minimum_version":"x.ciao.workloads.v1"}]`,
+		`[{"rel":"pools","href":"/pools","version":"x.ciao.pools.v1","minimum_version":"x.ciao.pools.v1"},{"rel":"external-ips","href":"/external-ips","version":"x.ciao.external-ips.v1","minimum_version":"x.ciao.external-ips.v1"},{"rel":"workloads","href":"/workloads","version":"x.ciao.workloads.v1","minimum_version":"x.ciao.workloads.v1"},{"rel":"tenants","href":"/tenants","version":"x.ciao.tenants.v1","minimum_version":"x.ciao.tenants.v1"}]`,
 	},
 	{
 		"GET",
@@ -148,6 +148,15 @@ var tests = []test{
 		"application/x.ciao.v1.workloads",
 		http.StatusCreated,
 		`{"workload":{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_id":"73a86d7e-93c0-480e-9c41-ab42f69b7799","image_name":"","config":"this will totally work!","defaults":[],"storage":null},"link":{"rel":"self","href":"/workloads/ba58f471-0735-4773-9550-188e2d012941"}}`,
+	},
+	{
+		"GET",
+		"/tenants/test-tenant-id/quotas/",
+		listQuotas,
+		"",
+		"application/x.ciao.v1.tenants",
+		http.StatusOK,
+		`{"quotas":[{"name":"test-quota-1","value":"10","usage":"3"},{"name":"test-quota-2","value":"unlimited","usage":"10"},{"name":"test-limit","value":"123"}]}`,
 	},
 }
 
@@ -257,6 +266,18 @@ func (ts testCiaoService) UnMapAddress(string) error {
 func (ts testCiaoService) CreateWorkload(req types.Workload) (types.Workload, error) {
 	req.ID = "ba58f471-0735-4773-9550-188e2d012941"
 	return req, nil
+}
+
+func (ts testCiaoService) ListQuotas(tenantID string) []types.QuotaDetails {
+	return []types.QuotaDetails{
+		{Name: "test-quota-1", Value: 10, Usage: 3},
+		{Name: "test-quota-2", Value: -1, Usage: 10},
+		{Name: "test-limit", Value: 123, Usage: 0},
+	}
+}
+
+func (ts testCiaoService) UpdateQuotas(tenantID string, qds []types.QuotaDetails) error {
+	return nil
 }
 
 func TestResponse(t *testing.T) {

--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -92,6 +92,10 @@ func (client *ssntpClient) deleteEphemeralStorage(instanceID string) {
 		if err != nil {
 			glog.Warningf("Error deleting attachment from datastore: %v", err)
 		}
+		bd, err := client.ctl.ds.GetBlockDevice(attachment.BlockID)
+		if err != nil {
+			glog.Warningf("Unable to get block device: %v", err)
+		}
 		err = client.ctl.ds.DeleteBlockDevice(attachment.BlockID)
 		if err != nil {
 			glog.Warningf("Error deleting block device from datastore: %v", err)
@@ -100,6 +104,9 @@ func (client *ssntpClient) deleteEphemeralStorage(instanceID string) {
 		if err != nil {
 			glog.Warningf("Error deleting block device: %v", err)
 		}
+		client.ctl.qs.Release(bd.TenantID,
+			payloads.RequestedResource{Type: payloads.Volume, Value: 1},
+			payloads.RequestedResource{Type: payloads.SharedDiskGiB, Value: bd.Size})
 	}
 }
 

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	datastore "github.com/01org/ciao/ciao-controller/internal/datastore"
+	"github.com/01org/ciao/ciao-controller/internal/quotas"
 	"github.com/01org/ciao/ciao-controller/types"
 	image "github.com/01org/ciao/ciao-image/client"
 	"github.com/01org/ciao/ciao-storage"
@@ -1877,6 +1878,7 @@ func TestMain(m *testing.M) {
 	ctl = new(controller)
 	ctl.tenantReadiness = make(map[string]*tenantConfirmMemo)
 	ctl.ds = new(datastore.Datastore)
+	ctl.qs = new(quotas.Quotas)
 
 	ctl.BlockDriver = func() storage.BlockDriver {
 		return &storage.NoopDriver{}
@@ -1908,6 +1910,7 @@ func TestMain(m *testing.M) {
 		os.RemoveAll(dir)
 		os.Exit(1)
 	}
+	ctl.qs.Init()
 
 	config := &ssntp.Config{
 		URI:    "localhost",
@@ -1950,6 +1953,7 @@ func TestMain(m *testing.M) {
 
 	ctl.client.Disconnect()
 	ctl.ds.Exit()
+	ctl.qs.Shutdown()
 	id.Close()
 	server.Shutdown()
 	f.Close()

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	datastore "github.com/01org/ciao/ciao-controller/internal/datastore"
+	"github.com/01org/ciao/ciao-controller/internal/datastore"
 	"github.com/01org/ciao/ciao-controller/internal/quotas"
 	"github.com/01org/ciao/ciao-controller/types"
 	image "github.com/01org/ciao/ciao-image/client"

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -174,6 +174,16 @@ func addBlockDevice(c *controller, tenant string, instanceID string, device stor
 		Description: s.Tag,
 	}
 
+	res := <-c.qs.Consume(tenant,
+		payloads.RequestedResource{Type: payloads.Volume, Value: 1},
+		payloads.RequestedResource{Type: payloads.SharedDiskGiB, Value: device.Size})
+
+	if !res.Allowed() {
+		c.DeleteBlockDevice(device.ID)
+		c.qs.Release(tenant, res.Resources()...)
+		return payloads.StorageResource{}, fmt.Errorf("Error creating volume: %s", res.Reason())
+	}
+
 	err := c.ds.AddBlockDevice(data)
 	if err != nil {
 		c.DeleteBlockDevice(device.ID)

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -131,6 +131,10 @@ type persistentStore interface {
 	addMappedIP(m types.MappedIP) error
 	deleteMappedIP(ID string) error
 	getMappedIPs() map[string]types.MappedIP
+
+	// quotas
+	updateQuotas(tenantID string, qds []types.QuotaDetails) error
+	getQuotas(tenantID string) ([]types.QuotaDetails, error)
 }
 
 // Datastore provides context for the datastore package.
@@ -2322,4 +2326,14 @@ users:
 
 	// for now we have a single global cnci workload.
 	ds.cnciWorkload = wl
+}
+
+// GetQuotas returns the set of quotas from the database without any caching.
+func (ds *Datastore) GetQuotas(tenantID string) ([]types.QuotaDetails, error) {
+	return ds.db.getQuotas(tenantID)
+}
+
+// UpdateQuotas updates the quotas for a tenant in the database.
+func (ds *Datastore) UpdateQuotas(tenantID string, qds []types.QuotaDetails) error {
+	return ds.db.updateQuotas(tenantID, qds)
 }

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -301,3 +301,11 @@ func (db *MemoryDB) updateWorkload(wl types.Workload) error {
 	tenant.workloads = append(tenant.workloads, wl)
 	return nil
 }
+
+func (db *MemoryDB) updateQuotas(tenantID string, qds []types.QuotaDetails) error {
+	return nil
+}
+
+func (db *MemoryDB) getQuotas(tenantID string) ([]types.QuotaDetails, error) {
+	return []types.QuotaDetails{}, nil
+}

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -1006,3 +1006,109 @@ users:
 
 	db.disconnect()
 }
+
+func findQuota(qds []types.QuotaDetails, name string, value int) bool {
+	for _, qd := range qds {
+		if qd.Name == name && qd.Value == value {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestSQLiteDBAddQuotas(t *testing.T) {
+	db, err := getPersistentStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	qds, err := db.getQuotas("test-tenand-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(qds) != 0 {
+		t.Fatalf("Expected zero quota entries: got %d", len(qds))
+	}
+
+	err = db.updateQuotas("test-tenant-id", []types.QuotaDetails{{Name: "test-quota-name", Value: 10}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	qds, err = db.getQuotas("test-tenant-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !findQuota(qds, "test-quota-name", 10) {
+		t.Fatal("Added quota not found")
+	}
+
+	err = db.updateQuotas("test-tenant-id", []types.QuotaDetails{{Name: "test-quota-name-2", Value: 20}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	qds, err = db.getQuotas("test-tenant-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(qds) != 2 {
+		t.Fatalf("Expected 2 quotas: got %d", len(qds))
+	}
+
+	if !findQuota(qds, "test-quota-name-2", 20) {
+		t.Fatal("Added quota not found")
+	}
+}
+
+func TestSQLiteDBUpdateQuotas(t *testing.T) {
+	db, err := getPersistentStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	qds, err := db.getQuotas("test-tenand-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(qds) != 0 {
+		t.Fatalf("Expected zero quota entries: got %d", len(qds))
+	}
+
+	err = db.updateQuotas("test-tenant-id", []types.QuotaDetails{{Name: "test-quota-name", Value: 10}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	qds, err = db.getQuotas("test-tenant-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !findQuota(qds, "test-quota-name", 10) {
+		t.Fatal("Added quota not found")
+	}
+
+	err = db.updateQuotas("test-tenant-id", []types.QuotaDetails{{Name: "test-quota-name", Value: 20}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	qds, err = db.getQuotas("test-tenant-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(qds) != 1 {
+		t.Fatalf("Expected 1 quotas: got %d", len(qds))
+	}
+
+	if !findQuota(qds, "test-quota-name", 20) {
+		t.Fatal("Added quota not found")
+	}
+}

--- a/ciao-controller/internal/quotas/quotas.go
+++ b/ciao-controller/internal/quotas/quotas.go
@@ -1,0 +1,400 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quotas
+
+import (
+	"github.com/01org/ciao/ciao-controller/types"
+	"github.com/01org/ciao/payloads"
+)
+
+type quota struct {
+	limit    int
+	consumed int
+}
+
+type tenantData struct {
+	quotas map[payloads.Resource]*quota
+
+	perInstanceVCPUs  int
+	perInstanceMemory int
+	perVolumeSize     int
+	perImageSize      int
+}
+
+// Quotas provides a quota and limit service
+type Quotas struct {
+	ch chan interface{}
+}
+
+// Result provides a method for querying the result of a Consume operation.
+type Result interface {
+	Allowed() bool
+	Reason() string
+	Resources() []payloads.RequestedResource
+}
+
+type consumeOp struct {
+	tenantID  string
+	resources []payloads.RequestedResource
+	ch        chan Result
+}
+
+type releaseOp struct {
+	tenantID  string
+	resources []payloads.RequestedResource
+}
+
+type updateOp struct {
+	tenantID string
+	quotas   []types.QuotaDetails
+	doneCh   chan struct{}
+}
+
+type dumpOp struct {
+	tenantID string
+	ch       chan []types.QuotaDetails
+}
+
+type result struct {
+	allowed   bool
+	reason    string
+	resources []payloads.RequestedResource
+	doneCh    chan struct{}
+}
+
+var supportedResources = [...]payloads.Resource{
+	payloads.VCPUs,
+	payloads.MemMB,
+	payloads.Volume,
+	payloads.SharedDiskGiB,
+	payloads.Instance,
+	payloads.Image,
+	payloads.ExternalIP,
+}
+
+func makeTentantData() *tenantData {
+	td := tenantData{}
+	td.quotas = make(map[payloads.Resource]*quota)
+
+	for _, resource := range supportedResources {
+		td.quotas[resource] = &quota{-1, 0}
+	}
+
+	td.perInstanceMemory = -1
+	td.perInstanceVCPUs = -1
+	td.perVolumeSize = -1
+
+	return &td
+}
+
+func getTenantData(tenantDetails map[string]*tenantData, tenantID string) *tenantData {
+	td, ok := tenantDetails[tenantID]
+	if !ok {
+		td = makeTentantData()
+		tenantDetails[tenantID] = td
+	}
+
+	return td
+}
+
+func consumeQuota(tenantDetails map[string]*tenantData, op *consumeOp) Result {
+	td := getTenantData(tenantDetails, op.tenantID)
+	allowed := true
+
+	for _, r := range op.resources {
+		q, ok := td.quotas[r.Type]
+
+		if ok {
+			q.consumed += r.Value
+			if q.limit > -1 && q.consumed > q.limit {
+				allowed = false
+			}
+		}
+	}
+
+	res := &result{resources: op.resources}
+	res.allowed = allowed
+	if !allowed {
+		// TODO: produce more precise reason
+		res.reason = "Over quota"
+	}
+	return res
+}
+
+func checkLimit(tenantDetails map[string]*tenantData, op *consumeOp) Result {
+	td := getTenantData(tenantDetails, op.tenantID)
+
+	allowed := true
+	for _, r := range op.resources {
+		switch r.Type {
+		case payloads.VCPUs:
+			if td.perInstanceVCPUs > -1 && r.Value > td.perInstanceVCPUs {
+				allowed = false
+			}
+		case payloads.MemMB:
+			if td.perInstanceMemory > -1 && r.Value > td.perInstanceMemory {
+				allowed = false
+			}
+		case payloads.SharedDiskGiB:
+			if td.perVolumeSize > -1 && r.Value > td.perVolumeSize {
+				allowed = false
+			}
+		}
+	}
+	res := &result{resources: op.resources}
+	res.allowed = allowed
+	if !allowed {
+		// TODO: produce more precise reason
+		res.reason = "Over limit"
+	}
+	return res
+}
+
+func release(tenantDetails map[string]*tenantData, op *releaseOp) {
+	td := getTenantData(tenantDetails, op.tenantID)
+
+	for _, r := range op.resources {
+		q, ok := td.quotas[r.Type]
+
+		if ok {
+			q.consumed -= r.Value
+			if q.consumed < 0 {
+				q.consumed = 0
+			}
+		}
+	}
+}
+
+func quotaNameToResource(name string) payloads.Resource {
+	switch name {
+	case "tenant-vcpu-quota":
+		return payloads.VCPUs
+	case "tenant-mem-quota":
+		return payloads.MemMB
+	case "tenant-storage-quota":
+		return payloads.SharedDiskGiB
+	case "tenant-volumes-quota":
+		return payloads.Volume
+	case "tenant-instances-quota":
+		return payloads.Instance
+	case "tenant-images-quota":
+		return payloads.Image
+	case "tenant-external-ips-quota":
+		return payloads.ExternalIP
+	}
+
+	return ""
+}
+
+func resourceToQuotaName(r payloads.Resource) string {
+	switch r {
+	case payloads.VCPUs:
+		return "tenant-vcpu-quota"
+	case payloads.MemMB:
+		return "tenant-mem-quota"
+	case payloads.Volume:
+		return "tenant-volumes-quota"
+	case payloads.SharedDiskGiB:
+		return "tenant-storage-quota"
+	case payloads.Instance:
+		return "tenant-instances-quota"
+	case payloads.Image:
+		return "tenant-images-quota"
+	case payloads.ExternalIP:
+		return "tenant-external-ips-quota"
+	}
+	return ""
+}
+
+func update(tenantDetails map[string]*tenantData, op *updateOp) {
+	td := getTenantData(tenantDetails, op.tenantID)
+
+	for _, q := range op.quotas {
+		r := quotaNameToResource(q.Name)
+
+		if r != "" {
+			td.quotas[r].limit = q.Value
+		}
+
+		switch q.Name {
+		case "tenant-vcpu-per-instance-limit":
+			td.perInstanceVCPUs = q.Value
+		case "tenant-mem-per-instance-limit":
+			td.perInstanceMemory = q.Value
+		case "tenant-volume-size-limit":
+			td.perVolumeSize = q.Value
+		}
+	}
+}
+
+func dump(tenantDetails map[string]*tenantData, op *dumpOp) []types.QuotaDetails {
+	td := getTenantData(tenantDetails, op.tenantID)
+
+	qds := []types.QuotaDetails{}
+
+	for r, q := range td.quotas {
+		name := resourceToQuotaName(r)
+		if name != "" {
+			qd := types.QuotaDetails{
+				Name:  name,
+				Value: q.limit,
+				Usage: q.consumed,
+			}
+			qds = append(qds, qd)
+		}
+	}
+
+	qd := types.QuotaDetails{
+		Name:  "tenant-vcpu-per-instance-limit",
+		Value: td.perInstanceVCPUs,
+	}
+	qds = append(qds, qd)
+	qd = types.QuotaDetails{
+		Name:  "tenant-mem-per-instance-limit",
+		Value: td.perInstanceMemory,
+	}
+	qds = append(qds, qd)
+	qd = types.QuotaDetails{
+		Name:  "tenant-volume-size-limit",
+		Value: td.perVolumeSize,
+	}
+	qds = append(qds, qd)
+
+	return qds
+}
+
+// Init is used to initialise the quota service.
+func (qs *Quotas) Init() {
+	qs.ch = make(chan interface{})
+
+	go func() {
+		tenantDetails := make(map[string]*tenantData)
+
+		for {
+			data, more := <-qs.ch
+			if !more {
+				return
+			}
+
+			switch data.(type) {
+
+			case *consumeOp:
+				consumeData := data.(*consumeOp)
+				res := consumeQuota(tenantDetails, consumeData)
+				if !res.Allowed() {
+					consumeData.ch <- res
+					close(consumeData.ch)
+					continue
+				}
+				res = checkLimit(tenantDetails, consumeData)
+				consumeData.ch <- res
+				close(consumeData.ch)
+
+			case *releaseOp:
+				releaseData := data.(*releaseOp)
+				release(tenantDetails, releaseData)
+
+			case *updateOp:
+				updateData := data.(*updateOp)
+				update(tenantDetails, updateData)
+				close(updateData.doneCh)
+
+			case *dumpOp:
+				dumpData := data.(*dumpOp)
+				dumpData.ch <- dump(tenantDetails, dumpData)
+				close(dumpData.ch)
+			}
+		}
+
+	}()
+}
+
+func copyResources(resources []payloads.RequestedResource) []payloads.RequestedResource {
+	copy := make([]payloads.RequestedResource, len(resources))
+
+	for i := range resources {
+		copy[i] = resources[i]
+	}
+
+	return copy
+}
+
+// Consume will update the quota records to indicate that the tenant is using
+// all the resources specified. This method should usually be used on a
+// per-instance/volume/image basis as it will also check against the limits.
+// The exception to this is for initial import when disregarding the result.
+//
+// This method returns a Result channel indicating whether the consumption is
+// allowed. The result of the Consume() is indicated by
+// Result.Allowed(). The caller can choose to ignore this or reclaim the
+// resources used (e.g. by terminating an instance.) If the caller chooses to
+// reclaim the resource they must call Quotas.Release(). The resources used in
+// the original request are available in the result by calling
+// Result.Resources(). If Result.Allowed() returns false then then
+// Result.Reason() returns an explanation that can be shared with the user.
+func (qs *Quotas) Consume(tenantID string, resources ...payloads.RequestedResource) chan Result {
+	ch := make(chan Result, 1)
+	data := &consumeOp{tenantID, copyResources(resources), ch}
+	qs.ch <- data
+
+	return ch
+}
+
+// Release will update the quota records for a tenant to indicate that it is no
+// longer using the supplied resources.
+func (qs *Quotas) Release(tenantID string, resources ...payloads.RequestedResource) {
+	data := &releaseOp{tenantID, copyResources(resources)}
+	qs.ch <- data
+}
+
+// Shutdown will stop the quota service and should be called when it is no
+// longer needed.
+func (qs *Quotas) Shutdown() {
+	close(qs.ch)
+}
+
+// Update will populate the quota service with quota and limits information.
+func (qs *Quotas) Update(tenantID string, quotas []types.QuotaDetails) {
+	ch := make(chan struct{})
+	op := &updateOp{tenantID, quotas, ch}
+	qs.ch <- op
+	<-ch
+}
+
+// DumpQuotas provides the list of quotas and limits along with usage
+// for a given tenant
+func (qs *Quotas) DumpQuotas(tenantID string) []types.QuotaDetails {
+	ch := make(chan []types.QuotaDetails, 1)
+	op := &dumpOp{tenantID, ch}
+	qs.ch <- op
+	qds := <-ch
+	return qds
+}
+
+// Allowed indicates whether the desired consumption should be permitted.
+func (r *result) Allowed() bool {
+	return r.allowed
+}
+
+// Reason gives an explanation for why the request should be denied.
+func (r *result) Reason() string {
+	return r.reason
+}
+
+// Resources gives the set of resources that made up the consumption request
+// that this Result was associated with.
+func (r *result) Resources() []payloads.RequestedResource {
+	return r.resources
+}

--- a/ciao-controller/internal/quotas/quotas_test.go
+++ b/ciao-controller/internal/quotas/quotas_test.go
@@ -1,0 +1,206 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quotas
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/01org/ciao/ciao-controller/types"
+	"github.com/01org/ciao/payloads"
+)
+
+func TestConsumeAndRelease(t *testing.T) {
+	qs := &Quotas{}
+	qs.Init()
+
+	quotas := []types.QuotaDetails{{Name: "tenant-vcpu-quota", Value: 10}}
+
+	qs.Update("test-tenant-1", quotas)
+
+	// "first instance""
+	ch := qs.Consume("test-tenant-1", payloads.RequestedResource{Type: payloads.VCPUs, Value: 10})
+	res := <-ch
+
+	if !res.Allowed() {
+		t.Fatal("Expected to be allowed")
+	}
+
+	// "second instance"
+	ch = qs.Consume("test-tenant-1", payloads.RequestedResource{Type: payloads.VCPUs, Value: 10})
+	res2 := <-ch
+
+	if res2.Allowed() {
+		t.Fatal("Expected to be denied")
+	}
+	// If denied we are responsible for releasing
+	qs.Release("test-tenant-1", res2.Resources()...)
+
+	// Now release "first instance"
+	qs.Release("test-tenant-1", res.Resources()...)
+
+	ch = qs.Consume("test-tenant-1", payloads.RequestedResource{Type: payloads.VCPUs, Value: 10})
+	res3 := <-ch
+
+	if !res3.Allowed() {
+		t.Fatal("Expected to be allowed")
+	}
+
+	qs.Shutdown()
+}
+
+func testHasQuota(t *testing.T, qds []types.QuotaDetails, qd types.QuotaDetails) {
+	for i := range qds {
+		if reflect.DeepEqual(qd, qds[i]) {
+			return
+		}
+	}
+	t.Fatalf("Quota not found: %+v", qd)
+}
+
+func TestDumpQuotas(t *testing.T) {
+	qs := &Quotas{}
+	qs.Init()
+
+	quotas := []types.QuotaDetails{
+		{Name: "tenant-vcpu-quota", Value: 10},
+		{Name: "tenant-mem-quota", Value: 100},
+	}
+
+	qs.Update("test-tenant-1", quotas)
+
+	dumpedQuotas := qs.DumpQuotas("test-tenant-1")
+
+	testHasQuota(t, dumpedQuotas, quotas[0])
+	testHasQuota(t, dumpedQuotas, quotas[1])
+
+	qs.Shutdown()
+}
+
+func TestTenantSeparation(t *testing.T) {
+	qs := &Quotas{}
+	qs.Init()
+
+	t1Quotas := []types.QuotaDetails{
+		{Name: "tenant-vcpu-quota", Value: 10},
+		{Name: "tenant-mem-quota", Value: 100},
+	}
+
+	qs.Update("test-tenant-1", t1Quotas)
+
+	t2Quotas := []types.QuotaDetails{
+		{Name: "tenant-vcpu-quota", Value: 20},
+		{Name: "tenant-mem-quota", Value: 40},
+	}
+
+	qs.Update("test-tenant-2", t2Quotas)
+
+	dumpedQuotas := qs.DumpQuotas("test-tenant-1")
+
+	testHasQuota(t, dumpedQuotas, t1Quotas[0])
+	testHasQuota(t, dumpedQuotas, t1Quotas[1])
+
+	dumpedQuotas = qs.DumpQuotas("test-tenant-2")
+
+	testHasQuota(t, dumpedQuotas, t2Quotas[0])
+	testHasQuota(t, dumpedQuotas, t2Quotas[1])
+
+	qs.Shutdown()
+}
+
+func TestResourceQuotaMapping(t *testing.T) {
+	resources := []payloads.Resource{
+		payloads.VCPUs,
+		payloads.MemMB,
+		payloads.SharedDiskGiB,
+		payloads.Volume,
+		payloads.Instance,
+		payloads.Image,
+		payloads.ExternalIP,
+	}
+
+	for _, resource := range resources {
+		qn := resourceToQuotaName(resource)
+		r := quotaNameToResource(qn)
+
+		if r != resource {
+			t.Fatal("Expected resources to be equal")
+		}
+	}
+}
+
+func TestAllLimits(t *testing.T) {
+	qs := &Quotas{}
+	qs.Init()
+
+	limits := []types.QuotaDetails{
+		{Name: "tenant-vcpu-per-instance-limit", Value: 4},
+		{Name: "tenant-mem-per-instance-limit", Value: 128},
+		{Name: "tenant-volume-size-limit", Value: 10},
+	}
+
+	qs.Update("test-tenant-1", limits)
+
+	dumpedQuotas := qs.DumpQuotas("test-tenant-1")
+
+	for _, qd := range limits {
+		testHasQuota(t, dumpedQuotas, qd)
+	}
+
+	// Over limit tests
+	rrs := []payloads.RequestedResource{
+		{
+			Type:  payloads.VCPUs,
+			Value: 8,
+		},
+		{
+			Type:  payloads.MemMB,
+			Value: 512,
+		},
+		{
+			Type:  payloads.SharedDiskGiB,
+			Value: 20,
+		},
+	}
+
+	for _, rr := range rrs {
+		r := <-qs.Consume("test-tenant-1", rr)
+		if r.Allowed() && r.Reason() != "Over limit" {
+			t.Fatalf("Expected to be over limit for: %s", rr.Type)
+		}
+	}
+
+	// Under limit tests
+	rrs = []payloads.RequestedResource{
+		{
+			Type:  payloads.VCPUs,
+			Value: 4,
+		},
+		{
+			Type:  payloads.MemMB,
+			Value: 128,
+		},
+		{
+			Type:  payloads.SharedDiskGiB,
+			Value: 10,
+		},
+	}
+	for _, rr := range rrs {
+		r := <-qs.Consume("test-tenant-1", rr)
+		if !r.Allowed() {
+			t.Fatalf("Expected to be under limit for: %s", rr.Type)
+		}
+	}
+}

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -32,7 +32,7 @@ import (
 	"sync"
 
 	"github.com/01org/ciao/ciao-controller/api"
-	datastore "github.com/01org/ciao/ciao-controller/internal/datastore"
+	"github.com/01org/ciao/ciao-controller/internal/datastore"
 	"github.com/01org/ciao/ciao-controller/internal/quotas"
 	image "github.com/01org/ciao/ciao-image/client"
 	storage "github.com/01org/ciao/ciao-storage"

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -99,26 +99,6 @@ var adminSSHKey = ""
 // default password set to "ciao"
 var adminPassword = "$6$rounds=4096$w9I3hR4g/hu$AnYjaC2DfznbPSG3vxsgtgAS4mJwWBkcR74Y/KHNB5OsfAlA4gpU5j6CHWMOkkt9j.9d7OYJXJ4icXHzKXTAO."
 
-func populateQuotasFromDatastore(qs *quotas.Quotas, ds *datastore.Datastore) error {
-	ts, err := ds.GetAllTenants()
-	if err != nil {
-		return errors.Wrap(err, "error getting tenants")
-	}
-
-	for _, t := range ts {
-
-		qds, err := ds.GetQuotas(t.ID)
-		if err != nil {
-			return errors.Wrapf(err, "error getting quotas for tenant %s", t.ID)
-		}
-		qs.Update(t.ID, qds)
-	}
-
-	// TODO: Need to import current usage from datastore too.
-
-	return nil
-}
-
 func init() {
 	flag.Parse()
 

--- a/ciao-controller/quotas.go
+++ b/ciao-controller/quotas.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "github.com/01org/ciao/ciao-controller/types"
+
+func (c *controller) UpdateQuotas(tenantID string, qds []types.QuotaDetails) error {
+	err := c.ds.UpdateQuotas(tenantID, qds)
+	if err != nil {
+		return errors.Wrap(err, "error updating quotas in database")
+	}
+	c.qs.Update(tenantID, qds)
+	return nil
+}
+
+func (c *controller) ListQuotas(tenantID string) []types.QuotaDetails {
+	return c.qs.DumpQuotas(tenantID)
+}

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -734,3 +734,13 @@ func (qd *QuotaDetails) UnmarshalJSON(data []byte) error {
 	qd.Usage, _ = strconv.Atoi(tmp.Usage)
 	return nil
 }
+
+// QuotaUpdateRequest holds the layout for updating quota API
+type QuotaUpdateRequest struct {
+	Quotas []QuotaDetails `json:"quotas"`
+}
+
+// QuotaListResponse holds the layout for returning quotas in the API
+type QuotaListResponse struct {
+	Quotas []QuotaDetails `json:"quotas"`
+}

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -17,7 +17,10 @@
 package types
 
 import (
+	"encoding/json"
 	"errors"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/01org/ciao/ciao-storage"
@@ -677,4 +680,57 @@ type QuotaDetails struct {
 	Name  string
 	Value int
 	Usage int
+}
+
+// MarshalJSON provides a custom marshaller for quota API
+func (qd *QuotaDetails) MarshalJSON() ([]byte, error) {
+	var v string
+	if qd.Value == -1 {
+		v = "unlimited"
+	} else {
+		v = strconv.Itoa(qd.Value)
+	}
+
+	if strings.Contains(qd.Name, "limit") {
+		return json.Marshal(&struct {
+			Name  string `json:"name"`
+			Value string `json:"value"`
+		}{
+			Name:  qd.Name,
+			Value: v,
+		})
+	}
+
+	return json.Marshal(&struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+		Usage string `json:"usage"`
+	}{
+		Name:  qd.Name,
+		Value: v,
+		Usage: strconv.Itoa(qd.Usage),
+	})
+}
+
+// UnmarshalJSON provides a custom demarshaller for quota API
+func (qd *QuotaDetails) UnmarshalJSON(data []byte) error {
+	tmp := struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+		Usage string `json:"usage"`
+	}{}
+
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+
+	qd.Name = tmp.Name
+	if tmp.Value == "unlimited" {
+		qd.Value = -1
+	} else {
+		qd.Value, _ = strconv.Atoi(tmp.Value)
+	}
+	qd.Usage, _ = strconv.Atoi(tmp.Usage)
+	return nil
 }

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -671,3 +671,10 @@ type MapIPRequest struct {
 	PoolName   *string `json:"pool_name"`
 	InstanceID string  `json:"instance_id"`
 }
+
+// QuotaDetails holds information for updating and querying quotas
+type QuotaDetails struct {
+	Name  string
+	Value int
+	Usage int
+}

--- a/payloads/start.go
+++ b/payloads/start.go
@@ -76,6 +76,23 @@ const (
 	// a network node (ie: only relevant when resource NetworkNode has
 	// value true.
 	PhysicalNetwork = "physical_network"
+
+	// Instance is used to indicate that this requested resource is an instance.
+	Instance = "instance"
+
+	// Volume is used to indicate that the requested resource is a volume.
+	Volume = "volume"
+
+	// Image is used to indicate that the requested resource is an image.
+	Image = "image"
+
+	// ExternalIP is used to indicate the the requested resource is an
+	// externally accessible IP address.
+	ExternalIP = "external_ip"
+
+	// SharedDiskGiB is used for shared storage across the cluster used for
+	// storing volume and images. (Measured in GiB)
+	SharedDiskGiB = "shared_disk_gib"
 )
 
 const (


### PR DESCRIPTION
Here is a working prototype for quotas and limits (the only thing i've not published here is the ciao-cli support as i'm still tidying that up)

The core of my design for this feature is based around a Quota Service (QS) that handles the in-memory storing of quotas/limits and the appropriate usage.

The main entry points to the API that the QS provides to other parts of controller is to Consume() or to Release() sets of payloads.RequestedResource structs.

An example of how this works can be seen in the "ciao-controller: Add quota checking for shared storage" commit.

The QS is designed so that it is safe to be accessed from multiple goroutines without using mutexes and also the API for consuming is asynchronous around a channel to allow e.g. instances to be started and then shutdown later if the quota is exceeded.

The sqlite database is used only to persist the quotas and is read from at startup and updated when the API is used to update the quota (the QS value for the quota is updated at the same time.)

One thing that this patch set does not yet cover is populating the QS with existing volumes that already exist when controller starts up.
