### PR TITLE
ciao-cli: auto-generate template documentation

### DIFF
--- a/ciao-cli/event.go
+++ b/ciao-cli/event.go
@@ -48,17 +48,8 @@ The list flags are:
 
 `)
 	cmd.Flag.PrintDefaults()
-	fmt.Fprintf(os.Stderr, `
-The template passed to the -f option operates on a 
-
-[]struct {
-	Timestamp time.Time // Event timestamp
-	TenantID  string    // UUID of the tenant that generated this event
-	EventType string    // Type of event, e.g., info, warn, error.
-	Message   string    // Event message
-}
-`)
-	fmt.Fprintln(os.Stderr, templateFunctionHelp)
+	fmt.Fprintf(os.Stderr, "\n%s",
+		generateUsageDecorated("f", types.CiaoEvents{}.Events))
 	os.Exit(2)
 }
 

--- a/ciao-cli/external-ips.go
+++ b/ciao-cli/external-ips.go
@@ -31,40 +31,6 @@ import (
 	"github.com/01org/ciao/ciao-controller/types"
 )
 
-const (
-	externalSubnetDesc = `struct {
-	ID	string			// ID of the external subnet
-	CIDR	string			// CIDR representation of the subnet
-}`
-	externalIPDesc = `struct {
-	ID	string			// ID of the external IP
-	Address	string			// the IPv4 Address
-}`
-	poolTemplateDesc = `struct {
-	ID       string                 // ID of the pool (Admin only)
-	Name     string                 // Name of the pool
-	TotalIPs int                    // Total IPs in pool (Admin only)
-	Free	 int                    // Total Free IPs in pool (Admin only)
-}`
-	poolShowTemplateDesc = `struct {
-	ID	string			// ID of the pool
-	Name	string			// name of the pool
-	Free	int			// Total free IPs in pool
-	TotalIPs int			// Total IPs in pool
-	Subnets []ExternalSubnet	// Subnets in this pool
-	IPs	[]ExternalIP		// Individual IPs in this pool
-}`
-	externalIPTemplate = `struct {
-	ID		string		// ID of the mapped IP
-	ExternalIP 	string		// External IP address
-	InternalIP	string		// Internal IP address
-	InstanceID	string		// ID of the instance that is mapped (Admin only)
-	TenantID	string		// ID of the tenant (Admin only)
-	PoolID		string		// ID of the allocation pool (Admin only)
-	PoolName	string		// Name of the allocation pool (Admin only)
-}`
-)
-
 func getCiaoExternalIPsResource() (string, string, error) {
 	url, err := getCiaoResource("external-ips", api.ExternalIPsV1)
 	return url, api.ExternalIPsV1, err
@@ -193,13 +159,7 @@ The list flags are:
 
 `)
 	cmd.Flag.PrintDefaults()
-
-	fmt.Fprintf(os.Stderr, `
-The template passed to the -f option operates on a
-
-[]%s
-`, externalIPTemplate)
-	fmt.Fprintln(os.Stderr, templateFunctionHelp)
+	fmt.Fprintf(os.Stderr, "\n%s", generateUsageDecorated("f", []types.MappedIP{}))
 	os.Exit(2)
 }
 
@@ -477,13 +437,8 @@ The list flags are:
 
 `)
 	cmd.Flag.PrintDefaults()
-	fmt.Fprintf(os.Stderr, `
-The template passed to the -f option operates on a
-
-[]%s
-`, poolTemplateDesc)
-	fmt.Fprintln(os.Stderr, templateFunctionHelp)
-
+	fmt.Fprintf(os.Stderr, "\n%s",
+		generateUsageDecorated("f", types.ListPoolsResponse{}.Pools))
 	os.Exit(2)
 }
 
@@ -566,24 +521,7 @@ The show flags are:
 
 `)
 	cmd.Flag.PrintDefaults()
-	fmt.Fprintf(os.Stderr, `
-The template passed to the -f option operates on a
-
-%s
-`, poolShowTemplateDesc)
-	fmt.Fprintf(os.Stderr, `
-The externalSubnets are described by
-
-%s
-`, externalSubnetDesc)
-
-	fmt.Fprintf(os.Stderr, `
-The externalIPs are described by
-
-%s
-`, externalIPDesc)
-	fmt.Fprintln(os.Stderr, templateFunctionHelp)
-
+	fmt.Fprintf(os.Stderr, "\n%s", generateUsageDecorated("f", types.Pool{}))
 	os.Exit(2)
 }
 

