### PR TITLE
Enable node networks based scheduling

### DIFF
--- a/ciao-launcher/overseer.go
+++ b/ciao-launcher/overseer.go
@@ -247,6 +247,10 @@ func (ovs *overseer) sendReadyStatusCommand(cns *cnStats) {
 	s.Load = cns.load
 	s.CpusOnline = cns.cpusOnline
 	s.DiskTotalMB, s.DiskAvailableMB = cns.totalDiskMB, cns.availableDiskMB
+	s.Networks = make([]payloads.NetworkStat, len(nicInfo))
+	for i, nic := range nicInfo {
+		s.Networks[i] = *nic
+	}
 
 	payload, err := yaml.Marshal(&s)
 	if err != nil {

--- a/ciao-scheduler/export_test.go
+++ b/ciao-scheduler/export_test.go
@@ -21,6 +21,7 @@ type NodeStat nodeStat
 type WorkResources workResources
 
 var PickComputeNode = pickComputeNode
+var PickNetworkNode = pickNetworkNode
 
 var ConnectController = connectController
 var DisconnectController = disconnectController

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -93,6 +93,7 @@ type nodeStat struct {
 	load        int
 	cpus        int
 	isNetNode   bool
+	networks    []payloads.NetworkStat
 }
 
 type controllerStatus uint8
@@ -381,6 +382,7 @@ func (sched *ssntpSchedulerServer) updateNodeStat(node *nodeStat, status ssntp.S
 		node.diskAvailMB = stats.DiskAvailableMB
 		node.load = stats.Load
 		node.cpus = stats.CpusOnline
+		node.networks = stats.Networks
 
 		//any changes to the payloads.Ready struct should be
 		//accompanied by a change here

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -723,7 +723,7 @@ func pickComputeNode(sched *ssntpSchedulerServer, controllerUUID string, workloa
 }
 
 // Find suitable net node, returning referenced to a locked nodeStat if found
-func (sched *ssntpSchedulerServer) pickNetworkNode(controllerUUID string, workload *workResources) (node *nodeStat) {
+func pickNetworkNode(sched *ssntpSchedulerServer, controllerUUID string, workload *workResources) (node *nodeStat) {
 	sched.nnMutex.RLock()
 	defer sched.nnMutex.RUnlock()
 
@@ -787,7 +787,7 @@ func startWorkload(sched *ssntpSchedulerServer, controllerUUID string, payload [
 	var targetNode *nodeStat
 
 	if workload.networkNode {
-		targetNode = sched.pickNetworkNode(controllerUUID, &workload)
+		targetNode = pickNetworkNode(sched, controllerUUID, &workload)
 	} else { //workload.network_node == false
 		targetNode = pickComputeNode(sched, controllerUUID, &workload)
 	}

--- a/ciao-scheduler/scheduler_internal_test.go
+++ b/ciao-scheduler/scheduler_internal_test.go
@@ -182,28 +182,28 @@ func TestPickComputeNode(t *testing.T) {
 	// no compute nodes
 	node := PickComputeNode(sched, "", &resources)
 	if node != nil {
-		t.Error("fount fit in empty node list")
+		t.Error("found compute fit in empty node list")
 	}
 
 	// 1st compute node, with little memory
 	spinUpComputeNodeVerySmall(sched, 1)
 	node = PickComputeNode(sched, "", &resources)
 	if node != nil {
-		t.Error("found fit when none should exist")
+		t.Error("found compute fit when none should exist")
 	}
 
 	// 2nd compute node, with little memory
 	spinUpComputeNodeVerySmall(sched, 2)
 	node = PickComputeNode(sched, "", &resources)
 	if node != nil {
-		t.Error("found fit when none should exist")
+		t.Error("found compute fit when none should exist")
 	}
 
 	// 3rd compute node, with a lot of memory
 	spinUpComputeNodeLarge(sched, 3)
 	node = PickComputeNode(sched, "", &resources)
 	if node == nil {
-		t.Error("found no fit when one should exist")
+		t.Error("found no compute fit when one should exist")
 	}
 
 	// 100 compute nodes := earlier 1 + 1 + 1 + now 97 more compute nodes
@@ -212,14 +212,14 @@ func TestPickComputeNode(t *testing.T) {
 	}
 	node = PickComputeNode(sched, "", &resources)
 	if node == nil {
-		t.Error("failed to fit in hundred node list")
+		t.Error("failed to fit in hundred compute node list")
 	}
 
-	// MRU set somewhere arbitrary
+	// compute MRU set somewhere arbitrary
 	sched.cnMRUIndex = 42
 	node = PickComputeNode(sched, "", &resources)
 	if node == nil {
-		t.Error("failed to find fit after MRU")
+		t.Error("failed to find compute fit after MRU")
 	}
 }
 

--- a/ciao-scheduler/scheduler_internal_test.go
+++ b/ciao-scheduler/scheduler_internal_test.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"testing"
 
+	yaml "gopkg.in/yaml.v2"
+
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp"
 	"github.com/01org/ciao/testutil"
@@ -63,6 +65,7 @@ func spinUpComputeNode(sched *ssntpSchedulerServer, ident int, RAM int) {
 	node.memAvailMB = RAM
 	node.load = 0
 	node.cpus = 4
+	node.isNetNode = false
 
 	sched.cnMutex.Lock()
 	defer sched.cnMutex.Unlock()
@@ -86,7 +89,7 @@ func spinUpComputeNodeVerySmall(sched *ssntpSchedulerServer, ident int) {
 	spinUpComputeNode(sched, ident, 200)
 }
 
-func spinUpNetworkNode(sched *ssntpSchedulerServer, ident int, RAM int) {
+func spinUpNetworkNode(sched *ssntpSchedulerServer, ident int, RAM int, networks []payloads.NetworkStat) {
 	var node nodeStat
 	node.status = ssntp.READY
 	node.uuid = fmt.Sprintf("%08d", ident)
@@ -94,6 +97,8 @@ func spinUpNetworkNode(sched *ssntpSchedulerServer, ident int, RAM int) {
 	node.memAvailMB = RAM
 	node.load = 0
 	node.cpus = 4
+	node.isNetNode = true
+	node.networks = networks
 
 	sched.nnMutex.Lock()
 	defer sched.nnMutex.Unlock()
@@ -103,17 +108,18 @@ func spinUpNetworkNode(sched *ssntpSchedulerServer, ident int, RAM int) {
 		return
 	}
 
+	sched.nnList = append(sched.nnList, &node)
 	sched.nnMap[node.uuid] = &node
 }
 
-func spinUpNetworkNodeLarge(sched *ssntpSchedulerServer, ident int) {
-	spinUpNetworkNode(sched, ident, 141312)
+func spinUpNetworkNodeLarge(sched *ssntpSchedulerServer, ident int, networks []payloads.NetworkStat) {
+	spinUpNetworkNode(sched, ident, 141312, networks)
 }
-func spinUpNetworkNodeSmall(sched *ssntpSchedulerServer, ident int) {
-	spinUpNetworkNode(sched, ident, 16384)
+func spinUpNetworkNodeSmall(sched *ssntpSchedulerServer, ident int, networks []payloads.NetworkStat) {
+	spinUpNetworkNode(sched, ident, 16384, networks)
 }
-func spinUpNetworkNodeVerySmall(sched *ssntpSchedulerServer, ident int) {
-	spinUpNetworkNode(sched, ident, 200)
+func spinUpNetworkNodeVerySmall(sched *ssntpSchedulerServer, ident int, networks []payloads.NetworkStat) {
+	spinUpNetworkNode(sched, ident, 200, networks)
 }
 
 /****************************************************************************/
@@ -274,9 +280,138 @@ func BenchmarkPickComputeNode100000(b *testing.B) {
 }
 func BenchmarkPickComputeNode1000000(b *testing.B) {
 	if testing.Short() {
-		b.Skip("skipping 1Mc n picker bench in short mode.")
+		b.Skip("skipping 1M cn picker bench in short mode.")
 	}
 	benchmarkPickComputeNode(b, 1000000)
+}
+
+func TestPickNetworkNode(t *testing.T) {
+	sched = configSchedulerServer()
+	if sched == nil {
+		t.Fatal("unable to configure test scheduler")
+	}
+
+	var work payloads.Start
+	err := yaml.Unmarshal([]byte(testutil.CNCIStartYaml), &work)
+	if err != nil {
+		t.Fatalf("bad CNCI workload yaml: %s", err)
+	}
+
+	resources, err := sched.getWorkloadResources(&work)
+	if err != nil ||
+		resources.instanceUUID != testutil.CNCIInstanceUUID {
+		t.Fatalf("bad CNCI workload resources %s, %d", resources.instanceUUID, resources.memReqMB)
+	}
+
+	// no network nodes
+	node := PickNetworkNode(sched, "", &resources)
+	if node != nil {
+		t.Error("found network fit in empty node list")
+	}
+
+	// 1st network node, with little memory
+	spinUpNetworkNodeVerySmall(sched, 1, testutil.MultipleComputeNetworks)
+	node = PickNetworkNode(sched, "", &resources)
+	if node != nil {
+		t.Error("found network fit when none should exist")
+	}
+
+	// 2nd network node, with even less resources
+	spinUpNetworkNodeVerySmall(sched, 2, testutil.PartialComputeNetworks)
+	node = PickNetworkNode(sched, "", &resources)
+	if node != nil {
+		t.Error("found network fit when none should exist")
+	}
+
+	// 3rd network node, with a lot of memory, well connected
+	spinUpNetworkNodeLarge(sched, 3, testutil.MultipleComputeNetworks)
+	node = PickNetworkNode(sched, "", &resources)
+	if node == nil {
+		t.Error("found no network fit when one should exist")
+	}
+
+	// 100 network nodes := earlier 1 + 1 + 1 + 1 + now 96 more compute nodes
+	// half and half with all or partial connectivity
+	for i := 5; i < 100; i++ {
+		if i%2 == 0 {
+			spinUpNetworkNode(sched, i, 256*i, testutil.MultipleComputeNetworks)
+		} else {
+			spinUpNetworkNode(sched, i, 256*i, testutil.PartialComputeNetworks)
+		}
+	}
+	node = PickNetworkNode(sched, "", &resources)
+	if node == nil {
+		t.Error("failed to fit in hundred network node list")
+	}
+
+	// do a few more to insure we walk some nodes that don't have the
+	// requested network connectivity after network MRU is set somewhere
+	// arbitrary
+	sched.nnMRUIndex = 42
+	node = PickNetworkNode(sched, "", &resources)
+	if node == nil {
+		t.Error("failed to find network fit after MRU")
+	}
+	node = PickNetworkNode(sched, "", &resources)
+	if node == nil {
+		t.Error("failed to find network fit when many should exist")
+	}
+}
+
+func benchmarkPickNetworkNode(b *testing.B, nodecount int) {
+	sched = configSchedulerServer()
+	if sched == nil {
+		b.Fatal("unable to configure test scheduler")
+	}
+
+	// eg: idle, small network nodes
+	for i := 0; i < nodecount; i++ {
+		spinUpNetworkNode(sched, i, 16138, testutil.MultipleComputeNetworks)
+	}
+
+	var work = createStartWorkload(2, 256, 10000)
+	resources, err := sched.getWorkloadResources(work)
+	if err != nil {
+		b.Fatal("bad workload resources")
+	}
+
+	b.ResetTimer()
+	// setup complete
+
+	for i := 0; i < b.N; i++ {
+		PickNetworkNode(sched, "", &resources)
+	}
+}
+
+func BenchmarkPickNetworkNode10(b *testing.B) {
+	benchmarkPickNetworkNode(b, 10)
+}
+func BenchmarkPickNetworkNode100(b *testing.B) {
+	benchmarkPickNetworkNode(b, 100)
+}
+func BenchmarkPickNetworkNode1000(b *testing.B) {
+	if testing.Short() {
+		b.Skip("skipping 1k nn picker bench in short mode.")
+	}
+	benchmarkPickNetworkNode(b, 1000)
+}
+func BenchmarkPickNetworkNode10000(b *testing.B) {
+	if testing.Short() {
+		b.Skip("skipping 10k nn picker bench in short mode.")
+	}
+	benchmarkPickNetworkNode(b, 10000)
+}
+func BenchmarkPickNetworkNode100000(b *testing.B) {
+	if testing.Short() {
+		b.Skip("skipping 100k nn picker bench in short mode.")
+	}
+	benchmarkPickNetworkNode(b, 100000)
+}
+func BenchmarkPickNetworkNode1000000(b *testing.B) {
+	if testing.Short() {
+		b.Skip("skipping 1M nn picker bench in short mode.")
+	}
+	benchmarkPickNetworkNode(b, 1000000)
 }
 
 func TestHeartBeatController(t *testing.T) {
@@ -369,11 +504,11 @@ func TestHeartBeat(t *testing.T) {
 	spinUpComputeNode(sched, 3, 10000)
 	spinUpComputeNode(sched, 4, 42)
 	spinUpComputeNode(sched, 5, 44032)
-	spinUpNetworkNode(sched, 1001, 16138)
-	spinUpNetworkNode(sched, 1002, 256)
-	spinUpNetworkNode(sched, 1003, 10000)
-	spinUpNetworkNode(sched, 1004, 42)
-	spinUpNetworkNode(sched, 1005, 44032)
+	spinUpNetworkNode(sched, 1001, 16138, testutil.MultipleComputeNetworks)
+	spinUpNetworkNode(sched, 1002, 256, testutil.MultipleComputeNetworks)
+	spinUpNetworkNode(sched, 1003, 10000, testutil.MultipleComputeNetworks)
+	spinUpNetworkNode(sched, 1004, 42, testutil.MultipleComputeNetworks)
+	spinUpNetworkNode(sched, 1005, 44032, testutil.MultipleComputeNetworks)
 	beatTxt = heartBeat(sched, 1)
 	expected = "controller-00000001:MASTER, controller-00000002:BACKUP\t\tnode-00000001:READY:16138/16138,0, node-00000002:READY:256/256,0, node-00000003:READY:10000/10000,0, node-00000004:READY:42/42,0"
 	if beatTxt != expected {
@@ -561,11 +696,11 @@ func TestStartWorkload(t *testing.T) {
 	spinUpComputeNode(sched, 4, 42)
 	spinUpComputeNode(sched, 5, 44032)
 
-	spinUpNetworkNode(sched, 1001, 16138)
-	spinUpNetworkNode(sched, 1002, 256)
-	spinUpNetworkNode(sched, 1003, 10000)
-	spinUpNetworkNode(sched, 1004, 42)
-	spinUpNetworkNode(sched, 1005, 44032)
+	spinUpNetworkNode(sched, 1001, 16138, testutil.MultipleComputeNetworks)
+	spinUpNetworkNode(sched, 1002, 256, testutil.MultipleComputeNetworks)
+	spinUpNetworkNode(sched, 1003, 10000, testutil.MultipleComputeNetworks)
+	spinUpNetworkNode(sched, 1004, 42, testutil.MultipleComputeNetworks)
+	spinUpNetworkNode(sched, 1005, 44032, testutil.MultipleComputeNetworks)
 
 	var dest string
 

--- a/ciao-scheduler/scheduler_ssntp_test.go
+++ b/ciao-scheduler/scheduler_ssntp_test.go
@@ -53,7 +53,7 @@ func TestSendAgentStatus(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		agent.SendStatus(163840, 163840)
+		agent.SendStatus(163840, 163840, testutil.PartialComputeNetworks)
 		wg.Done()
 	}()
 
@@ -82,7 +82,7 @@ func TestSendNetAgentStatus(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		netAgent.SendStatus(163840, 163840)
+		netAgent.SendStatus(163840, 163840, testutil.MultipleComputeNetworks)
 		wg.Done()
 	}()
 

--- a/payloads/ready.go
+++ b/payloads/ready.go
@@ -45,6 +45,10 @@ type Ready struct {
 	// cpu[0-9]+ entries in /proc/stat.
 	CpusOnline int `yaml:"cpus_online"`
 
+	// Array containing one entry for each network interface present on the
+	// CN/NN
+	Networks []NetworkStat
+
 	// Any changes to this struct should be accompanied by a change to
 	// the ciao-scheduler/scheduler.go:updateNodeStat() function
 }

--- a/payloads/ready_test.go
+++ b/payloads/ready_test.go
@@ -41,6 +41,10 @@ func TestReadyMarshal(t *testing.T) {
 		DiskAvailableMB: 256000,
 		Load:            0,
 		CpusOnline:      4,
+		Networks: []NetworkStat{
+			{NodeIP: "192.168.1.1", NodeMAC: "02:00:15:03:6f:49"},
+			{NodeIP: "10.168.1.1", NodeMAC: "02:00:8c:ba:f9:45"},
+		},
 	}
 
 	y, err := yaml.Marshal(&cmd)
@@ -79,7 +83,8 @@ func TestReadyNodeNotAllStats(t *testing.T) {
 		cmd.DiskTotalMB != expectedCmd.DiskTotalMB ||
 		cmd.DiskAvailableMB != expectedCmd.DiskAvailableMB ||
 		cmd.Load != expectedCmd.Load ||
-		cmd.CpusOnline != expectedCmd.CpusOnline {
+		cmd.CpusOnline != expectedCmd.CpusOnline ||
+		len(cmd.Networks) != 0 {
 		t.Error("Unexpected values in Ready")
 	}
 }

--- a/payloads/start.go
+++ b/payloads/start.go
@@ -71,6 +71,11 @@ const (
 	// ComputeNode indicates that a resource struct specifies whether the
 	// command in which it is embedded applies to a compute node.
 	ComputeNode = "compute_node"
+
+	// PhysicalNetwork indicates a resource is specifying an network on
+	// a network node (ie: only relevant when resource NetworkNode has
+	// value true.
+	PhysicalNetwork = "physical_network"
 )
 
 const (

--- a/payloads/start.go
+++ b/payloads/start.go
@@ -123,6 +123,9 @@ type RequestedResource struct {
 	// Value specifies the integer value associated with that resource.
 	Value int `yaml:"value"`
 
+	// ValueString is an optional string format value instead of integer
+	ValueString string `yaml:"value_string,omitempty"`
+
 	// Mandatory indicates whether a resource is mandatory or not.
 	Mandatory bool `yaml:"mandatory"`
 }

--- a/testutil/agent.go
+++ b/testutil/agent.go
@@ -610,10 +610,10 @@ func (client *SsntpTestClient) SendStatsCmd() {
 
 // SendStatus pushes an ssntp status frame from the SsntpTestClient with
 // the indicated total and available memory statistics
-func (client *SsntpTestClient) SendStatus(memTotal int, memAvail int) {
+func (client *SsntpTestClient) SendStatus(memTotal int, memAvail int, networks []payloads.NetworkStat) {
 	var result Result
 
-	payload := ReadyPayload(client.UUID, memTotal, memAvail)
+	payload := ReadyPayload(client.UUID, memTotal, memAvail, networks)
 
 	y, err := yaml.Marshal(payload)
 	if err != nil {

--- a/testutil/client_server_test.go
+++ b/testutil/client_server_test.go
@@ -39,7 +39,7 @@ var cnciAgent *SsntpTestClient
 func TestSendAgentStatus(t *testing.T) {
 	serverCh := server.AddStatusChan(ssntp.READY)
 
-	go agent.SendStatus(16384, 16384)
+	go agent.SendStatus(16384, 16384, PartialComputeNetworks)
 
 	_, err := server.GetStatusChanResult(serverCh, ssntp.READY)
 	if err != nil {
@@ -50,7 +50,7 @@ func TestSendAgentStatus(t *testing.T) {
 func TestSendNetAgentStatus(t *testing.T) {
 	serverCh := server.AddStatusChan(ssntp.READY)
 
-	go netAgent.SendStatus(16384, 16384)
+	go netAgent.SendStatus(16384, 16384, MultipleComputeNetworks)
 
 	_, err := server.GetStatusChanResult(serverCh, ssntp.READY)
 	if err != nil {

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -114,6 +114,33 @@ const AgentUUID = "4cb19522-1e18-439a-883a-f9b2a3a95f5e"
 // VolumeUUID is a node UUID for storage tests
 const VolumeUUID = "67d86208-b46c-4465-9018-e14187d4010"
 
+var computeNetwork001 = payloads.NetworkStat{
+	NodeIP:  "198.51.100.1",
+	NodeMAC: "02:00:aa:cb:84:41",
+}
+var computeNetwork002 = payloads.NetworkStat{
+	NodeIP:  "10.168.1.1",
+	NodeMAC: "02:00:8c:ba:f9:45",
+}
+var computeNetwork003 = payloads.NetworkStat{
+	NodeIP:  ComputeNet,
+	NodeMAC: "02:00:15:03:6f:49",
+}
+
+// PartialComputeNetworks is meant to represent a node with partial access to
+// compute networks in the testutil cluster
+var PartialComputeNetworks = []payloads.NetworkStat{
+	computeNetwork002,
+}
+
+// MultipleComputeNetworks is meant to represent a node with full access to
+// all compute networks in the testutil cluster
+var MultipleComputeNetworks = []payloads.NetworkStat{
+	computeNetwork001,
+	computeNetwork002,
+	computeNetwork003,
+}
+
 //////////////////////////////////////////////////////////////////////////////
 
 // StartYaml is a sample workload START ssntp.Command payload for test usage
@@ -166,6 +193,8 @@ const CNCIStartYaml = `start:
     - type: network_node
       value: 1
       mandatory: true
+    - type: physical_network
+      value_string: ` + ComputeNet + `
   networking:
     vnic_mac: ` + VNICMAC + `
     vnic_uuid: ` + VNICUUID + `
@@ -384,8 +413,8 @@ const NodeConnectedYaml = `node_connected:
 `
 
 // ReadyPayload is a helper to craft a mostly fixed ssntp.READY status
-// payload, with parameters to specify the source node uuid and memory metrics
-func ReadyPayload(uuid string, memTotal int, memAvail int) payloads.Ready {
+// payload, with parameters to specify the source node uuid and available resources
+func ReadyPayload(uuid string, memTotal int, memAvail int, networks []payloads.NetworkStat) payloads.Ready {
 	p := payloads.Ready{
 		NodeUUID:        uuid,
 		MemTotalMB:      memTotal,
@@ -394,6 +423,7 @@ func ReadyPayload(uuid string, memTotal int, memAvail int) payloads.Ready {
 		DiskAvailableMB: 256000,
 		Load:            0,
 		CpusOnline:      4,
+		Networks:        networks,
 	}
 	return p
 }

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -406,6 +406,11 @@ disk_total_mb: 500000
 disk_available_mb: 256000
 load: 0
 cpus_online: 4
+networks:
+- ip: 192.168.1.1
+  mac: 02:00:15:03:6f:49
+- ip: 10.168.1.1
+  mac: 02:00:8c:ba:f9:45
 `
 
 // PartialReadyYaml is a sample minimal node READY ssntp.Status payload for test cases


### PR DESCRIPTION
This PR allows scheduling of a workload to a network node that satisfies a workload's request for specific network connectivity.

Partially addresses #1044, but completely closing that issue depends on addressing issue #912.  When controller is able to restart a CNCI, it will need to add a network resource request, which scheduler can honor as of this PR.