### PR TITLE
configuration: implement cluster configuration update

### DIFF
--- a/ciao-cli/configuration.go
+++ b/ciao-cli/configuration.go
@@ -1,0 +1,241 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/01org/ciao/ciao-controller/api"
+	"github.com/01org/ciao/ciao-controller/types"
+)
+
+var configCommand = &command{
+	SubCommands: map[string]subCommand{
+		"update": new(configUpdateCommand),
+		"show":   new(configShowCommand),
+	},
+}
+
+type confElement string
+
+type configUpdateCommand struct {
+	Flag    flag.FlagSet
+	element confElement
+	value   string
+}
+
+func (e *confElement) String() string {
+	return string(*e)
+}
+
+func (e *confElement) Set(s string) error {
+	switch string(s) {
+	case "scheduler.storage_uri",
+		"controller.compute_port",
+		"launcher.disk_limit",
+		"launcher.mem_limit",
+		"identity_service.type",
+		"identity_service.url":
+
+		*e = confElement(s)
+		return nil
+	}
+	return fmt.Errorf("invalid element of the cluster configuration")
+
+}
+
+func (cmd *configUpdateCommand) usage(...string) {
+	fmt.Fprintf(os.Stderr, `
+Usage:
+
+ciao-cli [options] config update [flags]
+
+update cluster configuration
+
+The update flags are:
+
+`)
+	cmd.Flag.PrintDefaults()
+	os.Exit(2)
+}
+
+func (cmd *configUpdateCommand) parseArgs(args []string) []string {
+	cmd.Flag.Usage = func() { cmd.usage() }
+	cmd.Flag.Var(&cmd.element, "element", "configuration field to change")
+	cmd.Flag.StringVar(&cmd.value, "value", "", "new value for element to change")
+	cmd.Flag.Parse(args)
+	return cmd.Flag.Args()
+}
+
+func (cmd *configUpdateCommand) run(args []string) error {
+	var req types.ConfigRequest
+	var response types.ConfigUpdateResponse
+	if cmd.element == "" {
+		fmt.Fprintf(os.Stderr, "Missing required -element parameter\n")
+		cmd.usage()
+	}
+
+	if cmd.value == "" {
+		fmt.Fprintf(os.Stderr, "Missing required -value parameter\n")
+		cmd.usage()
+	}
+	if validConfigValue(cmd.value, string(cmd.element)) == false {
+		return fmt.Errorf("'%s' is not a valid value for %s", cmd.value, cmd.element)
+	}
+
+	if cmd.element == "launcher.mem_limit" || cmd.element == "launcher.disk_limit" {
+		cmd.value = sanatizeBoolean(cmd.value)
+	}
+
+	url := buildCiaoURL("configuration")
+	req = types.ConfigRequest{
+		Element: string(cmd.element),
+		Value:   cmd.value,
+	}
+	b, err := json.Marshal(req)
+	if err != nil {
+		fatalf(err.Error())
+	}
+	body := bytes.NewReader(b)
+	ver := api.ClusterConfigV1
+
+	resp, err := sendCiaoRequest("PUT", url, nil, body, &ver)
+	if err != nil {
+		return err
+	}
+
+	err = unmarshalHTTPResponse(resp, &response)
+	if err != nil {
+		return err
+	}
+	fmt.Println(response.Response)
+	return nil
+}
+
+func validConfigValue(s string, t string) bool {
+	switch t {
+	case "scheduler.storage_uri":
+		return validConfigURI(s, "file")
+	case "identity_service.url":
+		return validConfigURI(s, "https")
+	case "controller.compute_port":
+		return validConfigNumber(s)
+	case "launcher.disk_limit", "launcher.mem_limit":
+		return validConfigBoolean(s)
+	case "identity_service.type":
+		return s == "keystone"
+	}
+	return false
+}
+
+// validConfigNumber checks that current input is a sane integer number
+func validConfigNumber(s string) bool {
+	if _, err := strconv.Atoi(s); err == nil {
+		return true
+	}
+	return false
+}
+
+func sanatizeBoolean(s string) string {
+	s = strings.ToLower(s)
+	switch s {
+	case "1", "t", "true":
+		return "true"
+	case "0", "f", "false":
+		return "false"
+	}
+	return ""
+}
+
+// validConfigBoolean returns true if the input (s) is correct value
+// for a boolean and its representation for the configuration yaml payload
+func validConfigBoolean(s string) bool {
+	s = strings.ToLower(s)
+	switch s {
+	case "1", "t", "true", "0", "f", "false":
+		return true
+	}
+	return false
+}
+
+// validConfigURI check correctness of the URI given, evaluating
+// if the string to be analized matches with the expected scheme
+// and meets the URI elements needed for scheme
+func validConfigURI(s string, scheme string) bool {
+	uri, err := url.Parse(s)
+	if err != nil {
+		return false
+	}
+	if scheme != uri.Scheme {
+		return false
+	}
+	switch scheme {
+	case "file":
+		return uri.Path != ""
+	case "https":
+		// check hostname is explicit (e.g: "https://:35357" is invalid)
+		return (uri.Host != "") && (strings.HasPrefix(uri.Host, ":") == false)
+	}
+	return false
+}
+
+type configShowCommand struct {
+	Flag flag.FlagSet
+}
+
+func (cmd *configShowCommand) usage(...string) {
+	fmt.Fprintf(os.Stderr, `
+Usage:
+
+ciao-cli config show
+
+Show current cluster configuration
+`)
+	os.Exit(2)
+}
+
+func (cmd *configShowCommand) parseArgs(args []string) []string {
+	cmd.Flag.Usage = func() { cmd.usage() }
+	cmd.Flag.Parse(args)
+	return cmd.Flag.Args()
+}
+
+func (cmd *configShowCommand) run(args []string) error {
+	var response types.ConfigShowResponse
+
+	ver := api.ClusterConfigV1
+	url := buildCiaoURL("configuration")
+	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	if err != nil {
+		return err
+	}
+
+	err = unmarshalHTTPResponse(resp, &response)
+	if err != nil {
+		return err
+	}
+	fmt.Print(response.Configuration)
+
+	return nil
+}