--- a/ciao-cli/image.go
+++ b/ciao-cli/image.go
@@ -30,17 +30,6 @@ import (
 	"github.com/rackspace/gophercloud/pagination"
 )
 
-const imageTemplateDesc = `struct {
-	Name             string   // Image name
-	SizeBytes        int      // Size of image in bytes
-	ID               string   // Image UUID
-	Status           string   // Image status.  Can be queued or active
-	CreatedDate      string   // Image creation date
-	LastUpdate       string   // Timestamp of last update
-	File             string   // Image path
-	Schema           string   // Path to json schema
-}`
-
 var imageCommand = &command{
 	SubCommands: map[string]subCommand{
 		"add":    new(imageAddCommand),
@@ -67,12 +56,7 @@ The add flags are:
 
 `)
 	cmd.Flag.PrintDefaults()
-	fmt.Fprintf(os.Stderr, `
-The template passed to the -f option operates on a 
-
-%s
-`, imageTemplateDesc)
-	fmt.Fprintln(os.Stderr, templateFunctionHelp)
+	fmt.Fprintf(os.Stderr, "\n%s", generateUsageDecorated("f", images.Image{}))
 	os.Exit(2)
 }
 
@@ -142,12 +126,7 @@ func (cmd *imageShowCommand) usage(...string) {
 Show images
 `)
 	cmd.Flag.PrintDefaults()
-	fmt.Fprintf(os.Stderr, `
-The template passed to the -f option operates on a 
-
-%s
-`, imageTemplateDesc)
-	fmt.Fprintln(os.Stderr, templateFunctionHelp)
+	fmt.Fprintf(os.Stderr, "\n%s", generateUsageDecorated("f", images.Image{}))
 	os.Exit(2)
 }
 
@@ -197,12 +176,12 @@ List images
 	fmt.Fprintf(os.Stderr, `
 The template passed to the -f option operates on a 
 
-[]%s
+%s
 
 As images are retrieved in pages, the template may be applied multiple
 times.  You can not therefore rely on the length of the slice passed
 to the template to determine the total number of images.
-`, imageTemplateDesc)
+`, generateUsageUndecorated([]images.Image{}))
 	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }

--- a/ciao-cli/instance.go
+++ b/ciao-cli/instance.go
@@ -35,30 +35,9 @@ import (
 )
 
 const (
-	osStart              = "os-start"
-	osStop               = "os-stop"
-	osDelete             = "os-delete"
-	instanceTemplateDesc = `struct {
-	HostID   string                               // ID of the host node
-	ID       string                               // Instance UUID
-	TenantID string                               // Tenant UUID
-	Flavor   struct {
-		ID string                             // Workload UUID
-	}
-	Image struct {
-		ID string                             // Backing image UUID
-	}
-	Status    string                              // Instance status
-	Addresses struct {
-		Private []struct {
-			Addr               string     // Instance IP address
-			OSEXTIPSMACMacAddr string     // Instance MAC address
-		}
-	}
-	SSHIP   string                                // Instance SSH IP address
-	SSHPort int                                   // Instance SSH Port
-	OsExtendedVolumesVolumesAttached []string     // list of attached volumes
-}`
+	osStart  = "os-start"
+	osStop   = "os-stop"
+	osDelete = "os-delete"
 )
 
 var instanceCommand = &command{
@@ -719,12 +698,7 @@ The list flags are:
 
 `)
 	cmd.Flag.PrintDefaults()
-	fmt.Fprintf(os.Stderr, `
-The template passed to the -f option operates on a 
-
-[]%s
-`, instanceTemplateDesc)
-	fmt.Fprintln(os.Stderr, templateFunctionHelp)
+	fmt.Fprintf(os.Stderr, "\n%s", generateUsageDecorated("f", []compute.ServerDetails{}))
 	os.Exit(2)
 }
 
