### PR TITLE
test-cases: Treat SKIPped tests as ok

### DIFF
--- a/test-cases/test-cases.go
+++ b/test-cases/test-cases.go
@@ -702,7 +702,7 @@ func generateTAPOutput(tests []*PackageTests) {
 		pkgName := p.Name[len(prefix):]
 		fmt.Printf("# Tests for %s\n", pkgName)
 		for _, t := range p.Tests {
-			if t.Result == "PASS" {
+			if t.Result == "PASS" || t.Result == "SKIP" {
 				fmt.Printf("ok ")
 			} else {
 				fmt.Printf("not ok ")


### PR DESCRIPTION
This change modifies test-cases so it treats skipped tests as
'ok'.  This is needed to ensure that our release builds pass.  Currently,
some of the BAT tests are skipped due to missing functionality.

Fixes #1145

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>