### PR TITLE
ansible: add fedora25 and ubuntu yakkety support for docker role

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/roles/docker/meta/main.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/docker/meta/main.yml
@@ -31,6 +31,7 @@ galaxy_info:
   - name: Fedora
     versions:
       - 24
+      - 25
   - name: ClearLinux
     versions:
       - all

--- a/_DeploymentAndDistroPackaging/ansible/roles/docker/meta/main.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/docker/meta/main.yml
@@ -27,7 +27,8 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
-      - xenial
+      - Xenial
+      - Yakkety
   - name: Fedora
     versions:
       - 24
@@ -38,7 +39,6 @@ galaxy_info:
 
   galaxy_tags:
     - ubuntu
-    - xenial
     - clearlinux
     - fedora
     - docker

--- a/_DeploymentAndDistroPackaging/ansible/roles/docker/tasks/install_fedora.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/docker/tasks/install_fedora.yml
@@ -13,11 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+  - name: Remove unofficial Docker packages
+    dnf: name=docker state=absent
+
   - name: Install docker repository (Fedora)
     yum_repository:
       name: docker
       description: Docker Repository
-      baseurl: https://yum.dockerproject.org/repo/main/fedora/24/
+      baseurl: https://yum.dockerproject.org/repo/main/fedora/$releasever/
       state: present
       enabled: yes
       gpgkey: https://yum.dockerproject.org/gpg

--- a/_DeploymentAndDistroPackaging/ansible/roles/docker/tasks/install_ubuntu.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/docker/tasks/install_ubuntu.yml
@@ -13,11 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+  - name: Remove unofficial Docker packages
+    apt: name=docker.io state=absent
+
   - name: Install CA certificates (Ubuntu)
     apt: name={{ item }} state=present
     with_items:
       - apt-transport-https
       - ca-certificates
+      - curl
+      - linux-image-extra-virtual
       - linux-image-extra-{{ ansible_kernel }}
 
   - name: Install docker repository GPG Key (Ubuntu)
@@ -28,7 +33,7 @@
 
   - name: Install docker repository (Ubuntu)
     apt_repository:
-      repo: "deb https://apt.dockerproject.org/repo ubuntu-xenial experimental"
+      repo: "deb https://apt.dockerproject.org/repo ubuntu-{{ ansible_distribution_release }} main"
       state: present
       filename: docker
 


### PR DESCRIPTION
This two commits adds support for Fedora25, Yakkety in addition to the current supported Fedora24 and Xenial.

Fixes #1110 