### PR TITLE
Controller fqdn from cert

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/templates/configuration.yaml.j2
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/templates/configuration.yaml.j2
@@ -8,7 +8,6 @@ configure:
     compute_cert: /etc/pki/keystone/keystone_key.pem
     identity_user: {{ ciao_service_user }}
     identity_password: {{ ciao_service_password }}
-    compute_fqdn: {{ ciao_controller_fqdn }}
   image_service:
     url: https://{{ ciao_controller_fqdn }}:9292
   storage:

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -225,10 +225,7 @@ func main() {
 	wg.Add(1)
 	go ctl.startImageService()
 
-	host := clusterConfig.Configure.Controller.ControllerFQDN
-	if host == "" {
-		host, _ = os.Hostname()
-	}
+	host, _ := os.Hostname()
 	ctl.apiURL = fmt.Sprintf("https://%s:%d", host, controllerAPIPort)
 
 	wg.Add(1)

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -25,9 +25,12 @@ package main
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"sync"
@@ -225,7 +228,16 @@ func main() {
 	wg.Add(1)
 	go ctl.startImageService()
 
-	host, _ := os.Hostname()
+	host, err := getControllerFQDNFromCert(*cert)
+	if err != nil {
+		glog.Infof("Unable to determine hostname from controller certificate %s: %s", *cert, err)
+
+		host, err = os.Hostname()
+		if err != nil {
+			glog.Fatal("Unable to determine hostname from OS: ", err)
+			return
+		}
+	}
 	ctl.apiURL = fmt.Sprintf("https://%s:%d", host, controllerAPIPort)
 
 	wg.Add(1)
@@ -282,4 +294,34 @@ func (c *controller) startCiaoService() error {
 	}
 
 	return nil
+}
+
+func getControllerFQDNFromCert(cert string) (string, error) {
+	bytesCert, err := ioutil.ReadFile(cert)
+	if err != nil {
+		return "", fmt.Errorf("couldn't read cert: %s", err)
+	}
+
+	blockCert, _ := pem.Decode(bytesCert)
+	if blockCert == nil {
+		return "", fmt.Errorf("couldn't decode cert")
+	}
+
+	parsedCert, err := x509.ParseCertificate(blockCert.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("couldn't parse cert: %s", err)
+	}
+
+	role := ssntp.GetRoleFromOIDs(parsedCert.UnknownExtKeyUsage)
+	if !role.IsController() {
+		return "", fmt.Errorf("expected certificate role ssntp.Controller, got role %s", role.String())
+	}
+
+	for _, host := range parsedCert.DNSNames {
+		if host != "" {
+			return host, nil
+		}
+	}
+
+	return "", fmt.Errorf("found no hostname in certificate")
 }

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -67,7 +67,6 @@ const fullValidConf = `configure:
     volume_port: 8776
     compute_port: 8774
     ciao_port: 8889
-    compute_fqdn: ""
     compute_ca: /etc/pki/ciao/compute_ca.pem
     compute_cert: /etc/pki/ciao/compute_key.pem
     identity_user: controller

--- a/payloads/configure.go
+++ b/payloads/configure.go
@@ -69,7 +69,6 @@ type ConfigureController struct {
 	VolumePort       int    `yaml:"volume_port"`
 	ComputePort      int    `yaml:"compute_port"`
 	CiaoPort         int    `yaml:"ciao_port"`
-	ControllerFQDN   string `yaml:"compute_fqdn"`
 	HTTPSCACert      string `yaml:"compute_ca"`
 	HTTPSKey         string `yaml:"compute_cert"`
 	IdentityUser     string `yaml:"identity_user"`

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -377,7 +377,6 @@ const ConfigureYaml = `configure:
     volume_port: ` + VolumePort + `
     compute_port: ` + ComputePort + `
     ciao_port: ` + CiaoPort + `
-    compute_fqdn: ""
     compute_ca: ` + HTTPSCACert + `
     compute_cert: ` + HTTPSKey + `
     identity_user: ` + IdentityUser + `


### PR DESCRIPTION
This PR reverts the two patches which allow the FQDN to come in via a user configuration touch point with fallback to os.Hostname().  Instead it pulls the FQDN from the controller certificate, which ciao-cert populates.  If not present, it still falls back to os.Hostname().  Passes BAT and singlevm test automation.