@@ -852,13 +826,7 @@ The show flags are:
 
 `)
 	cmd.Flag.PrintDefaults()
-
-	fmt.Fprintf(os.Stderr, `
-The template passed to the -f option operates on a 
-
-%s
-`, instanceTemplateDesc)
-	fmt.Fprintln(os.Stderr, templateFunctionHelp)
+	fmt.Fprintf(os.Stderr, "\n%s", generateUsageDecorated("f", compute.ServerDetails{}))
 	os.Exit(2)
 }
 

--- a/ciao-cli/node.go
+++ b/ciao-cli/node.go
@@ -25,34 +25,6 @@ import (
 	"github.com/01org/ciao/ciao-controller/types"
 )
 
-const cnciTemplateDesc = `struct {
-	ID        string // UUID of network node
-	TenantID  string // UUID of tenant to which this CNCI pertains
-	IPv4      string // IP address of CNCI
-	Geography string // Physical location of the network node
-	Subnets   []struct {
-		Subnet string // Subnet used by the CNCI
-	}
-}
-`
-
-const computeTemplateDesc = `struct {
-	ID                    string // UUID of the compute node
-	Timestamp             time.Time
-	Status                string // Node status, e.g., READY, FULL
-	MemTotal              int    // Total amount of RAM on Compute Node in MB
-	MemAvailable          int    // Memory available on Compute Node in MB
-	DiskTotal             int    // Total amount of Disk Space on Compute Node in MB
-	DiskAvailable         int    // Disk Space available on Compute Node in MB
-	Load                  int    // Compute node load
-	OnlineCPUs            int    // Number of CPUs
-	TotalInstances        int    // Number of instances hosted by the Compute Node
-	TotalRunningInstances int    // Number of running instances
-	TotalPendingInstances int    // Number of pending instances
-	TotalPausedInstances  int    // Number of paused instances
-}
-`
-
 var nodeCommand = &command{
 	SubCommands: map[string]subCommand{
 		"list":   new(nodeListCommand),
@@ -82,12 +54,13 @@ The template passed to the -f option operates on one of the following types:
 
 --cnci
 
-[]%s
+%s
 
 --compute
 
-[]%s
-`, cnciTemplateDesc, computeTemplateDesc)
+%s`,
+		generateUsageUndecorated([]types.CiaoCNCI{}),
+		generateUsageUndecorated([]types.CiaoComputeNode{}))
 	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
@@ -197,18 +170,8 @@ func (cmd *nodeStatusCommand) usage(...string) {
 Show cluster status
 `)
 	cmd.Flag.PrintDefaults()
-	fmt.Fprintf(os.Stderr, `
-The template passed to the -f option operates on a
-
-struct {
-	TotalNodes            int
-	TotalNodesReady       int
-	TotalNodesFull        int
-	TotalNodesOffline     int
-	TotalNodesMaintenance int
-}
-`)
-	fmt.Fprintln(os.Stderr, templateFunctionHelp)
+	fmt.Fprintf(os.Stderr, "\n%s",
+		generateUsageDecorated("f", types.CiaoClusterStatus{}.Status))
 	os.Exit(2)
 }
 
@@ -267,8 +230,7 @@ The template passed to the -f option operates on one of the following types:
 
 --cnci
 
-%s
-`, cnciTemplateDesc)
+%s`, generateUsageUndecorated(types.CiaoCNCI{}))
 	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }

--- a/ciao-cli/template.go
+++ b/ciao-cli/template.go
@@ -246,27 +246,6 @@ func generateStruct(buf io.Writer, dummy reflect.Type) {
 	}
 }
 
