### PR TITLE
travis: Allow go tip builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ go:
 
 env:
     - COVERALLS_TOKEN=mwTn1pOFqEOUT13vylZNHq53NanoMznO7
+matrix:
+  allow_failures:
+  - go: tip
 
 go_import_path: github.com/01org/ciao
 


### PR DESCRIPTION
The go tip builds are currently failing due to a compiler error, i.e.,
a crash in the compiler.  This commit will allow ciao builds to continue
to pass even if go tip builds fail.  This is reasonable enough as there
are likely to be build breakages on go tip from time to time.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>