### PR TITLE
ciao-down: Add support for clearcontainers development enviornment

### DIFF
--- a/testutil/ciao-down/README.md
+++ b/testutil/ciao-down/README.md
@@ -109,6 +109,13 @@ git repo, ciao-down will perform no action other than to mount the directory
 in the guest VM.  It will not try to clone the repo or update it.  It assumes
 that the directory already contains the webui code.
 
+ciao-down by default creates a VM suitable for ciao development. It also supports
+setting up development enviornments for other projects.
+
+ciao-down prepare -vmtype clearcontainers
+
+will create a new ciao-down VM for development of clearcontainers.
+
 ### delete
 
 ciao-down delete, shuts down and deletes all the files associated with the VM.

--- a/testutil/ciao-down/vm.go
+++ b/testutil/ciao-down/vm.go
@@ -53,11 +53,16 @@ func bootVM(ctx context.Context, ws *workspace, memGB, CPUs int) error {
 		"-drive", fmt.Sprintf("file=%s,if=virtio,aio=threads,format=qcow2", vmImage),
 		"-drive", fmt.Sprintf("file=%s,if=virtio,media=cdrom", isoPath),
 		"-daemonize", "-enable-kvm", "-cpu", "host",
-		"-net", "user,hostfwd=tcp::10022-:22,hostfwd=tcp::3000-:3000",
 		"-net", "nic,model=virtio",
 		"-fsdev", fsdevParam,
 		"-device", "virtio-9p-pci,id=fs0,fsdev=fsdev0,mount_tag=hostgo",
 	}
+	if ws.vmType == CIAO {
+		args = append(args, "-net", "user,hostfwd=tcp::10022-:22,hostfwd=tcp::3000-:3000")
+	} else {
+		args = append(args, "-net", "user,hostfwd=tcp::10022-:22")
+	}
+
 	if ws.UIPath != "" {
 		fsdevParam := fmt.Sprintf("local,security_model=passthrough,id=fsdev1,path=%s",
 			ws.UIPath)


### PR DESCRIPTION
First step in making ciao-down a generic dev-test VM launcher.
Adding support for a clear containers development environment.

To use ciao-down to setup a clear containers development environment 
the prepare command has been enhanced to add vmtype parameter

  -vmtype string
        Type of VM to launch. ciao or clearcontainers (default "ciao")

This is backwards compatible with VM's created prior to this update.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>