### PR TITLE
ansible: Fix some issues with the README.md

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/README.md
+++ b/_DeploymentAndDistroPackaging/ansible/README.md
@@ -28,7 +28,7 @@ We provide a ready-to-use
 [Docker container](https://hub.docker.com/r/clearlinux/ciao-deploy/).
 Simply download it and run your setup:
 
-    $ docker pull clarlinux/ciao-deploy
+    $ docker pull clearlinux/ciao-deploy
 
 ---
 
@@ -70,6 +70,7 @@ you would start the container as follows:
 $ docker run --privileged -v /path/to/your/.ssh/key:/root/.ssh/id_rsa \
              -v $(pwd):/root/ciao \
              -v /dev/:/dev/ \
+             --net=host \
              -it clearlinux/ciao-deploy
 ```
 


### PR DESCRIPTION
This commit fixes two errors with the README.md file that prevent one
from installing ciao via ansible.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>