### PR TITLE
ansible: Use keystone:stable container

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/ciao_prepare.yml
+++ b/_DeploymentAndDistroPackaging/ansible/ciao_prepare.yml
@@ -24,7 +24,7 @@
       register: pull_images
       changed_when: "'Image is up to date' not in pull_images.stdout"
       with_items:
-        - clearlinux/keystone
+        - clearlinux/keystone:stable
         - clearlinux/ciao-webui
 
     - name: Stop containers running from an old image

--- a/_DeploymentAndDistroPackaging/ansible/roles/keystone/tasks/main.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/keystone/tasks/main.yml
@@ -27,7 +27,7 @@
   - name: Start keystone container
     docker_container:
       name: ciao-keystone
-      image: clearlinux/keystone
+      image: clearlinux/keystone:stable
       state: started
       privileged: True
       etc_hosts: "{{ etc_hosts }}"


### PR DESCRIPTION
Use clearlinux/keystone:stable container rather than
clearlinux/keystone:latest

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>