### PR TITLE
ciao-down: Fix docker version to 1.12.6

### DIFF
--- a/testutil/ciao-down/cloudinit.go
+++ b/testutil/ciao-down/cloudinit.go
@@ -112,7 +112,7 @@ runcmd:
  - {{template "CHECK" .}}
 
  - curl -X PUT -d "Installing Docker" 10.0.2.2:{{.HTTPServerPort}}
- - {{template "PROXIES" .}}apt-get install docker-engine -y
+ - {{template "PROXIES" .}}apt-get install docker-engine=1.12.6-0~ubuntu-xenial -y
  - {{template "CHECK" .}}
 
  - curl -X PUT -d "Installing GCC" 10.0.2.2:{{.HTTPServerPort}}


### PR DESCRIPTION
The latest version of docker seems to break the ceph/demo container.
This commit fixes the docker version at 1.12.6 which is known to
work well with ciao.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>