### PR TITLE
ciao-down: Allow qemu boot to continue even if 9p mounts fail

### DIFF
--- a/testutil/ciao-down/cloudinit.go
+++ b/testutil/ciao-down/cloudinit.go
@@ -30,8 +30,8 @@ curl -X PUT -d "OK" 10.0.2.2:{{.HTTPServerPort -}}
 {{end -}}
 #cloud-config
 mounts:
- - [hostgo, {{.GoPath}}, 9p, "trans=virtio,version=9p2000.L", "0", "0"]
-{{if len .UIPath }} - [hostui, {{.UIPath}}, 9p, "trans=virtio,version=9p2000.L", "0", "0"]{{end}}
+ - [hostgo, {{.GoPath}}, 9p, "x-systemd.automount,x-systemd.device-timeout=10,nofail,trans=virtio,version=9p2000.L", "0", "0"]
+{{if len .UIPath }} - [hostui, {{.UIPath}}, 9p, "x-systemd.automount,x-systemd.device-timeout=10,nofail,trans=virtio,version=9p2000.L", "0", "0"]{{end}}
 write_files:
 {{- if len $.HTTPProxy }}
  - content: |
@@ -253,7 +253,7 @@ curl -X PUT -d "OK" 10.0.2.2:{{.HTTPServerPort -}}
 {{end -}}
 #cloud-config
 mounts:
- - [hostgo, {{.GoPath}}, 9p, "trans=virtio,version=9p2000.L", "0", "0"]
+ - [hostgo, {{.GoPath}}, 9p, "x-systemd.automount,x-systemd.device-timeout=10,nofail,trans=virtio,version=9p2000.L", "0", "0"]
 write_files:
 {{- if len $.HTTPProxy }}
  - content: |


### PR DESCRIPTION
There seems to be a race condition that causes the mounting of the
shared folders via 9p to fail.  This in turn causes the ciao-down
VM boot to fail.  This commit switches to using the system.d
automount facility ( which may fix the mount problem ) and allows the
boot to continue even if the mounts fail.  This is preferable to the
current status in which ciao-down connect seems to hang from time
to time on some machines.  If automatic mounting fails it should
still be possible to manually mount the shared folders from the command
line.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>