-// This function is not currently used.  The idea was to annotate
-// types with their user defined typenames, if such names existed.
-// This would allow users to know whether they could invoke
-// methods on those types.  Unfortunately, I couldn't figure out
-// a nice way of displaying this information, so it's disabled for
-// now.
-func getFullTypeName(typ reflect.Type) string {
-	if typ.Name() == "" {
-		return ""
-	}
-	pkg := typ.PkgPath()
-	if pkg != "" {
-		li := strings.LastIndex(pkg, "/")
-		if li != -1 {
-			pkg = pkg[li+1:]
-		}
-		pkg = fmt.Sprintf("%s.", pkg)
-	}
-	return fmt.Sprintf("%s%s", pkg, typ.Name())
-}
-
 func generateUsage(buf io.Writer, dummy reflect.Type, tag string) {
 	kind := dummy.Kind()
 	if ignoreKind(kind) {

--- a/ciao-cli/template_test.go
+++ b/ciao-cli/template_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type testint int
+
+var templateUsageTests = []struct {
+	obj      interface{}
+	expected string
+}{
+	{int(0), "int"},
+	{testint(0), "main.testint"},
+	{[]int{}, "[]int"},
+	{false, "bool"},
+	{[5]int{}, "[5]int"},
+	{func(int) (int, error) { return 0, nil }, "func(int) (int, error)"},
+	{"", "string"},
+	{struct {
+		X       int
+		Y       string
+		hidden  float64
+		Invalid chan int
+		Empty   struct{}
+	}{}, "struct {\nX int\nY string\nEmpty struct {\n}\n}"},
+	{map[string]struct{ X int }{}, "map[string]struct {\nX int\n}"},
+	{map[string]struct{ x int }{}, "map[string]struct {\n}"},
+	{struct {
+		hidden int
+		Embed  struct {
+			X int
+		}
+	}{}, "struct {\nEmbed struct {\nX int\n}\n}"},
+	{struct{ hidden int }{}, "struct {\n}"},
+	{struct{ Empty struct{} }{}, "struct { Empty struct{\n}}"},
+	{struct{}{}, "struct {\n}"},
+	{struct {
+		X int            `test:"tag"`
+		Y []int          `test:"tag"`
+		Z map[string]int `test:"tag"`
+		B struct {
+			A int
+		} `test:"tag"`
+	}{}, "struct { X int `test:\"tag\"`; Y []int `test:\"tag\"`; Z map[string]int `test:\"tag\"`; B struct {\nA int\n} `test:\"tag\"`} "},
+}
+
+func TestTemplateGenerateUsage(t *testing.T) {
+	for _, s := range templateUsageTests {
+		gen := generateUsageUndecorated(s.obj)
+		var buf bytes.Buffer
+		formatType(&buf, []byte(s.expected))
+		trimmedGen := strings.TrimSpace(gen)
+		trimmedExpected := strings.TrimSpace(buf.String())
+		if trimmedGen != trimmedExpected {
+			t.Errorf("Bad template usage. Found\n%s, expected\n%s",
+				trimmedGen, trimmedExpected)
+		}
+	}
+	fmt.Println()
+}

--- a/ciao-cli/tenant.go
+++ b/ciao-cli/tenant.go
@@ -54,49 +54,21 @@ The template passed to the -f option operates on the following structs:
 
 no options:
 
-[]struct {
-	ID   string              // Tenant ID
-	Name string              // Tenant name
-}
-
+%s
 --all:
 
-[]struct {
-	Description string       // Tenant description
-	DomainID    string       // Tenant domain
-	Enabled     bool         // Indicates whether the tenant is enabled
-	ID          string       // Tenant ID
-	Links       struct { 
-		Self string      // Link to resource collection
-	}
-	Name        string       // Tenant name
-	ParentID    string       // ID or parent tenant
-}
-
+%s
 --quotas:
 
-struct {
-	ID            string    // Tenant ID
-	Timestamp     time.Time // Not currently used
-	InstanceLimit int       // Maximum number of instances allowed for tenant
-	InstanceUsage int       // Number of existing instances
-	VCPULimit     int       // Maximum number of CPUs that can be used by tenant
-	VCPUUsage     int       // Current number of CPUS used
-	MemLimit      int       // Maximum amount of RAM that can be used by tenant
-	MemUsage      int       // Current RAM consumed by tenant
-	DiskLimit     int       // Maximum amount of disk space that can be used by tenant
-	DiskUsage     int       // Current disk space consumed by tenant
-}
-
+%s
 --resources:
 
-[]struct {
-	VCPU      int        // Current number of CPUS used
-	Memory    int        // Current RAM consumed by tenant
-	Disk      int        // Current disk space consumed by tenant in MB
-	Timestamp time.Time  // Time resource snapshot was taken
-}
-`)
+%s`,
+		generateUsageUndecorated([]Project{}),
+		generateUsageUndecorated(IdentityProjects{}.Projects),
+		generateUsageUndecorated(types.CiaoTenantResources{}),
+		generateUsageUndecorated(types.CiaoUsageHistory{}.Usages))
+
 	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }

--- a/ciao-cli/trace.go
+++ b/ciao-cli/trace.go
@@ -43,15 +43,8 @@ func (cmd *traceListCommand) usage(...string) {
 List all trace label
 `)
 	cmd.Flag.PrintDefaults()
-	fmt.Fprintf(os.Stderr, `
-The template passed to the -f option operates on
-
-[]struct {
-	Label     string // Trace label
-	Instances int    // Number of instances created with this label
-}
-`)
-	fmt.Fprintln(os.Stderr, templateFunctionHelp)
+	fmt.Fprintf(os.Stderr, "\n%s",
+		generateUsageDecorated("f", types.CiaoTracesSummary{}.Summaries))
 	os.Exit(2)
 }
 
@@ -105,22 +98,8 @@ The show flags are:
 
 `)
 	cmd.Flag.PrintDefaults()
