### PR TITLE
small fixes

### DIFF
--- a/ciao-launcher/virtualizer.go
+++ b/ciao-launcher/virtualizer.go
@@ -112,7 +112,7 @@ type virtualizer interface {
 
 	// connected is called by the instance go routine to inform the virtualizer that
 	// the VM is running.  The virtualizer can used this notification to perform some
-	// bookeeping, for example determine the pid of the underlying process.  It may
+	// bookkeeping, for example determine the pid of the underlying process.  It may
 	// seem slightly odd that this function exists.  After all, it's a goroutine
 	// spawned by the monitorVM function that initially informs the instance go
 	// routine that the VM is connected. The problem is that all virtualizer methods

--- a/testutil/agent_test.go
+++ b/testutil/agent_test.go
@@ -59,8 +59,17 @@ func TestAgentStatusChanTimeout(t *testing.T) {
 
 	agentCh := agent.AddStatusChan(ssntp.READY)
 
+	// should time out
 	_, err := agent.GetStatusChanResult(agentCh, ssntp.READY)
 	if err == nil {
+		t.Fatal(err)
+	}
+
+	// don't leave the result on the channel
+	var result Result
+	go agent.SendResultAndDelStatusChan(ssntp.READY, result)
+	_, err = agent.GetStatusChanResult(agentCh, ssntp.READY)
+	if err != nil {
 		t.Fatal(err)
 	}
 }
@@ -88,8 +97,17 @@ func TestAgentErrorChanTimeout(t *testing.T) {
 
 	agentCh := agent.AddErrorChan(ssntp.StopFailure)
 
+	// should time out
 	_, err := agent.GetErrorChanResult(agentCh, ssntp.StopFailure)
 	if err == nil {
+		t.Fatal(err)
+	}
+
+	// don't leave the result on the channel
+	var result Result
+	go agent.SendResultAndDelErrorChan(ssntp.StopFailure, result)
+	_, err = agent.GetErrorChanResult(agentCh, ssntp.StopFailure)
+	if err != nil {
 		t.Fatal(err)
 	}
 }
@@ -117,8 +135,17 @@ func TestAgentEventChanTimeout(t *testing.T) {
 
 	agentCh := agent.AddEventChan(ssntp.TraceReport)
 
+	// should time out
 	_, err := agent.GetEventChanResult(agentCh, ssntp.TraceReport)
 	if err == nil {
+		t.Fatal(err)
+	}
+
+	// don't leave the result on the channel
+	var result Result
+	go agent.SendResultAndDelEventChan(ssntp.TraceReport, result)
+	_, err = agent.GetEventChanResult(agentCh, ssntp.TraceReport)
+	if err != nil {
 		t.Fatal(err)
 	}
 }
@@ -146,8 +173,17 @@ func TestAgentCmdChanTimeout(t *testing.T) {
 
 	agentCh := agent.AddCmdChan(ssntp.START)
 
+	// should time out
 	_, err := agent.GetCmdChanResult(agentCh, ssntp.START)
 	if err == nil {
+		t.Fatal(err)
+	}
+
+	// don't leave the result on the channel
+	var result Result
+	go agent.SendResultAndDelCmdChan(ssntp.START, result)
+	_, err = agent.GetCmdChanResult(agentCh, ssntp.START)
+	if err != nil {
 		t.Fatal(err)
 	}
 }

--- a/testutil/controller_test.go
+++ b/testutil/controller_test.go
@@ -54,8 +54,17 @@ func TestControllerErrorChanTimeout(t *testing.T) {
 
 	controllerCh := controller.AddErrorChan(ssntp.StopFailure)
 
+	// should time out
 	_, err := controller.GetErrorChanResult(controllerCh, ssntp.StopFailure)
 	if err == nil {
+		t.Fatal(err)
+	}
+
+	// don't leave the result on the channel
+	var result Result
+	go controller.SendResultAndDelErrorChan(ssntp.StopFailure, result)
+	_, err = controller.GetErrorChanResult(controllerCh, ssntp.StopFailure)
+	if err != nil {
 		t.Fatal(err)
 	}
 }
@@ -83,8 +92,17 @@ func TestControllerEventChanTimeout(t *testing.T) {
 
 	controllerCh := controller.AddEventChan(ssntp.TraceReport)
 
+	// should time out
 	_, err := controller.GetEventChanResult(controllerCh, ssntp.TraceReport)
 	if err == nil {
+		t.Fatal(err)
+	}
+
+	// don't leave the result on the channel
+	var result Result
+	go controller.SendResultAndDelEventChan(ssntp.TraceReport, result)
+	_, err = controller.GetEventChanResult(controllerCh, ssntp.TraceReport)
+	if err != nil {
 		t.Fatal(err)
 	}
 }
@@ -112,8 +130,17 @@ func TestControllerCmdChanTimeout(t *testing.T) {
 
 	controllerCh := controller.AddCmdChan(ssntp.START)
 
+	// should time out
 	_, err := controller.GetCmdChanResult(controllerCh, ssntp.START)
 	if err == nil {
+		t.Fatal(err)
+	}
+
+	// don't leave the result on the channel
+	var result Result
+	go controller.SendResultAndDelCmdChan(ssntp.START, result)
+	_, err = controller.GetCmdChanResult(controllerCh, ssntp.START)
+	if err != nil {
 		t.Fatal(err)
 	}
 }

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -190,11 +190,11 @@ func (server *SsntpTestServer) GetStatusChanResult(c chan Result, status ssntp.S
 }
 
 // SendResultAndDelStatusChan deletes an ssntp.Status from the SsntpTestServer status channel
-func (server *SsntpTestServer) SendResultAndDelStatusChan(error ssntp.Status, result Result) {
+func (server *SsntpTestServer) SendResultAndDelStatusChan(status ssntp.Status, result Result) {
 	server.StatusChansLock.Lock()
-	c, ok := server.StatusChans[error]
+	c, ok := server.StatusChans[status]
 	if ok {
-		delete(server.StatusChans, error)
+		delete(server.StatusChans, status)
 		server.StatusChansLock.Unlock()
 		c <- result
 		close(c)

--- a/testutil/server_test.go
+++ b/testutil/server_test.go
@@ -47,8 +47,17 @@ func TestServerStatusChanTimeout(t *testing.T) {
 
 	serverCh := server.AddStatusChan(ssntp.READY)
 
+	// should time out
 	_, err := server.GetStatusChanResult(serverCh, ssntp.READY)
 	if err == nil {
+		t.Fatal(err)
+	}
+
+	// don't leave the result on the channel
+	var result Result
+	go server.SendResultAndDelStatusChan(ssntp.READY, result)
+	_, err = server.GetStatusChanResult(serverCh, ssntp.READY)
+	if err != nil {
 		t.Fatal(err)
 	}
 }
@@ -76,8 +85,17 @@ func TestServerErrorChanTimeout(t *testing.T) {
 
 	serverCh := server.AddErrorChan(ssntp.StopFailure)
 
+	// should time out
 	_, err := server.GetErrorChanResult(serverCh, ssntp.StopFailure)
 	if err == nil {
+		t.Fatal(err)
+	}
+
+	// don't leave the result on the channel
+	var result Result
+	go server.SendResultAndDelErrorChan(ssntp.StopFailure, result)
+	_, err = server.GetErrorChanResult(serverCh, ssntp.StopFailure)
+	if err != nil {
 		t.Fatal(err)
 	}
 }
@@ -105,8 +123,17 @@ func TestServerEventChanTimeout(t *testing.T) {
 
 	serverCh := server.AddEventChan(ssntp.TraceReport)
 
+	// should time out
 	_, err := server.GetEventChanResult(serverCh, ssntp.TraceReport)
 	if err == nil {
+		t.Fatal(err)
+	}
+
+	// don't leave the result on the channel
+	var result Result
+	go server.SendResultAndDelEventChan(ssntp.TraceReport, result)
+	_, err = server.GetEventChanResult(serverCh, ssntp.TraceReport)
+	if err != nil {
 		t.Fatal(err)
 	}
 }
@@ -134,8 +161,17 @@ func TestServerCmdChanTimeout(t *testing.T) {
 
 	serverCh := server.AddCmdChan(ssntp.START)
 
+	// should time out
 	_, err := server.GetCmdChanResult(serverCh, ssntp.START)
 	if err == nil {
+		t.Fatal(err)
+	}
+
+	// don't leave the result on the channel
+	var result Result
+	go server.SendResultAndDelCmdChan(ssntp.START, result)
+	_, err = server.GetCmdChanResult(serverCh, ssntp.START)
+	if err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This PR cobbles together a few small fixes based on code inspection:  a misnamed variable which is less clear than it should be, a simple comment typo, and a bug in normally-not-run (due to "-short") testutil results channel timeout unit tests.