### PR TITLE
ciao-image: Add support for private, public and internal images

### DIFF
--- a/_release/bat/image_bat/image_bat_test.go
+++ b/_release/bat/image_bat/image_bat_test.go
@@ -18,6 +18,7 @@ package imagebat
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -27,26 +28,26 @@ import (
 
 const standardTimeout = time.Second * 300
 
-// Add a new image, check it's listed and delete it
-//
-// TestAddShowDelete adds a new image containing random content to the image
+// addShowDelete adds a new image containing random content to the image
 // service.  It then retrieves the meta data for the new image and checks that
-// various fields are correct.  Finally, it deletes the image.
+// various fields are correct.  Finally, it deletes the image. It will also
+// receive the visibility in order images are created with the right visibility
 //
 // The image is successfully uploaded, it appears when ciao-cli image show is
 // executed, it can be successfully deleted and is no longer present in the
 // ciao-cli image list output after deletion.
-func TestAddShowDelete(t *testing.T) {
-	const name = "test-image"
+func addShowDelete(t *testing.T, visibility string) {
+	name := fmt.Sprintf("test-image-%v", visibility)
 	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
 	defer cancelFunc()
 
 	// TODO:  The only options currently supported by the image service are
-	// ID and Name.  This code needs to be updated when the image service's
+	// ID, Visibility and  Name. This code needs to be updated when the image service's
 	// support for meta data improves.
 
 	options := bat.ImageOptions{
-		Name: name,
+		Name:       name,
+		Visibility: visibility,
 	}
 	img, err := bat.AddRandomImage(ctx, "", 10, &options)
 	if err != nil {
@@ -54,7 +55,7 @@ func TestAddShowDelete(t *testing.T) {
 	}
 
 	if img.ID == "" || img.Name != name || img.Status != "active" ||
-		img.Visibility != "private" || img.Protected {
+		img.Visibility != visibility || img.Protected {
 		t.Errorf("Meta data of added image is incorrect")
 	}
 
@@ -76,6 +77,21 @@ func TestAddShowDelete(t *testing.T) {
 			t.Fatalf("Call to get non-existing image should fail")
 		}
 	}
+}
+
+// TestPrivateAddShowDelete adds a new private image, checks it's listed and deletes it
+func TestPrivateAddShowDelete(t *testing.T) {
+	addShowDelete(t, "private")
+}
+
+// TestPublicAddShowDelete adds a new public image, checks it's listed and deletes it
+func TestPublicAddShowDelete(t *testing.T) {
+	addShowDelete(t, "public")
+}
+
+// TestInternalAddShowDelete adds a new internal image, checks it's listed and deletes it
+func TestInternalAddShowDelete(t *testing.T) {
+	addShowDelete(t, "internal")
 }
 
 // Delete a non-existing image

--- a/_release/bat/image_bat/image_bat_test.go
+++ b/_release/bat/image_bat/image_bat_test.go
@@ -54,7 +54,7 @@ func TestAddShowDelete(t *testing.T) {
 	}
 
 	if img.ID == "" || img.Name != name || img.Status != "active" ||
-		img.Visibility != "public" || img.Protected {
+		img.Visibility != "private" || img.Protected {
 		t.Errorf("Meta data of added image is incorrect")
 	}
 
@@ -132,7 +132,7 @@ func TestImageList(t *testing.T) {
 		foundNewImage = k == img.ID
 		if foundNewImage {
 			if newImg.ID == "" || newImg.Name != name || newImg.Status != "active" ||
-				newImg.Visibility != "public" || newImg.Protected {
+				newImg.Visibility != "private" || newImg.Protected {
 				t.Errorf("Meta data of added image is incorrect")
 			}
 			break

--- a/ciao-cli/image.go
+++ b/ciao-cli/image.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rackspace/gophercloud/openstack"
 	"github.com/rackspace/gophercloud/openstack/imageservice/v2/images"
 	"github.com/rackspace/gophercloud/pagination"
+	"strings"
 )
 
 var imageCommand = &command{
@@ -40,12 +41,18 @@ var imageCommand = &command{
 }
 
 type imageAddCommand struct {
-	Flag     flag.FlagSet
-	name     string
-	id       string
-	file     string
-	template string
+	Flag       flag.FlagSet
+	name       string
+	id         string
+	file       string
+	template   string
+	tags       string
+	visibility string
 }
+
+const (
+	internalImage images.ImageVisibility = "internal"
+)
 
 func (cmd *imageAddCommand) usage(...string) {
 	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] image add [flags]
@@ -65,6 +72,9 @@ func (cmd *imageAddCommand) parseArgs(args []string) []string {
 	cmd.Flag.StringVar(&cmd.id, "id", "", "Image UUID")
 	cmd.Flag.StringVar(&cmd.file, "file", "", "Image file to upload")
 	cmd.Flag.StringVar(&cmd.template, "f", "", "Template used to format output")
+	cmd.Flag.StringVar(&cmd.visibility, "visibility", string(images.ImageVisibilityPrivate),
+		"Image visibility (internal,public,private)")
+	cmd.Flag.StringVar(&cmd.tags, "tag", "", "Image tags (comma separated)")
 	cmd.Flag.Usage = func() { cmd.usage() }
 	cmd.Flag.Parse(args)
 	return cmd.Flag.Args()
@@ -89,9 +99,23 @@ func (cmd *imageAddCommand) run(args []string) error {
 		fatalf("Could not get Image service client [%s]\n", err)
 	}
 
+	imageVisibility := images.ImageVisibilityPrivate
+	if cmd.visibility != "" {
+		imageVisibility = images.ImageVisibility(cmd.visibility)
+		switch imageVisibility {
+		case images.ImageVisibilityPublic, images.ImageVisibilityPrivate, internalImage:
+		default:
+			fatalf("Invalid image visibility [%v]", imageVisibility)
+		}
+	}
+
+	tags := strings.Split(cmd.tags, ",")
+
 	opts := images.CreateOpts{
-		Name: cmd.name,
-		ID:   cmd.id,
+		Name:       cmd.name,
+		ID:         cmd.id,
+		Visibility: &imageVisibility,
+		Tags:       tags,
 	}
 
 	image, err := images.Create(client, opts).Extract()
@@ -408,6 +432,8 @@ func dumpImage(i *images.Image) {
 	fmt.Printf("\tSize             [%d bytes]\n", i.SizeBytes)
 	fmt.Printf("\tUUID             [%s]\n", i.ID)
 	fmt.Printf("\tStatus           [%s]\n", i.Status)
+	fmt.Printf("\tVisibility       [%s]\n", i.Visibility)
+	fmt.Printf("\tTags             %v\n", i.Tags)
 	fmt.Printf("\tCreatedDate      [%s]\n", i.CreatedDate)
 }
 

--- a/ciao-controller/openstack_image.go
+++ b/ciao-controller/openstack_image.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	imageDatastore "github.com/01org/ciao/ciao-image/datastore"
@@ -37,10 +38,11 @@ type ImageService struct {
 }
 
 // CreateImage will create an empty image in the image datastore.
-func (is ImageService) CreateImage(req image.CreateImageRequest) (image.DefaultResponse, error) {
+func (is ImageService) CreateImage(tenantID string, req image.CreateImageRequest) (image.DefaultResponse, error) {
 	// create an ImageInfo struct and store it in our image
 	// datastore.
 	glog.Infof("Creating Image: %v", req.ID)
+
 	id := req.ID
 	if id == "" {
 		id = uuid.Generate().String()
@@ -50,23 +52,21 @@ func (is ImageService) CreateImage(req image.CreateImageRequest) (image.DefaultR
 			return image.DefaultResponse{}, image.ErrBadUUID
 		}
 
-		img, err := is.ds.GetImage(id)
-		if err != nil {
-			glog.Errorf("Error on decoding image: %v", err)
-			return image.DefaultResponse{}, image.ErrDecodeImage
-		}
-
+		img, _ := is.ds.GetImage(tenantID, id)
 		if img != (imageDatastore.Image{}) {
-			glog.Errorf("Image %v already exists", err)
+			glog.Errorf("Image [%v] already exists", id)
 			return image.DefaultResponse{}, image.ErrAlreadyExists
 		}
 	}
 
 	i := imageDatastore.Image{
 		ID:         id,
+		TenantID:   tenantID,
 		State:      imageDatastore.Created,
 		Name:       req.Name,
 		CreateTime: time.Now(),
+		Tags:       strings.Join(req.Tags, ","),
+		Visibility: req.Visibility,
 	}
 
 	err := is.ds.CreateImage(i)
@@ -77,13 +77,17 @@ func (is ImageService) CreateImage(req image.CreateImageRequest) (image.DefaultR
 
 	glog.Infof("Image %v created", id)
 	size := int(i.Size)
+	tags := []string{}
+	if len(i.Tags) > 0 {
+		tags = strings.Split(i.Tags, ",")
+	}
 	return image.DefaultResponse{
 		Status:     image.Queued,
 		CreatedAt:  i.CreateTime,
-		Tags:       make([]string, 0),
+		Tags:       tags,
 		Locations:  make([]string, 0),
 		DiskFormat: image.Raw,
-		Visibility: i.Visibility(),
+		Visibility: i.Visibility,
 		Self:       fmt.Sprintf("/v2/images/%s", i.ID),
 		Protected:  false,
 		ID:         i.ID,
@@ -96,13 +100,17 @@ func (is ImageService) CreateImage(req image.CreateImageRequest) (image.DefaultR
 
 func createImageResponse(img imageDatastore.Image) (image.DefaultResponse, error) {
 	size := int(img.Size)
+	tags := []string{}
+	if len(img.Tags) > 0 {
+		tags = strings.Split(img.Tags, ",")
+	}
 	return image.DefaultResponse{
 		Status:     img.State.Status(),
 		CreatedAt:  img.CreateTime,
-		Tags:       make([]string, 0),
+		Tags:       tags,
 		Locations:  make([]string, 0),
 		DiskFormat: image.DiskFormat(img.Type),
-		Visibility: img.Visibility(),
+		Visibility: img.Visibility,
 		Self:       fmt.Sprintf("/v2/images/%s", img.ID),
 		Protected:  false,
 		ID:         img.ID,
@@ -114,13 +122,13 @@ func createImageResponse(img imageDatastore.Image) (image.DefaultResponse, error
 }
 
 // ListImages will return a list of all the images in the datastore.
-func (is ImageService) ListImages() ([]image.DefaultResponse, error) {
-	glog.Info("Listing images")
+func (is ImageService) ListImages(tenant string) ([]image.DefaultResponse, error) {
+	glog.Infof("Listing images from [%v]", tenant)
 	response := []image.DefaultResponse{}
 
-	images, err := is.ds.GetAllImages()
+	images, err := is.ds.GetAllImages(tenant)
 	if err != nil {
-		glog.Errorf("Error on listing images: %v", err)
+		glog.Errorf("Error on retrieving images from tenant [%v]: %v", tenant, err)
 		return response, err
 	}
 
@@ -133,11 +141,11 @@ func (is ImageService) ListImages() ([]image.DefaultResponse, error) {
 }
 
 // UploadImage will upload a raw image data and update its status.
-func (is ImageService) UploadImage(imageID string, body io.Reader) (image.NoContentImageResponse, error) {
+func (is ImageService) UploadImage(tenantID, imageID string, body io.Reader) (image.NoContentImageResponse, error) {
 	glog.Infof("Uploading image: %v", imageID)
 	var response image.NoContentImageResponse
 
-	err := is.ds.UploadImage(imageID, body)
+	err := is.ds.UploadImage(tenantID, imageID, body)
 	if err != nil {
 		glog.Errorf("Error on uploading image: %v", err)
 		return response, err
@@ -149,11 +157,11 @@ func (is ImageService) UploadImage(imageID string, body io.Reader) (image.NoCont
 }
 
 // DeleteImage will delete a raw image and its metadata
-func (is ImageService) DeleteImage(imageID string) (image.NoContentImageResponse, error) {
+func (is ImageService) DeleteImage(tenantID, imageID string) (image.NoContentImageResponse, error) {
 	glog.Infof("Deleting image: %v", imageID)
 	var response image.NoContentImageResponse
 
-	err := is.ds.DeleteImage(imageID)
+	err := is.ds.DeleteImage(tenantID, imageID)
 	if err != nil {
 		glog.Errorf("Error on deleting image: %v", err)
 		return response, err
@@ -165,11 +173,11 @@ func (is ImageService) DeleteImage(imageID string) (image.NoContentImageResponse
 }
 
 // GetImage will get the raw image data
-func (is ImageService) GetImage(imageID string) (image.DefaultResponse, error) {
-	glog.Infof("Getting Image %v", imageID)
+func (is ImageService) GetImage(tenantID, imageID string) (image.DefaultResponse, error) {
+	glog.Infof("Getting Image [%v] from [%v]", imageID, tenantID)
 	var response image.DefaultResponse
 
-	img, err := is.ds.GetImage(imageID)
+	img, err := is.ds.GetImage(tenantID, imageID)
 	if err != nil {
 		glog.Errorf("Error on getting image: %v", err)
 		return response, err
@@ -222,9 +230,10 @@ func (c *controller) startImageService() error {
 	glog.Infof("DbDir      : %v", metaDs.DbDir)
 	glog.Infof("DbFile     : %v", metaDs.DbFile)
 
-	metaDsTables := []string{"images"}
+	metaDsTables := []string{"public", "internal"}
 
 	err := metaDs.DbInit(metaDs.DbDir, metaDs.DbFile)
+
 	if err != nil {
 		glog.Fatalf("Error on DB Initialization: %v", err)
 	}
@@ -274,7 +283,7 @@ func (c *controller) startImageService() error {
 	}
 
 	// get our routes.
-	r := image.Routes(apiConfig)
+	r := image.Routes(apiConfig, c.id.scV3)
 
 	// setup identity for these routes.
 	validServices := []osIdentity.ValidService{
@@ -296,7 +305,6 @@ func (c *controller) startImageService() error {
 		}
 
 		route.Handler(h)
-
 		return nil
 	})
 	if err != nil {

--- a/ciao-controller/openstack_image.go
+++ b/ciao-controller/openstack_image.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/01org/ciao/ciao-controller/internal/quotas"
-	"github.com/01org/ciao/ciao-controller/types"
 	imageDatastore "github.com/01org/ciao/ciao-image/datastore"
 	"github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/database"
@@ -83,7 +82,7 @@ func (is *ImageService) CreateImage(tenantID string, req image.CreateImageReques
 	if !res.Allowed() {
 		is.ds.DeleteImage(tenantID, id)
 		is.qs.Release(tenantID, payloads.RequestedResource{Type: payloads.Image, Value: 1})
-		return image.DefaultResponse{}, types.ErrQuota
+		return image.DefaultResponse{}, image.ErrQuota
 	}
 
 	glog.Infof("Image %v created", id)

--- a/ciao-controller/openstack_image.go
+++ b/ciao-controller/openstack_image.go
@@ -38,7 +38,7 @@ type ImageService struct {
 }
 
 // CreateImage will create an empty image in the image datastore.
-func (is ImageService) CreateImage(tenantID string, req image.CreateImageRequest) (image.DefaultResponse, error) {
+func (is *ImageService) CreateImage(tenantID string, req image.CreateImageRequest) (image.DefaultResponse, error) {
 	// create an ImageInfo struct and store it in our image
 	// datastore.
 	glog.Infof("Creating Image: %v", req.ID)
@@ -122,7 +122,7 @@ func createImageResponse(img imageDatastore.Image) (image.DefaultResponse, error
 }
 
 // ListImages will return a list of all the images in the datastore.
-func (is ImageService) ListImages(tenant string) ([]image.DefaultResponse, error) {
+func (is *ImageService) ListImages(tenant string) ([]image.DefaultResponse, error) {
 	glog.Infof("Listing images from [%v]", tenant)
 	response := []image.DefaultResponse{}
 
@@ -141,7 +141,7 @@ func (is ImageService) ListImages(tenant string) ([]image.DefaultResponse, error
 }
 
 // UploadImage will upload a raw image data and update its status.
-func (is ImageService) UploadImage(tenantID, imageID string, body io.Reader) (image.NoContentImageResponse, error) {
+func (is *ImageService) UploadImage(tenantID, imageID string, body io.Reader) (image.NoContentImageResponse, error) {
 	glog.Infof("Uploading image: %v", imageID)
 	var response image.NoContentImageResponse
 
@@ -157,7 +157,7 @@ func (is ImageService) UploadImage(tenantID, imageID string, body io.Reader) (im
 }
 
 // DeleteImage will delete a raw image and its metadata
-func (is ImageService) DeleteImage(tenantID, imageID string) (image.NoContentImageResponse, error) {
+func (is *ImageService) DeleteImage(tenantID, imageID string) (image.NoContentImageResponse, error) {
 	glog.Infof("Deleting image: %v", imageID)
 	var response image.NoContentImageResponse
 
@@ -173,7 +173,7 @@ func (is ImageService) DeleteImage(tenantID, imageID string) (image.NoContentIma
 }
 
 // GetImage will get the raw image data
-func (is ImageService) GetImage(tenantID, imageID string) (image.DefaultResponse, error) {
+func (is *ImageService) GetImage(tenantID, imageID string) (image.DefaultResponse, error) {
 	glog.Infof("Getting Image [%v] from [%v]", imageID, tenantID)
 	var response image.DefaultResponse
 
@@ -279,7 +279,7 @@ func (c *controller) startImageService() error {
 
 	apiConfig := image.APIConfig{
 		Port:         config.Port,
-		ImageService: is,
+		ImageService: &is,
 	}
 
 	// get our routes.

--- a/ciao-image/datastore/datastore.go
+++ b/ciao-image/datastore/datastore.go
@@ -54,14 +54,6 @@ func (state State) Status() image.Status {
 	return image.Active
 }
 
-// Visibility returns the image visibility
-func (i Image) Visibility() image.Visibility {
-	if i.TenantID == "" {
-		return image.Public
-	}
-	return image.Private
-}
-
 // Type represents the valid image types.
 type Type string
 
@@ -85,26 +77,28 @@ type Image struct {
 	CreateTime time.Time
 	Type       Type
 	Size       uint64
+	Visibility image.Visibility
+	Tags       string
 }
 
 // DataStore is the image data storage interface.
 type DataStore interface {
 	Init(RawDataStore, MetaDataStore) error
-	CreateImage(Image) error
-	GetAllImages() ([]Image, error)
-	GetImage(string) (Image, error)
+	CreateImage(image Image) error
+	GetAllImages(tenant string) ([]Image, error)
+	GetImage(tenant, id string) (Image, error)
 	UpdateImage(Image) error
-	DeleteImage(string) error
-	UploadImage(string, io.Reader) error
+	DeleteImage(tenant, id string) error
+	UploadImage(tenant, id string, imageFile io.Reader) error
 }
 
 // MetaDataStore is the metadata storing interface that's used by
 // image cache implementation.
 type MetaDataStore interface {
-	Write(Image) error
-	Delete(ID string) error
-	Get(ID string) (Image, error)
-	GetAll() ([]Image, error)
+	Write(image Image) error
+	Delete(tenant, ID string) error
+	Get(tenant, ID string) (Image, error)
+	GetAll(tenant string) ([]Image, error)
 }
 
 // RawDataStore is the raw data storage interface that's used by the

--- a/ciao-image/datastore/datastore_test.go
+++ b/ciao-image/datastore/datastore_test.go
@@ -28,11 +28,13 @@ var metaDsTables = []string{"images"}
 var dbDir = "/tmp"
 var dbFile = "ciao-image.db"
 var testImageID = "12345678-1234-5678-1234-567812345678"
+var testTenantID = "34345678-1234-5678-1234-567812345345"
 
 func testCreateAndGet(t *testing.T, d RawDataStore, m MetaDataStore) {
 	i := Image{
-		ID:    testImageID,
-		State: Created,
+		ID:       testImageID,
+		TenantID: testTenantID,
+		State:    Created,
 	}
 
 	imageStore := ImageStore{}
@@ -45,7 +47,7 @@ func testCreateAndGet(t *testing.T, d RawDataStore, m MetaDataStore) {
 	}
 
 	// retrieve the entry
-	image, err := imageStore.GetImage(i.ID)
+	image, err := imageStore.GetImage(i.TenantID, i.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,8 +59,9 @@ func testCreateAndGet(t *testing.T, d RawDataStore, m MetaDataStore) {
 
 func testGetAll(t *testing.T, d RawDataStore, m MetaDataStore) {
 	i := Image{
-		ID:    testImageID,
-		State: Created,
+		ID:       testImageID,
+		TenantID: testTenantID,
+		State:    Created,
 	}
 
 	imageStore := ImageStore{}
@@ -71,7 +74,7 @@ func testGetAll(t *testing.T, d RawDataStore, m MetaDataStore) {
 	}
 
 	// retrieve the entry
-	images, err := imageStore.GetAllImages()
+	images, err := imageStore.GetAllImages(i.TenantID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,8 +92,9 @@ func testGetAll(t *testing.T, d RawDataStore, m MetaDataStore) {
 
 func testDelete(t *testing.T, d RawDataStore, m MetaDataStore) {
 	i := Image{
-		ID:    testImageID,
-		State: Created,
+		ID:       testImageID,
+		TenantID: testTenantID,
+		State:    Created,
 	}
 
 	imageStore := ImageStore{}
@@ -103,14 +107,14 @@ func testDelete(t *testing.T, d RawDataStore, m MetaDataStore) {
 	}
 
 	// delete the entry
-	err = imageStore.DeleteImage(i.ID)
+	err = imageStore.DeleteImage(i.TenantID, i.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// now attempt to retrive the entry
 	if _, ok := m.(*Noop); !ok {
-		_, err = imageStore.GetImage(i.ID)
+		_, err = imageStore.GetImage(i.TenantID, i.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -119,8 +123,9 @@ func testDelete(t *testing.T, d RawDataStore, m MetaDataStore) {
 
 func testUpload(t *testing.T, d RawDataStore, m MetaDataStore) {
 	i := Image{
-		ID:    testImageID,
-		State: Created,
+		ID:       testImageID,
+		TenantID: testTenantID,
+		State:    Created,
 	}
 
 	imageStore := ImageStore{}
@@ -133,7 +138,7 @@ func testUpload(t *testing.T, d RawDataStore, m MetaDataStore) {
 	}
 
 	// Upload a string
-	err = imageStore.UploadImage(i.ID, strings.NewReader("Upload file"))
+	err = imageStore.UploadImage(i.TenantID, i.ID, strings.NewReader("Upload file"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +177,7 @@ func initMetaDs() *MetaDs {
 		DbDir:      dbDir,
 		DbFile:     dbFile,
 	}
-	metaDsTables := []string{"images"}
+	metaDsTables := []string{"public", "internal"}
 	_ = metaDs.DbInit(metaDs.DbDir, metaDs.DbFile)
 	_ = metaDs.DbTablesInit(metaDsTables)
 

--- a/ciao-image/datastore/metads.go
+++ b/ciao-image/datastore/metads.go
@@ -27,23 +27,26 @@ type MetaDs struct {
 
 // Write is the metadata write implementation.
 func (m *MetaDs) Write(i Image) error {
-	err := m.DbAdd("images", i.ID, &i)
+	tenant := i.TenantID
+
+	err := m.DbAdd(tenant, i.ID, &i)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
 // Delete is the metadata delete implementation.
-func (m *MetaDs) Delete(id string) error {
-	return m.DbDelete("images", id)
+func (m *MetaDs) Delete(tenant, id string) error {
+	return m.DbDelete(tenant, id)
 }
 
 // Get is the metadata get implementation.
-func (m *MetaDs) Get(ID string) (Image, error) {
+func (m *MetaDs) Get(tenant, ID string) (Image, error) {
 
 	imageTable := &ImageMap{}
-	img, err := m.DbGet("images", ID, imageTable)
+	img, err := m.DbGet(tenant, ID, imageTable)
 	if err != nil {
 		return Image{}, err
 	}
@@ -53,13 +56,12 @@ func (m *MetaDs) Get(ID string) (Image, error) {
 }
 
 // GetAll is the metadata get all images implementation.
-func (m *MetaDs) GetAll() (images []Image, err error) {
+func (m *MetaDs) GetAll(tenant string) (images []Image, err error) {
 	var elements []interface{}
 	imageTable := &ImageMap{}
-	elements, err = m.DbProvider.DbGetAll("images", imageTable)
+	elements, err = m.DbProvider.DbGetAll(tenant, imageTable)
 
 	images = make([]Image, len(elements))
-
 	for i, img := range elements {
 		image := img.(*Image)
 		images[i] = *image

--- a/ciao-image/datastore/noop.go
+++ b/ciao-image/datastore/noop.go
@@ -28,23 +28,23 @@ func (n *Noop) Write(i Image) error {
 
 // Delete is the noop image metadata delete implementation.
 // It drops data.
-func (n *Noop) Delete(id string) error {
+func (n *Noop) Delete(tenant, id string) error {
 	return nil
 }
 
 // GetImageSize is the noop image implementation of image size querying
-func (n *Noop) GetImageSize(ID string) (uint64, error) {
+func (n *Noop) GetImageSize(tenant, id string) (uint64, error) {
 	return 0, nil
 }
 
 // Get is the noop image metadata get an image implementation.
 // It drops data.
-func (n *Noop) Get(id string) (Image, error) {
-	return Image{ID: id}, nil
+func (n *Noop) Get(tenant, id string) (Image, error) {
+	return Image{ID: id, TenantID: tenant}, nil
 }
 
 // GetAll is the noop image metadata get all images implementation.
 // It drops data.
-func (n *Noop) GetAll() ([]Image, error) {
+func (n *Noop) GetAll(tenant string) ([]Image, error) {
 	return []Image{}, nil
 }

--- a/ciao-image/datastore/store.go
+++ b/ciao-image/datastore/store.go
@@ -90,12 +90,11 @@ func (s *ImageStore) CreateImage(i Image) error {
 }
 
 // GetAllImages gets returns all the known images.
-func (s *ImageStore) GetAllImages() ([]Image, error) {
+func (s *ImageStore) GetAllImages(tenant string) ([]Image, error) {
 	var images []Image
 	s.ImageMap.RLock()
 	defer s.ImageMap.RUnlock()
-
-	images, err := s.metaDs.GetAll()
+	images, err := s.metaDs.GetAll(tenant)
 	if err != nil {
 		return nil, err
 	}
@@ -104,11 +103,11 @@ func (s *ImageStore) GetAllImages() ([]Image, error) {
 }
 
 // GetImage returns the image specified by the ID string.
-func (s *ImageStore) GetImage(ID string) (Image, error) {
+func (s *ImageStore) GetImage(tenant, ID string) (Image, error) {
 	s.ImageMap.RLock()
 	defer s.ImageMap.RUnlock()
 
-	img, err := s.metaDs.Get(ID)
+	img, err := s.metaDs.Get(tenant, ID)
 	if err != nil {
 		return Image{}, image.ErrNoImage
 	}
@@ -130,16 +129,16 @@ func (s *ImageStore) UpdateImage(i Image) error {
 }
 
 // DeleteImage will delete an existing image.
-func (s *ImageStore) DeleteImage(ID string) error {
+func (s *ImageStore) DeleteImage(tenant, ID string) error {
 	s.ImageMap.Lock()
 	defer s.ImageMap.Unlock()
 
-	img, err := s.metaDs.Get(ID)
+	img, err := s.metaDs.Get(tenant, ID)
 	if err != nil {
 		return err
 	}
 
-	if img == (Image{}) {
+	if img == (Image{}) || img.TenantID != tenant {
 		return image.ErrNoImage
 	}
 
@@ -150,16 +149,19 @@ func (s *ImageStore) DeleteImage(ID string) error {
 		}
 	}
 
-	err = s.metaDs.Delete(ID)
+	if img.Visibility == image.Public {
+		tenant = string(image.Public)
+	}
+	err = s.metaDs.Delete(tenant, ID)
 
 	return err
 }
 
 // UploadImage will read an image, save it and update the image cache.
-func (s *ImageStore) UploadImage(ID string, body io.Reader) error {
+func (s *ImageStore) UploadImage(tenant, ID string, body io.Reader) error {
 
 	s.ImageMap.RLock()
-	img, err := s.metaDs.Get(ID)
+	img, err := s.metaDs.Get(tenant, ID)
 	s.ImageMap.RUnlock()
 	if err != nil {
 		return err

--- a/openstack/identity/identity.go
+++ b/openstack/identity/identity.go
@@ -253,6 +253,7 @@ func (h Handler) validateToken(ctx context.Context, r *http.Request) (context.Co
 
 	if tenantFromVars == "" {
 		glog.V(2).Infof("Token validation for [%s]", tenantFromToken)
+		ctx = service.SetTenantID(ctx, tenantFromToken)
 		return h.checkToken(ctx, r, tenantFromToken, tokenResult)
 	}
 	// verify that tenant from token is consistent with the tenant
@@ -262,6 +263,7 @@ func (h Handler) validateToken(ctx context.Context, r *http.Request) (context.Co
 		return ctx, false
 	}
 
+	ctx = service.SetTenantID(ctx, tenantFromVars)
 	glog.V(2).Infof("Token validation for [%s]", tenantFromVars)
 	return h.checkToken(ctx, r, tenantFromVars, tokenResult)
 }

--- a/openstack/image/api.go
+++ b/openstack/image/api.go
@@ -169,6 +169,9 @@ var (
 
 	// ErrForbiddenAccess is returned for only-privileged image operations
 	ErrForbiddenAccess = errors.New("Forbidden Access")
+
+	// ErrQuota is returned when the tenant exceeds its quota
+	ErrQuota = errors.New("Tenant over quota")
 )
 
 // CreateImageRequest contains information for a create image request.
@@ -274,7 +277,7 @@ type APIHandler struct {
 func (h APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	resp, err := h.Handler(h.Context, w, r)
 	if err != nil {
-		http.Error(w, http.StatusText(resp.status), resp.status)
+		http.Error(w, err.Error(), resp.status)
 	}
 
 	b, err := json.Marshal(resp.response)
@@ -301,7 +304,7 @@ func errorResponse(err error) APIResponse {
 		return APIResponse{http.StatusBadRequest, nil}
 	case ErrAlreadyExists:
 		return APIResponse{http.StatusConflict, nil}
-	case ErrForbiddenAccess:
+	case ErrForbiddenAccess, ErrQuota:
 		return APIResponse{http.StatusForbidden, nil}
 	default:
 		return APIResponse{http.StatusInternalServerError, nil}

--- a/openstack/image/api.go
+++ b/openstack/image/api.go
@@ -24,8 +24,10 @@ import (
 	"os"
 	"time"
 
+	"github.com/01org/ciao/service"
 	"github.com/01org/ciao/ssntp/uuid"
 	"github.com/gorilla/mux"
+	"github.com/rackspace/gophercloud"
 )
 
 // APIPort is the standard OpenStack Image port
@@ -109,6 +111,17 @@ const (
 
 	// Private indicates that the image is only available to a tenant.
 	Private Visibility = "private"
+
+	// Internal indicates that an image is only for Ciao internal usage.
+	Internal Visibility = "internal"
+)
+
+// InternalImage defines the types of CIAO internal images (e.g. cnci)
+type InternalImage string
+
+const (
+	// CNCI is the type of image for CIAO per-tenant networking managenent
+	CNCI InternalImage = "cnci"
 )
 
 // ContainerFormat defines the acceptable container format strings.
@@ -153,6 +166,9 @@ var (
 
 	// ErrDecodeImage is returned when there was an error on image decoding
 	ErrDecodeImage = errors.New("Error on Image decode")
+
+	// ErrForbiddenAccess is returned for only-privileged image operations
+	ErrForbiddenAccess = errors.New("Forbidden Access")
 )
 
 // CreateImageRequest contains information for a create image request.
@@ -224,11 +240,11 @@ type APIConfig struct {
 // Service is the interface that the api requires in order to get
 // information needed to implement the image endpoints.
 type Service interface {
-	CreateImage(CreateImageRequest) (DefaultResponse, error)
-	UploadImage(string, io.Reader) (NoContentImageResponse, error)
-	ListImages() ([]DefaultResponse, error)
-	GetImage(string) (DefaultResponse, error)
-	DeleteImage(string) (NoContentImageResponse, error)
+	CreateImage(string, CreateImageRequest) (DefaultResponse, error)
+	UploadImage(string, string, io.Reader) (NoContentImageResponse, error)
+	ListImages(string) ([]DefaultResponse, error)
+	GetImage(string, string) (DefaultResponse, error)
+	DeleteImage(string, string) (NoContentImageResponse, error)
 }
 
 // Context contains data and interfaces that the image api will need.
@@ -236,6 +252,7 @@ type Service interface {
 type Context struct {
 	port int
 	Service
+	*gophercloud.ServiceClient
 }
 
 // APIResponse is returned from the API handlers.
@@ -284,9 +301,15 @@ func errorResponse(err error) APIResponse {
 		return APIResponse{http.StatusBadRequest, nil}
 	case ErrAlreadyExists:
 		return APIResponse{http.StatusConflict, nil}
+	case ErrForbiddenAccess:
+		return APIResponse{http.StatusForbidden, nil}
 	default:
 		return APIResponse{http.StatusInternalServerError, nil}
 	}
+}
+
+func validPrivilege(visibility Visibility, privileged bool) bool {
+	return visibility == Private || (visibility == Public || visibility == Internal) && privileged
 }
 
 // endpoints
@@ -325,12 +348,12 @@ func listAPIVersions(context *Context, w http.ResponseWriter, r *http.Request) (
 
 // createImage creates information about an image, but doesn't contain
 // any actual image.
-//
-// TBD: this endpoint has no tenant var - how do you know who owns the
-// image if the tenant id isn't passed in? Default visibility is supposed
-// to be private.
 func createImage(context *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	defer r.Body.Close()
+	tenantID, err := service.GetTenantID(r.Context())
+	if err != nil {
+		return APIResponse{http.StatusBadRequest, nil}, err
+	}
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -344,7 +367,18 @@ func createImage(context *Context, w http.ResponseWriter, r *http.Request) (APIR
 		return APIResponse{http.StatusInternalServerError, nil}, err
 	}
 
-	resp, err := context.CreateImage(req)
+	privileged := service.GetPrivilege(r.Context())
+
+	if !validPrivilege(req.Visibility, privileged) {
+		return APIResponse{http.StatusForbidden, nil}, nil
+	}
+
+	if req.Visibility == Public || req.Visibility == Internal {
+		tenantID = string(req.Visibility)
+	}
+
+	resp, err := context.CreateImage(tenantID, req)
+
 	if err != nil {
 		return errorResponse(err), err
 	}
@@ -356,9 +390,26 @@ func createImage(context *Context, w http.ResponseWriter, r *http.Request) (APIR
 //
 // TBD: support query & sort parameters
 func listImages(context *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
-	images, err := context.ListImages()
+	images := []DefaultResponse{}
+
+	tenantID, err := service.GetTenantID(r.Context())
 	if err != nil {
-		return errorResponse(err), err
+		return APIResponse{http.StatusBadRequest, nil}, err
+	}
+
+	imageTables := []string{tenantID, string(Public)}
+
+	privileged := service.GetPrivilege(r.Context())
+	if privileged {
+		imageTables = append(imageTables, string(Internal))
+	}
+
+	for _, table := range imageTables {
+		tableImages, err := context.ListImages(table)
+		if err != nil {
+			return errorResponse(err), err
+		}
+		images = append(images, tableImages...)
 	}
 
 	resp := ListImagesResponse{
@@ -375,19 +426,71 @@ func listImages(context *Context, w http.ResponseWriter, r *http.Request) (APIRe
 func getImage(context *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	vars := mux.Vars(r)
 	imageID := vars["image_id"]
+	resp := DefaultResponse{}
 
-	resp, err := context.GetImage(imageID)
+	tenantID, err := service.GetTenantID(r.Context())
+	if err != nil {
+		return APIResponse{http.StatusBadRequest, nil}, err
+	}
+
+	imageTables := []string{tenantID, string(Public)}
+
+	privileged := service.GetPrivilege(r.Context())
+	if privileged {
+		imageTables = append(imageTables, string(Internal))
+	}
+
+	for _, table := range imageTables {
+		resp, err = context.GetImage(table, imageID)
+		if err != nil && err != ErrNoImage {
+			return errorResponse(err), err
+		}
+		if resp.ID != "" {
+			break
+		}
+	}
 	if err != nil {
 		return errorResponse(err), err
 	}
+
 	return APIResponse{http.StatusOK, resp}, nil
 }
 
 func uploadImage(context *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	vars := mux.Vars(r)
 	imageID := vars["image_id"]
+	tenantID, err := service.GetTenantID(r.Context())
+	if err != nil {
+		return APIResponse{http.StatusBadRequest, nil}, err
+	}
 
-	_, err := context.UploadImage(imageID, r.Body)
+	imageTables := []string{tenantID, string(Public)}
+
+	privileged := service.GetPrivilege(r.Context())
+	if privileged {
+		imageTables = append(imageTables, string(Internal))
+	}
+
+	for _, table := range imageTables {
+		img, err := context.GetImage(table, imageID)
+		if err != nil && err != ErrNoImage {
+			return errorResponse(err), err
+		}
+		if img.ID != "" {
+			if !validPrivilege(img.Visibility, privileged) {
+				return APIResponse{http.StatusForbidden, nil}, nil
+			}
+			if img.Visibility == Public || img.Visibility == Internal {
+				tenantID = string(img.Visibility)
+			}
+			break
+		}
+	}
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	_, err = context.UploadImage(tenantID, imageID, r.Body)
 	if err != nil {
 		return errorResponse(err), err
 	}
@@ -397,8 +500,34 @@ func uploadImage(context *Context, w http.ResponseWriter, r *http.Request) (APIR
 func deleteImage(context *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	vars := mux.Vars(r)
 	imageID := vars["image_id"]
+	tenantID, err := service.GetTenantID(r.Context())
+	if err != nil {
+		return APIResponse{http.StatusBadRequest, nil}, err
+	}
 
-	_, err := context.DeleteImage(imageID)
+	imageTables := []string{tenantID, string(Public), string(Internal)}
+	privileged := service.GetPrivilege(r.Context())
+
+	for _, table := range imageTables {
+		img, err := context.GetImage(table, imageID)
+		if err != ErrNoImage {
+			if img.ID != "" {
+				if !validPrivilege(img.Visibility, privileged) {
+					return APIResponse{http.StatusForbidden, nil}, nil
+				}
+				if img.Visibility == Public || img.Visibility == Internal {
+					tenantID = string(img.Visibility)
+				}
+				break
+			}
+		}
+	}
+
+	if err != nil {
+		return errorResponse(err), err
+	}
+
+	_, err = context.DeleteImage(tenantID, imageID)
 	if err != nil {
 		return errorResponse(err), err
 	}
@@ -406,9 +535,9 @@ func deleteImage(context *Context, w http.ResponseWriter, r *http.Request) (APIR
 }
 
 // Routes provides gorilla mux routes for the supported endpoints.
-func Routes(config APIConfig) *mux.Router {
+func Routes(config APIConfig, serviceClient *gophercloud.ServiceClient) *mux.Router {
 	// make new Context
-	context := &Context{config.Port, config.ImageService}
+	context := &Context{config.Port, config.ImageService, serviceClient}
 
 	r := mux.NewRouter()
 

--- a/openstack/image/api_test.go
+++ b/openstack/image/api_test.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/01org/ciao/service"
 )
 
 // TBD - can some of this stuff be pulled out into a common test area?
@@ -48,9 +50,17 @@ var tests = []test{
 		"POST",
 		"/v2/images",
 		createImage,
-		`{"container_format":"bare","disk_format":"raw","name":"Ubuntu","id":"b2173dd3-7ad6-4362-baa6-a68bce3565cb"}`,
+		`{"container_format":"bare","disk_format":"raw","name":"Ubuntu","id":"b2173dd3-7ad6-4362-baa6-a68bce3565cb","visibility":"private"}`,
 		http.StatusCreated,
 		`{"status":"queued","container_format":"bare","min_ram":0,"updated_at":"2015-11-29T22:21:42Z","owner":"bab7d5c60cd041a0a36f7c4b6e1dd978","min_disk":0,"tags":[],"locations":[],"visibility":"private","id":"b2173dd3-7ad6-4362-baa6-a68bce3565cb","size":null,"virtual_size":null,"name":"Ubuntu","checksum":null,"created_at":"2015-11-29T22:21:42Z","disk_format":"raw","properties":null,"protected":false,"self":"/v2/images/b2173dd3-7ad6-4362-baa6-a68bce3565cb","file":"/v2/images/b2173dd3-7ad6-4362-baa6-a68bce3565cb/file","schema":"/v2/schemas/image"}`,
+	},
+	{
+		"POST",
+		"/v2/images",
+		createImage,
+		"",
+		http.StatusInternalServerError,
+		fmt.Sprintf("Internal Server Error\nnull"),
 	},
 	{
 		"GET",
@@ -86,6 +96,8 @@ var tests = []test{
 	},
 }
 
+const testTenantID = "1bea47ed-f6a9-463b-b423-14b9cca9ad27"
+
 func myHostname() string {
 	host, _ := os.Hostname()
 	return host
@@ -93,7 +105,7 @@ func myHostname() string {
 
 type testImageService struct{}
 
-func (is testImageService) CreateImage(req CreateImageRequest) (DefaultResponse, error) {
+func (is testImageService) CreateImage(tenantID string, req CreateImageRequest) (DefaultResponse, error) {
 	format := Bare
 	name := "Ubuntu"
 	createdAt, _ := time.Parse(time.RFC3339, "2015-11-29T22:21:42Z")
@@ -123,7 +135,7 @@ func (is testImageService) CreateImage(req CreateImageRequest) (DefaultResponse,
 	}, nil
 }
 
-func (is testImageService) ListImages() ([]DefaultResponse, error) {
+func (is testImageService) ListImages(tenantID string) ([]DefaultResponse, error) {
 	format := Bare
 	name := "Ubuntu"
 	createdAt, _ := time.Parse(time.RFC3339, "2015-11-29T22:21:42Z")
@@ -153,12 +165,15 @@ func (is testImageService) ListImages() ([]DefaultResponse, error) {
 	}
 
 	var images []DefaultResponse
-	images = append(images, image)
+
+	if tenantID == testTenantID {
+		images = append(images, image)
+	}
 
 	return images, nil
 }
 
-func (is testImageService) GetImage(ID string) (DefaultResponse, error) {
+func (is testImageService) GetImage(tenantID, ID string) (DefaultResponse, error) {
 	imageID := "1bea47ed-f6a9-463b-b423-14b9cca9ad27"
 	format := Bare
 	name := "cirros-0.3.2-x86_64-disk"
@@ -184,20 +199,21 @@ func (is testImageService) GetImage(ID string) (DefaultResponse, error) {
 		Protected:       false,
 		CheckSum:        &checksum,
 		ID:              imageID,
-		File:            fmt.Sprintf("/v2/images/%s/file", imageID),
-		Owner:           &owner,
-		MinRAM:          &minRAM,
-		Schema:          "/v2/schemas/image",
-		Name:            &name,
-		Size:            &size,
+
+		File:   fmt.Sprintf("/v2/images/%s/file", imageID),
+		Owner:  &owner,
+		MinRAM: &minRAM,
+		Schema: "/v2/schemas/image",
+		Name:   &name,
+		Size:   &size,
 	}, nil
 }
 
-func (is testImageService) UploadImage(string, io.Reader) (NoContentImageResponse, error) {
+func (is testImageService) UploadImage(string, string, io.Reader) (NoContentImageResponse, error) {
 	return NoContentImageResponse{}, nil
 }
 
-func (is testImageService) DeleteImage(string) (NoContentImageResponse, error) {
+func (is testImageService) DeleteImage(string, string) (NoContentImageResponse, error) {
 	return NoContentImageResponse{}, nil
 }
 
@@ -205,7 +221,7 @@ func TestRoutes(t *testing.T) {
 	var is testImageService
 	config := APIConfig{9292, is}
 
-	r := Routes(config)
+	r := Routes(config, nil)
 	if r == nil {
 		t.Fatalf("No routes returned")
 	}
@@ -217,18 +233,23 @@ func TestAPIResponse(t *testing.T) {
 	// TBD: add context to test definition so it can be created per
 	// endpoint with either a pass testVolumeService or a failure
 	// one.
-	context := &Context{9292, is}
+	context := &Context{9292, is, nil}
 
 	for _, tt := range tests {
 		req, err := http.NewRequest(tt.method, tt.pattern, bytes.NewBuffer([]byte(tt.request)))
 		if err != nil {
 			t.Fatal(err)
 		}
-
 		rr := httptest.NewRecorder()
 		handler := APIHandler{context, tt.handler}
 
-		handler.ServeHTTP(rr, req)
+		ctx := service.SetPrivilege(req.Context(), true)
+		ctx = service.SetTenantID(ctx, testTenantID)
+		if err != nil {
+			t.Fatalf("Error on setting tenant [%v]", testTenantID)
+		}
+
+		handler.ServeHTTP(rr, req.WithContext(ctx))
 
 		status := rr.Code
 		if status != tt.expectedStatus {

--- a/openstack/image/api_test.go
+++ b/openstack/image/api_test.go
@@ -60,7 +60,7 @@ var tests = []test{
 		createImage,
 		"",
 		http.StatusInternalServerError,
-		fmt.Sprintf("Internal Server Error\nnull"),
+		fmt.Sprintf("unexpected end of JSON input\nnull"),
 	},
 	{
 		"GET",

--- a/service/service.go
+++ b/service/service.go
@@ -16,6 +16,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 )
 
 type key int
@@ -23,6 +24,10 @@ type key int
 // PrivKey is the index of the context map which indicates whether a
 // service API has been called by a privileged user or not.
 const PrivKey key = 0
+
+// TenantIDKey is the index of the context map which indicates the
+// tenant id which is being used in the API call
+const TenantIDKey key = 1
 
 // GetPrivilege returns the value of PrivKey
 func GetPrivilege(ctx context.Context) bool {
@@ -33,4 +38,18 @@ func GetPrivilege(ctx context.Context) bool {
 // SetPrivilege is used to set the value of PrivKey
 func SetPrivilege(ctx context.Context, privileged bool) context.Context {
 	return context.WithValue(ctx, PrivKey, privileged)
+}
+
+// GetTenantID returns the value of TenantIDKey
+func GetTenantID(ctx context.Context) (string, error) {
+	tenantID, ok := ctx.Value(TenantIDKey).(string)
+	if ok {
+		return tenantID, nil
+	}
+	return tenantID, fmt.Errorf("There's no tenant on this Context")
+}
+
+// SetTenantID sets the value of Tenant ID
+func SetTenantID(ctx context.Context, tenantID string) context.Context {
+	return context.WithValue(ctx, TenantIDKey, tenantID)
 }

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -729,19 +729,22 @@ echo "--------------------------------------------------------------------------
 if [ -f "$ciao_cnci_image".qcow ]; then
     "$ciao_gobin"/ciao-cli \
         image add --file "$ciao_cnci_image".qcow \
-        --name "ciao CNCI image" --id 4e16e743-265a-4bf2-9fd1-57ada0b28904
+        --name "ciao CNCI image" --id 4e16e743-265a-4bf2-9fd1-57ada0b28904 \
+	--visibility internal
 fi
 
 if [ -f clear-"${LATEST}"-cloud.img ]; then
     "$ciao_gobin"/ciao-cli \
         image add --file clear-"${LATEST}"-cloud.img \
-        --name "Clear Linux ${LATEST}" --id df3768da-31f5-4ba6-82f0-127a1a705169
+        --name "Clear Linux ${LATEST}" --id df3768da-31f5-4ba6-82f0-127a1a705169 \
+	--visibility public
 fi
 
 if [ -f $fedora_cloud_image ]; then
     "$ciao_gobin"/ciao-cli \
         image add --file $fedora_cloud_image \
-        --name "Fedora Cloud Base 24-1.2" --id 73a86d7e-93c0-480e-9c41-ab42f69b7799
+        --name "Fedora Cloud Base 24-1.2" --id 73a86d7e-93c0-480e-9c41-ab42f69b7799 \
+	--visibility public
 fi
 
 echo ""


### PR DESCRIPTION
It's using a new metadata field called ``visibility`` which defines the access
restrictions that users and CIAO inself have when trying to access the images
catalog. Below are the 3 main types of visibility that are supported:

- Internal
      - CIAO cluster's internal images (e.g. cnci)
      - Only created by members of admin tenant/project
- Private
      - Default visibility for any created image
      - Only available in the tenant/project where it was created
- Public
      - Only created/deleted by members of admin tenant/project
      - Available in all tenants/projects