--- a/ciao-cli/configuration_test.go
+++ b/ciao-cli/configuration_test.go
@@ -1,0 +1,173 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package main
+
+import "testing"
+
+var configURICases = []struct {
+	uri      string // URI to evaluate
+	scheme   string // expected case to handle validation
+	expected bool   // expected result of the test case
+}{
+	{"http://identity.example.com:35357", "http", false},   // invalid URI (insecure scheme)
+	{"http://identity.example.com:35357", "https", false},  // invalid URI (invalid scheme)
+	{"https://:8080/subdir", "https", false},               // invalid URI (no host)
+	{"file://no-path-defined.example.com", "file", false},  // invalid URI (no path)
+	{"https://some-host.example.com:35357", "https", true}, // valid URI (host defined)
+	{"file:///etc/ciao/configuration.yaml", "file", true},  // valid URI (path defined)
+}
+
+var configBooleanCases = []struct {
+	boolStr  string // boolean string to evaluate
+	saneBool string // boolean value sanatized
+	expected bool   // expected result of the test case
+}{
+	{"1", "true", true},
+	{"t", "true", true},
+	{"T", "true", true},
+	{"true", "true", true},
+	{"TruE", "true", true},
+	{"TRUE", "true", true},
+	{"0", "false", true},
+	{"f", "false", true},
+	{"F", "false", true},
+	{"false", "false", true},
+	{"FalsE", "false", true},
+	{"FALSE", "false", true},
+	{"invalid", "", false},
+}
+
+var configNumberCases = []struct {
+	numStr   string // number string to evaluate
+	expected bool   // expected result of the test case
+}{
+	{"45", true},
+	{"invalid", false},
+}
+
+var configValueCases = []struct {
+	confElement string // element of configuration to test
+	confValue   string // value of the element in the configuration to test
+	expected    bool   // expected result of the test case
+}{
+	{"scheduler.storage_uri", "file:///etc/ciao/configuration.yaml", true},     // valid location for config
+	{"scheduler.storage_uri", "https:///etc/ciao/configuration.yaml", false},   // invalid scheme for config
+	{"storage.ceph_id", "42", false},                                           // unsupported configurable element
+	{"storage.ceph_id", "", false},                                             // unsupported configurable element
+	{"controller.volume_port", "42", false},                                    // unsupported configurable element
+	{"controller.volume_port", "NaN", false},                                   // unsupported configurable element
+	{"controller.compute_port", "8774", true},                                  // valid configurable value
+	{"controller.compute_port", "NaN", false},                                  // invalid port
+	{"controller.ciao_port", "8889", false},                                    // unsupported configurable element
+	{"controller.ciao_port", "NaN", false},                                     // unsupported configurable element
+	{"controller.compute_fqdn", "invalid", false},                              // unsupported configurable element
+	{"controller.compute_fqdn", "compute.example.com", false},                  // unsupported configurable element
+	{"controller.compute_ca", "notACert", false},                               // unsupported configurable element
+	{"controller.compute_ca", "/etc/pki/ciao/api/controller_cert.pem", false},  // unsupported configurable element
+	{"controller.compute_cert", "notACert", false},                             // unsupported configurable element
+	{"controller.compute_cert", "/etc/pki/ciao/api/controller_key.pem", false}, // unsupported configurable element
+	{"controller.identity_user", "", false},                                    // unsupported configurable element
+	{"controller.identity_user", "admin", false},                               // unsupported configurable element
+	{"controller.identity_password", "", false},                                // unsupported configurable element
+	{"controller.identity_password", "someAdminPassword", false},               // unsupported configurable element
+	{"controller.cnci_vcpus", "0", false},                                      // unsupported configurable element
+	{"controller.cnci_vcpus", "NaN", false},                                    // unsupported configurable element
+	{"controller.cnci_mem", "0", false},                                        // unsupported configurable element
+	{"controller.cnci_mem", "NaN", false},                                      // unsupported configurable element
+	{"controller.cnci_disk", "0", false},                                       // unsupported configurable element
+	{"controller.cnci_disk", "NaN", false},                                     // unsupported configurable element
+	{"controller.admin_ssh_key", "", false},                                    // unsupported configurable element
+	{"controller.admin_ssh_password", "notAKey", false},                        // unsupported configurable element
+	{"launcher.compute_net", "- 192.138.0.1/24", false},                        // unsupported configurable element
+	{"launcher.compute_net", "notANetList", false},                             // unsupported configurable element
+	{"launcher.mgmt_net", "- 192.138.0.1/24", false},                           // unsupported configurable element
+	{"launcher.mgmt_net", "notANetList", false},                                // unsupported configurable element
+	{"launcher.disk_limit", "true", true},                                      // valid value for disk_limit
+	{"launcher.disk_limit", "false", true},                                     // valid value for disk_limit
+	{"launcher.disk_limit", "invalid", false},                                  // invalid value for disk_limit
+	{"launcher.mem_limit", "true", true},                                       // valid value for mem_limit
+	{"launcher.mem_limit", "false", true},                                      // valid value for mem_limit
+	{"launcher.mem_limit", "invalid", false},                                   // invalid value for mem_limit
+	{"image_service.type", "glance", false},                                    // unsupported configurable element
+	{"image_service.type", "non-glance", false},                                // unsupported configurable element
+	{"image_service.url", "https://image.example.com", false},                  // unsupported configurable element
+	{"image_service.url", "invalidURL", false},                                 // unsupported configurable element
+	{"identity_service.type", "keystone", true},                                // valid value for identity_service.type
+	{"identity_service.type", "non-keystone", false},                           // unsupported configurable element
+	{"identity_service.url", "https://keystone.example.com:35357", true},       // valid value for identity_service.url
+	{"identity_service.url", "https://keystone.example.com:35358", true},       // valid value for identity_service.url
+	{"identity_service.url", "invalidURL", false},                              // invalid value for identity_service.url
+}
+
+func testValidConfigURICase(t *testing.T, uri string, scheme string, pass bool) {
+	val := validConfigURI(uri, scheme)
+	if (pass == false && val == true) || (pass == true && val == false) {
+		t.Fatalf("expected %v, got %v", pass, val)
+	}
+}
+
+// TestConfigurationValidConfigURI tests the 'validConfigURI' function
+// This test is expected to pass
+func TestConfigurationValidConfigURI(t *testing.T) {
+	for _, tt := range configURICases {
+		testValidConfigURICase(t, tt.uri, tt.scheme, tt.expected)
+	}
+
+}
+
+// TestConfigurationValidConfigBoolean tests the 'validConfigBoolean' function
+// This test is expected to pass
+func TestConfigurationValidConfigBoolean(t *testing.T) {
+	for _, tt := range configBooleanCases {
+		ret := validConfigBoolean(tt.boolStr)
+		if ret != tt.expected {
+			t.Fatalf("expected %v, got %v", tt.expected, ret)
+		}
+	}
+}
+
+// TestConfigurationValidConfigBoolean tests the 'sanatizeBoolean' function
+// This test is expected to pass
+func TestConfigurationSanatizeBoolean(t *testing.T) {
+	for _, tt := range configBooleanCases {
+		ret := sanatizeBoolean(tt.boolStr)
+		if ret != tt.saneBool {
+			t.Fatalf("expected %v, got %v", tt.saneBool, ret)
+		}
+	}
+}
+
+// TestConfigurationValidConfigNumber tests the 'validConfigNumber' function
+// This test is expected to pass
+func TestConfigurationValidConfigNumber(t *testing.T) {
+	for _, tt := range configNumberCases {
+		ret := validConfigNumber(tt.numStr)
+		if ret != tt.expected {
+			t.Fatalf("expected %v, got %v", tt.expected, ret)
+		}
+	}
+}
+
+// TestConfigurationValidConfigValue tests the 'validConfigValue' function
+// This test is expected to pass
+func TestConfigurationValidConfigValue(t *testing.T) {
+	for _, tt := range configValueCases {
+		ret := validConfigValue(tt.confValue, tt.confElement)
+		if ret != tt.expected {
+			t.Fatalf("expected %v, got %v", tt.expected, ret)
+		}
+	}
+}