-	fmt.Fprintf(os.Stderr, `
-The template passed to the -f option operates on
-
-struct {
-	NumInstances             int     // Number of instances started
-	TotalElapsed             float64 // Total time to start all instances
-	AverageElapsed           float64 // Average instance start time
-	AverageControllerElapsed float64 // Average time spent in controller starting an instance
-	AverageLauncherElapsed   float64 // Average time spent in launcher starting an instance
-	AverageSchedulerElapsed  float64 // Average time spent in scheduler starting an instance
-	VarianceController       float64 // Controller start time variance
-	VarianceLauncher         float64 // Launcher start time variance
-	VarianceScheduler        float64 // Scheduler start time variance
-}
-`)
-	fmt.Fprintln(os.Stderr, templateFunctionHelp)
+	fmt.Fprintf(os.Stderr, "\n%s",
+		generateUsageDecorated("f", types.CiaoTraceData{}.Summary))
 	os.Exit(2)
 }
 

--- a/ciao-cli/volume.go
+++ b/ciao-cli/volume.go
@@ -30,17 +30,6 @@ import (
 	"github.com/rackspace/gophercloud/pagination"
 )
 
-const volumeTemplateDesc = `struct {
-	ID          string // Volume UUID
-	Size        int    // Volume Size in GB
-	TenantID    string // Tenant to which volume belongs
-	CreatedAt   string // Volume creation time
-	Name        string // Volume name
-	Description string // Volume description
-	Status      string // Volume status
-}
-`
-
 var volumeCommand = &command{
 	SubCommands: map[string]subCommand{
 		"add":    new(volumeAddCommand),
@@ -126,12 +115,11 @@ List all volumes
 	fmt.Fprintf(os.Stderr, `
 The template passed to the -f option operates on a 
 
-[]%s
-
+%s
 As volumes are retrieved in pages, the template may be applied multiple
 times.  You can not therefore rely on the length of the slice passed
 to the template to determine the total number of volumes.
-`, volumeTemplateDesc)
+`, generateUsageUndecorated([]volumes.Volume{}))
 	fmt.Fprintln(os.Stderr, templateFunctionHelp)
 	os.Exit(2)
 }
@@ -206,12 +194,7 @@ Show information about a volume
 The show flags are:
 `)
 	cmd.Flag.PrintDefaults()
-	fmt.Fprintf(os.Stderr, `
-The template passed to the -f option operates on a 
-
-%s
-`, volumeTemplateDesc)
-	fmt.Fprintln(os.Stderr, templateFunctionHelp)
+	fmt.Fprintf(os.Stderr, "\n%s", generateUsageDecorated("f", volumes.Volume{}))
 	os.Exit(2)
 }
 

--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -53,23 +53,8 @@ List all workloads
 
 `)
 	cmd.Flag.PrintDefaults()
-	fmt.Fprintf(os.Stderr, `
-The template passed to the -f option operates on a 
-
-[]struct {
-	OSFLVDISABLEDDisabled  bool    // Not used
-	Disk                   string  // Backing images associated with workload
-	OSFLVEXTDATAEphemeral  int     // Not currently used
-	OsFlavorAccessIsPublic bool    // Indicates whether the workload is available to all tenants
-	ID                     string  // ID of the workload
-	Links                  []Link  // Not currently used
-	Name                   string  // Name of the workload
-	RAM                    int     // Amount of RAM allocated to instances of this workload 
-	Swap                   string  // Not currently used
-	Vcpus                  int     // Number of Vcpus allocated to instances of this workload 
-}
-`)
-	fmt.Fprintln(os.Stderr, templateFunctionHelp)
+	fmt.Fprintf(os.Stderr, "\n%s",
+		generateUsageDecorated("f", compute.FlavorsDetails{}.Flavors))
 	os.Exit(2)
 }
 


### PR DESCRIPTION
This PR adds some functions that can be used to auto-generate the documentation that describes how templates may be used for ciao-cli commands.  As, an example, to generate the template usage documentation for a command that operates on slices of  CiaoCNCIs you might call
```    
generateUsageUndecorated([]types.CiaoCNCI{})
```
and you would receive a string that looks something like this.
```    
    []struct {
        ID        string `json:"id"`
        TenantID  string `json:"tenant_id"`
        IPv4      string `json:"IPv4"`
        Geography string `json:"geography"`
        Subnets   []struct {
                Subnet string `json:"subnet_cidr"`
        } `json:"subnets"`
    }
```

There's another function, generateUsageDecorated that also includes information about all the additional functions ciao-cli provides for use in templates.

The PR also updates ciao-cli to use these new functions removing all of the hand coded template documentation.
