### PR TITLE
ciao-down: Use apt section of cloudinit file

### DIFF
--- a/testutil/ciao-down/cloudinit.go
+++ b/testutil/ciao-down/cloudinit.go
@@ -35,9 +35,6 @@ mounts:
 write_files:
 {{- if len $.HTTPProxy }}
  - content: |
-     Acquire::http::Proxy "{{$.HTTPProxy}}";
-   path: /etc/apt/apt.conf
- - content: |
      [Service]
      Environment="HTTP_PROXY={{$.HTTPProxy}}"{{if len .HTTPSProxy}} "HTTPS_PROXY={{.HTTPSProxy}}{{end}}"{{if len .NoProxy}} "NO_PROXY={{.NoProxy}},singlevm{{end}}"
    path: /etc/systemd/system/docker.service.d/http-proxy.conf
@@ -61,6 +58,15 @@ write_files:
  - content: |
      deb https://apt.dockerproject.org/repo ubuntu-xenial main
    path: /etc/apt/sources.list.d/docker.list
+
+apt:
+{{- if len $.HTTPProxy }}
+  proxy: "{{$.HTTPProxy}}"
+{{- end}}
+{{- if len $.HTTPSProxy }}
+  https_proxy: "{{$.HTTPSProxy}}"
+{{- end}}
+package_upgrade: true
 
 runcmd:
  - echo "127.0.0.1 singlevm" >> /etc/hosts
@@ -107,10 +113,6 @@ runcmd:
 
  - curl -X PUT -d "Retrieving updated list of packages" 10.0.2.2:{{.HTTPServerPort}}
  - {{template "ENV" .}}apt-get update
- - {{template "CHECK" .}}
-
- - curl -X PUT -d "Upgrading" 10.0.2.2:{{.HTTPServerPort}}
- - {{template "ENV" .}}apt-get upgrade -y
  - {{template "CHECK" .}}
 
  - curl -X PUT -d "Installing Docker" 10.0.2.2:{{.HTTPServerPort}}
@@ -257,9 +259,6 @@ mounts:
 write_files:
 {{- if len $.HTTPProxy }}
  - content: |
-     Acquire::http::Proxy "{{$.HTTPProxy}}";
-   path: /etc/apt/apt.conf
- - content: |
      [Service]
      Environment="HTTP_PROXY={{$.HTTPProxy}}"{{if len .HTTPSProxy}} "HTTPS_PROXY={{.HTTPSProxy}}{{end}}"{{if len .NoProxy}} "NO_PROXY={{.NoProxy}},singlevm{{end}}"
    path: /etc/systemd/system/docker.service.d/http-proxy.conf
@@ -282,6 +281,15 @@ write_files:
  - content: |
      deb https://apt.dockerproject.org/repo ubuntu-xenial main
    path: /etc/apt/sources.list.d/docker.list
+
+apt:
+{{- if len $.HTTPProxy }}
+  proxy: "{{$.HTTPProxy}}"
+{{- end}}
+{{- if len $.HTTPSProxy }}
+  https_proxy: "{{$.HTTPSProxy}}"
+{{- end}}
+package_upgrade: true
 
 runcmd:
  - echo "127.0.0.1 singlevm" >> /etc/hosts
@@ -330,13 +338,8 @@ runcmd:
  - {{template "ENV" .}}curl -fsSL http://download.opensuse.org/repositories/home:clearlinux:preview:clear-containers-2.1/xUbuntu_16.04/Release.key | sudo apt-key add -
  - {{template "CHECK" .}}
 
-
  - curl -X PUT -d "Retrieving updated list of packages" 10.0.2.2:{{.HTTPServerPort}}
  - {{template "ENV" .}}apt-get update
- - {{template "CHECK" .}}
-
- - curl -X PUT -d "Upgrading" 10.0.2.2:{{.HTTPServerPort}}
- - {{template "ENV" .}}apt-get upgrade -y
  - {{template "CHECK" .}}
 
  - curl -X PUT -d "Installing Clear Containers Runtime" 10.0.2.2:{{.HTTPServerPort}}


### PR DESCRIPTION
The cloudinit file has a dedicated section for configuring apt but
we weren't using it.  Instead we were executing all of the apt
commands in the runcmd and write_files section of the cloud-init file.
This commit moves the instructions that set up the apt proxies and
initiate the apt-get upgrade to the apt section.  The other commands
such as setting up sources and installing packages can not be used
as these sections do not handle proxies correctly.

Fixes #1131

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>