--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -95,6 +95,7 @@ var commands = map[string]subCommand{
 	"pool":        poolCommand,
 	"external-ip": externalIPCommand,
 	"quotas":      quotasCommand,
+	"config":      configCommand,
 }
 
 var scopedToken string

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/01org/ciao/ciao-controller/types"
 	"github.com/01org/ciao/payloads"
+	"github.com/01org/ciao/testutil"
 )
 
 type test struct {
@@ -313,6 +314,14 @@ func (ts testCiaoService) ListQuotas(tenantID string) []types.QuotaDetails {
 
 func (ts testCiaoService) UpdateQuotas(tenantID string, qds []types.QuotaDetails) error {
 	return nil
+}
+
+func (ts testCiaoService) UpdateClusterConfig(newConf types.ConfigRequest) error {
+	return nil
+}
+func (ts testCiaoService) ShowClusterConfig() (string, error) {
+	return testutil.ConfigureSanatizedYaml, nil
+
 }
 
 func TestResponse(t *testing.T) {

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -49,7 +49,7 @@ var tests = []test{
 		"",
 		"application/text",
 		http.StatusOK,
-		`[{"rel":"pools","href":"/pools","version":"x.ciao.pools.v1","minimum_version":"x.ciao.pools.v1"},{"rel":"external-ips","href":"/external-ips","version":"x.ciao.external-ips.v1","minimum_version":"x.ciao.external-ips.v1"},{"rel":"workloads","href":"/workloads","version":"x.ciao.workloads.v1","minimum_version":"x.ciao.workloads.v1"},{"rel":"tenants","href":"/tenants","version":"x.ciao.tenants.v1","minimum_version":"x.ciao.tenants.v1"}]`,
+		`[{"rel":"pools","href":"/pools","version":"x.ciao.pools.v1","minimum_version":"x.ciao.pools.v1"},{"rel":"external-ips","href":"/external-ips","version":"x.ciao.external-ips.v1","minimum_version":"x.ciao.external-ips.v1"},{"rel":"workloads","href":"/workloads","version":"x.ciao.workloads.v1","minimum_version":"x.ciao.workloads.v1"},{"rel":"tenants","href":"/tenants","version":"x.ciao.tenants.v1","minimum_version":"x.ciao.tenants.v1"},{"rel":"configuration","href":"/configuration","version":"x.ciao.cluster-config.v1","minimum_version":"x.ciao.cluster-config.v1"}]`,
 	},
 	{
 		"GET",

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -178,6 +178,24 @@ var tests = []test{
 		http.StatusOK,
 		`{"quotas":[{"name":"test-quota-1","value":"10","usage":"3"},{"name":"test-quota-2","value":"unlimited","usage":"10"},{"name":"test-limit","value":"123"}]}`,
 	},
+	{
+		"GET",
+		"/configuration",
+		showConfig,
+		"",
+		"application/x.ciao.cluster-config.v1",
+		http.StatusOK,
+		`{"configuration":"configure:\n  scheduler:\n    storage_uri: /etc/ciao/ciao.json\n  storage:\n    ceph_id: ciao\n  controller:\n    volume_port: 446\n    compute_port: 443\n    ciao_port: 447\n    compute_fqdn: \"\"\n    compute_ca: /etc/pki/ciao/compute_ca.pem\n    compute_cert: /etc/pki/ciao/compute_key.pem\n    identity_user: controller\n    identity_password: ''\n    cnci_vcpus: 0\n    cnci_mem: 0\n    cnci_disk: 0\n    admin_ssh_key: ''\n    admin_password: ''\n  launcher:\n    compute_net:\n    - 192.168.1.110\n    mgmt_net:\n    - 192.168.1.111\n    disk_limit: false\n    mem_limit: false\n  image_service:\n    type: glance\n    url: http://glance.example.com\n  identity_service:\n    type: keystone\n    url: http://keystone.example.com\n"}`,
+	},
+	{
+		"PUT",
+		"/configuration",
+		updateConfig,
+		`{"element": "launcher.mem_limit","value": "True"}`,
+		"application/x.ciao.cluster-config.v1",
+		http.StatusOK,
+		`{"response":"Configuration update from 'launcher.mem_limit' to 'True' sent"}`,
+	},
 }
 
 type testCiaoService struct{}

--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -44,6 +44,7 @@ type controllerClient interface {
 	attachVolume(volID string, instanceID string, nodeID string) error
 	detachVolume(volID string, instanceID string, nodeID string) error
 	ssntpClient() *ssntp.Client
+	UpdateConfig(newConfPyld []byte) error
 }
 
 type ssntpClient struct {
@@ -684,5 +685,10 @@ func (client *ssntpClient) unMapExternalIP(t types.Tenant, m types.MappedIP) err
 	glog.V(1).Info(string(y))
 
 	_, err = client.ssntp.SendCommand(ssntp.ReleasePublicIP, y)
+	return err
+}
+
+func (client *ssntpClient) UpdateConfig(newConfPyld []byte) error {
+	_, err := client.ssntp.SendCommand(ssntp.CONFIGURE, newConfPyld)
 	return err
 }

--- a/ciao-controller/client_wrapper.go
+++ b/ciao-controller/client_wrapper.go
@@ -125,6 +125,10 @@ func (client *ssntpClientWrapper) Disconnect() {
 	client.closeClientChans()
 }
 
+func (client *ssntpClientWrapper) UpdateConfig(newConfPyld []byte) error {
+	return client.realClient.UpdateConfig(newConfPyld)
+}
+
 func (client *ssntpClientWrapper) openClientChans() {
 	client.CmdChansLock.Lock()
 	client.CmdChans = make(map[ssntp.Command]chan struct{})

--- a/ciao-controller/configuration.go
+++ b/ciao-controller/configuration.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/01org/ciao/ciao-controller/types"
+	"github.com/01org/ciao/payloads"
+	"gopkg.in/yaml.v2"
+)
+
+func (c *controller) UpdateClusterConfig(newConf types.ConfigRequest) error {
+	var pyld payloads.Configure
+	if newConf.Element == "" {
+		return errors.New("empty Element")
+	}
+	if newConf.Value == "" {
+		return errors.New("empty Value")
+	}
+	if validConfigElement(newConf.Element) == false {
+		return errors.New("invalid Value")
+	}
+	if validConfigValue(newConf.Value, newConf.Element) == false {
+		return errors.New("invalid Element")
+	}
+	pyld, err := c.client.ssntpClient().ClusterConfiguration()
+	if err != nil {
+		return err
+	}
+	err = updateConfPayload(newConf, &pyld)
+	if err != nil {
+		return err
+	}
+	newConfPyld, err := yaml.Marshal(pyld)
+	if err != nil {
+		return err
+	}
+	c.client.UpdateConfig(newConfPyld)
+	return nil
+}
+
+func (c *controller) ShowClusterConfig() (string, error) {
+	pyld, err := c.client.ssntpClient().ClusterConfiguration()
+	if err != nil {
+		return "", err
+	}
+	// no need to share sensitive information
+	pyld.Configure.Controller.IdentityPassword = ""
+	pyld.Configure.Controller.AdminPassword = ""
+	pyld.Configure.Controller.AdminSSHKey = ""
+	s, err := yaml.Marshal(pyld)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s", string(s)), nil
+}
+
+func updateConfPayload(confReq types.ConfigRequest, pyld *payloads.Configure) error {
+	badValueErr := fmt.Errorf("Unable to set '%s' value for '%s'", confReq.Value, confReq.Element)
+	switch confReq.Element {
+	case "scheduler.storage_uri":
+		pyld.Configure.Scheduler.ConfigStorageURI = confReq.Value
+	case "controller.compute_port":
+		newVal, err := strconv.Atoi(confReq.Value)
+		if err != nil {
+			return badValueErr
+		}
+		pyld.Configure.Controller.ComputePort = newVal
+	case "launcher.disk_limit":
+		newVal, err := strconv.ParseBool(confReq.Value)
+		if err != nil {
+			return badValueErr
+		}
+		pyld.Configure.Launcher.DiskLimit = newVal
+	case "launcher.mem_limit":
+		newVal, err := strconv.ParseBool(confReq.Value)
+		if err != nil {
+			return badValueErr
+		}
+		pyld.Configure.Launcher.MemoryLimit = newVal
+	case "identity_service.type":
+		if confReq.Element != "keystone" {
+			return badValueErr
+		}
+	case "identity_service.url":
+		pyld.Configure.IdentityService.URL = confReq.Value
+	}
+	return nil
+}
+
+// validConfigElement checks if the element to be modified matches
+// the the elements that are allowed to be changed
+func validConfigElement(s string) bool {
+	switch s {
+	case "scheduler.storage_uri", "controller.compute_port",
+		"launcher.disk_limit", "launcher.mem_limit",
+		"identity_service.type", "identity_service.url":
+		return true
+	}
+	return false
+}
+
+func validConfigValue(s string, t string) bool {
+	switch t {
+	case "scheduler.storage_uri":
+		return validConfigURI(s, "file")
+	case "identity_service.url":
+		return validConfigURI(s, "https")
+	case "controller.compute_port":
+		return validConfigNumber(s)
+	case "launcher.disk_limit", "launcher.mem_limit":
+		return validConfigBoolean(s)
+	case "identity_service.type":
+		return s == "keystone"
+	}
+	return false
+}
+
+// validConfigNumber checks that current input is a sane integer number
+func validConfigNumber(s string) bool {
+	if _, err := strconv.Atoi(s); err == nil {
+		return true
+	}
+	return false
+}
+
+// validConfigBoolean returns true if the input (s) is correct value
+// for a boolean and its representation for the configuration yaml payload
+func validConfigBoolean(s string) bool {
+	s = strings.ToLower(s)
+	switch s {
+	case "1", "t", "true", "0", "f", "false":
+		return true
+	}
+	return false
+}
+
+// validConfigURI check correctness of the URI given, evaluating
+// if the string to be analized matches with the expected scheme
+// and meets the URI elements needed for scheme
+func validConfigURI(s string, scheme string) bool {
+	uri, err := url.Parse(s)
+	if err != nil {
+		return false
+	}
+	if scheme != uri.Scheme {
+		return false
+	}
+	switch scheme {
+	case "file":
+		return uri.Path != ""
+	case "https":
+		// check hostname is explicit (e.g: "https://:35357" is invalid)
+		return (uri.Host != "") && (strings.HasPrefix(uri.Host, ":") == false)
+	}
+	return false
+}

--- a/ciao-controller/configuration_test.go
+++ b/ciao-controller/configuration_test.go
@@ -1,0 +1,202 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package main
+
+import "testing"
+
+var configURICases = []struct {
+	uri      string // URI to evaluate
+	scheme   string // expected case to handle validation
+	expected bool   // expected result of the test case
+}{
+	{"http://identity.example.com:35357", "http", false},   // invalid URI (insecure scheme)
+	{"http://identity.example.com:35357", "https", false},  // invalid URI (invalid scheme)
+	{"https://:8080/subdir", "https", false},               // invalid URI (no host)
+	{"file://no-path-defined.example.com", "file", false},  // invalid URI (no path)
+	{"https://some-host.example.com:35357", "https", true}, // valid URI (host defined)
+	{"file:///etc/ciao/configuration.yaml", "file", true},  // valid URI (path defined)
+}
+
+var configBooleanCases = []struct {
+	boolStr  string // boolean string to evaluate
+	saneBool string // boolean value sanatized
+	expected bool   // expected result of the test case
+}{
+	{"1", "true", true},
+	{"t", "true", true},
+	{"T", "true", true},
+	{"true", "true", true},
+	{"TruE", "true", true},
+	{"TRUE", "true", true},
+	{"0", "false", true},
+	{"f", "false", true},
+	{"F", "false", true},
+	{"false", "false", true},
+	{"FalsE", "false", true},
+	{"FALSE", "false", true},
+	{"invalid", "", false},
+}
+
+var configNumberCases = []struct {
+	numStr   string // number string to evaluate
+	expected bool   // expected result of the test case
+}{
+	{"45", true},
+	{"invalid", false},
+}
+
+var configElementCases = []struct {
+	element  string // element of the configuration to check
+	expected bool   // expected result of the test case
+}{
+	{"scheduler.storage_uri", true},          // valid supported element
+	{"storage.ceph_id", false},               // unsupported configurable element
+	{"controller.volume_port", false},        // unsupported configurable element
+	{"controller.compute_port", true},        // valid supported element
+	{"controller.ciao_port", false},          // unsupported configurable element
+	{"controller.compute_fqdn", false},       // unsupported configurable element
+	{"controller.compute_ca", false},         // unsupported configurable element
+	{"controller.compute_cert", false},       // unsupported configurable element
+	{"controller.identity_user", false},      // unsupported configurable element
+	{"controller.identity_password", false},  // unsupported configurable element
+	{"controller.cnci_vcpus", false},         // unsupported configurable element
+	{"controller.cnci_mem", false},           // unsupported configurable element
+	{"controller.cnci_disk", false},          // unsupported configurable element
+	{"controller.admin_ssh_key", false},      // unsupported configurable element
+	{"controller.admin_ssh_password", false}, // unsupported configurable element
+	{"launcher.compute_net", false},          // unsupported configurable element
+	{"launcher.mgmt_net", false},             // unsupported configurable element
+	{"launcher.disk_limit", true},            // valid supported element
+	{"launcher.mem_limit", true},             // valid supported element
+	{"image_service.type", false},            // unsupported configurable element
+	{"image_service.url", false},             // unsupported configurable element
+	{"identity_service.type", true},          // valid supported element
+	{"identity_service.url", true},           // valid supported element
+}
+
+var configValueCases = []struct {
+	confElement string // element of configuration to test
+	confValue   string // value of the element in the configuration to test
+	expected    bool   // expected result of the test case
+}{
+	{"scheduler.storage_uri", "file:///etc/ciao/configuration.yaml", true},     // valid location for config
+	{"scheduler.storage_uri", "https:///etc/ciao/configuration.yaml", false},   // invalid scheme for config
+	{"storage.ceph_id", "42", false},                                           // unsupported configurable element
+	{"storage.ceph_id", "", false},                                             // unsupported configurable element
+	{"controller.volume_port", "42", false},                                    // unsupported configurable element
+	{"controller.volume_port", "NaN", false},                                   // unsupported configurable element
+	{"controller.compute_port", "8774", true},                                  // valid configurable value
+	{"controller.compute_port", "NaN", false},                                  // invalid port
+	{"controller.ciao_port", "8889", false},                                    // unsupported configurable element
+	{"controller.ciao_port", "NaN", false},                                     // unsupported configurable element
+	{"controller.compute_fqdn", "invalid", false},                              // unsupported configurable element
+	{"controller.compute_fqdn", "compute.example.com", false},                  // unsupported configurable element
+	{"controller.compute_ca", "notACert", false},                               // unsupported configurable element
+	{"controller.compute_ca", "/etc/pki/ciao/api/controller_cert.pem", false},  // unsupported configurable element
+	{"controller.compute_cert", "notACert", false},                             // unsupported configurable element
+	{"controller.compute_cert", "/etc/pki/ciao/api/controller_key.pem", false}, // unsupported configurable element
+	{"controller.identity_user", "", false},                                    // unsupported configurable element
+	{"controller.identity_user", "admin", false},                               // unsupported configurable element
+	{"controller.identity_password", "", false},                                // unsupported configurable element
+	{"controller.identity_password", "someAdminPassword", false},               // unsupported configurable element
+	{"controller.cnci_vcpus", "0", false},                                      // unsupported configurable element
+	{"controller.cnci_vcpus", "NaN", false},                                    // unsupported configurable element
+	{"controller.cnci_mem", "0", false},                                        // unsupported configurable element
+	{"controller.cnci_mem", "NaN", false},                                      // unsupported configurable element
+	{"controller.cnci_disk", "0", false},                                       // unsupported configurable element
+	{"controller.cnci_disk", "NaN", false},                                     // unsupported configurable element
+	{"controller.admin_ssh_key", "", false},                                    // unsupported configurable element
+	{"controller.admin_ssh_password", "notAKey", false},                        // unsupported configurable element
+	{"launcher.compute_net", "- 192.138.0.1/24", false},                        // unsupported configurable element
+	{"launcher.compute_net", "notANetList", false},                             // unsupported configurable element
+	{"launcher.mgmt_net", "- 192.138.0.1/24", false},                           // unsupported configurable element
+	{"launcher.mgmt_net", "notANetList", false},                                // unsupported configurable element
+	{"launcher.disk_limit", "true", true},                                      // valid value for disk_limit
+	{"launcher.disk_limit", "false", true},                                     // valid value for disk_limit
+	{"launcher.disk_limit", "invalid", false},                                  // invalid value for disk_limit
+	{"launcher.mem_limit", "true", true},                                       // valid value for mem_limit
+	{"launcher.mem_limit", "false", true},                                      // valid value for mem_limit
+	{"launcher.mem_limit", "invalid", false},                                   // invalid value for mem_limit
+	{"image_service.type", "glance", false},                                    // unsupported configurable element
+	{"image_service.type", "non-glance", false},                                // unsupported configurable element
+	{"image_service.url", "https://image.example.com", false},                  // unsupported configurable element
+	{"image_service.url", "invalidURL", false},                                 // unsupported configurable element
+	{"identity_service.type", "keystone", true},                                // valid value for identity_service.type
+	{"identity_service.type", "non-keystone", false},                           // unsupported configurable element
+	{"identity_service.url", "https://keystone.example.com:35357", true},       // valid value for identity_service.url
+	{"identity_service.url", "https://keystone.example.com:35358", true},       // valid value for identity_service.url
+	{"identity_service.url", "invalidURL", false},                              // invalid value for identity_service.url
+}
+
+func testValidConfigURICase(t *testing.T, uri string, scheme string, pass bool) {
+	val := validConfigURI(uri, scheme)
+	if (pass == false && val == true) || (pass == true && val == false) {
+		t.Fatalf("expected %v, got %v", pass, val)
+	}
+}
+
+// TestConfigurationValidConfigURI tests the 'validConfigURI' function
+// This test is expected to pass
+func TestConfigurationValidConfigURI(t *testing.T) {
+	for _, tt := range configURICases {
+		testValidConfigURICase(t, tt.uri, tt.scheme, tt.expected)
+	}
+
+}
+
+// TestConfigurationValidConfigBoolean tests the 'validConfigBoolean' function
+// This test is expected to pass
+func TestConfigurationValidConfigBoolean(t *testing.T) {
+	for _, tt := range configBooleanCases {
+		ret := validConfigBoolean(tt.boolStr)
+		if ret != tt.expected {
+			t.Fatalf("expected %v, got %v", tt.expected, ret)
+		}
+	}
+}
+
+// TestConfigurationValidConfigNumber tests the 'validConfigNumber' function
+// This test is expected to pass
+func TestConfigurationValidConfigNumber(t *testing.T) {
+	for _, tt := range configNumberCases {
+		ret := validConfigNumber(tt.numStr)
+		if ret != tt.expected {
+			t.Fatalf("expected %v, got %v", tt.expected, ret)
+		}
+	}
+}
+
+// TestConfigurationValidConfigValue tests the 'validConfigValue' function
+// This test is expected to pass
+func TestConfigurationValidConfigValue(t *testing.T) {
+	for _, tt := range configValueCases {
+		ret := validConfigValue(tt.confValue, tt.confElement)
+		if ret != tt.expected {
+			t.Fatalf("expected %v, got %v", tt.expected, ret)
+		}
+	}
+}
+
+// TestConfigurationValidElementValue tests the 'validConfigElement' function
+// This test is expected to pass
+func TestConfigurationValidElementValue(t *testing.T) {
+	for _, tt := range configElementCases {
+		ret := validConfigElement(tt.element)
+		if ret != tt.expected {
+			t.Fatalf("expected %v, got %v", tt.expected, ret)
+		}
+	}
+}

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -731,3 +731,20 @@ type QuotaUpdateRequest struct {
 type QuotaListResponse struct {
 	Quotas []QuotaDetails `json:"quotas"`
 }
+
+// ConfigRequest is used to request a change in  a specific element of the
+// cluster configuration
+type ConfigRequest struct {
+	Element string `json:"element"`
+	Value   string `json:"value"`
+}
+
+// ConfigUpdateResponse is used to respond a configuration update request
+type ConfigUpdateResponse struct {
+	Response string `json:"response"`
+}
+
+// ConfigShowResponse is used to respond a configuration show request
+type ConfigShowResponse struct {
+	Configuration string `json:"configuration"`
+}

--- a/configuration/file.go
+++ b/configuration/file.go
@@ -18,10 +18,12 @@ package configuration
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/url"
 
 	"github.com/01org/ciao/payloads"
+	"gopkg.in/yaml.v2"
 )
 
 type file struct {
@@ -60,7 +62,18 @@ func (f *file) fetchConfiguration(uriStr string) (conf payloads.Configure, err e
 	return conf, nil
 }
 
-func (f *file) storeConfiguration(payloads.Configure) error {
-	//empty for now
+func (f *file) storeConfiguration(config payloads.Configure) error {
+	uri, err := url.Parse(config.Configure.Scheduler.ConfigStorageURI)
+	if err != nil {
+		return fmt.Errorf("unable to obtain configuration file location: %v", err)
+	}
+	pyld, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("unable to save new configuration: %v", err)
+	}
+	err = ioutil.WriteFile(uri.Path, pyld, 0600)
+	if err != nil {
+		return fmt.Errorf("unable to save new configuration: %v", err)
+	}
 	return nil
 }

--- a/configuration/file_test.go
+++ b/configuration/file_test.go
@@ -18,6 +18,7 @@ package configuration
 
 import (
 	"io/ioutil"
+	"os"
 	"syscall"
 	"testing"
 
@@ -126,7 +127,21 @@ func TestFileStoreConfiguration(t *testing.T) {
 	conf.InitDefaults()
 	d = &file{}
 
-	err := d.storeConfiguration(conf)
+	// create temp file where we can read the conf
+	tmpf, err := ioutil.TempFile("", "configuration.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpf.Name())
+	uri := "file://" + tmpf.Name()
+	conf.Configure.Scheduler.ConfigStorageURI = uri
+	err = ioutil.WriteFile(tmpf.Name(), []byte(fullValidConf), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = d.storeConfiguration(conf)
+
 	if err != nil {
 		t.Errorf("expected nil, got %v", err)
 	}

--- a/ssntp/ssntp.go
+++ b/ssntp/ssntp.go
@@ -969,6 +969,7 @@ type connectionStatus struct {
 type clusterConfiguration struct {
 	sync.RWMutex
 	configuration []byte
+	backup        string
 }
 
 func (conf *clusterConfiguration) setConfiguration(configuration []byte) {

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -414,6 +414,41 @@ const ConfigureYaml = `configure:
     url: ` + KeystoneURL + `
 `
 
+// ConfigureSanatizedYaml is a sample CONFIGURE ssntp.Command response for test cases
+const ConfigureSanatizedYaml = `configure:
+  scheduler:
+    storage_uri: ` + StorageURI + `
+  storage:
+    ceph_id: ` + ManagementID + `
+  controller:
+    volume_port: ` + VolumePort + `
+    compute_port: ` + ComputePort + `
+    ciao_port: ` + CiaoPort + `
+    compute_fqdn: ""
+    compute_ca: ` + HTTPSCACert + `
+    compute_cert: ` + HTTPSKey + `
+    identity_user: ` + IdentityUser + `
+    identity_password: ''
+    cnci_vcpus: 0
+    cnci_mem: 0
+    cnci_disk: 0
+    admin_ssh_key: ''
+    admin_password: ''
+  launcher:
+    compute_net:
+    - ` + ComputeNet + `
+    mgmt_net:
+    - ` + MgmtNet + `
+    disk_limit: false
+    mem_limit: false
+  image_service:
+    type: glance
+    url: ` + GlanceURL + `
+  identity_service:
+    type: keystone
+    url: ` + KeystoneURL + `
+`
+
 // DeleteFailureYaml is a sample workload DeleteFailure ssntp.Error payload for test cases
 const DeleteFailureYaml = `instance_uuid: ` + InstanceUUID + `
 reason: no_instance


### PR DESCRIPTION
This PR enables CIAO to update the cluster configuration though the `ciao-cli` command line

Examples of the commands usage are
```
$ ciao-cli config show
```
and
```
$ ciao-cli config update -element identity_service.url -value https://localhost:9996
```
Current functionality of this feature updates the configuration of the ciao-scheduler node and also writes new configuration file, but broadcasting of configuration changes are not done due to the lack of functionality to work with multiple ciao-controller nodes, and the tooling for mirroring identity nodes (so we don't break current tenants) (more details in #1113), so **new nodes connecting to the ciao-scheduler will receive the new configuration payload while nodes already connected are required to restart in order to fetch new configuration** from the ciao-scheduler node.

This closes #929 

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>