### PR TITLE
ansible: Create /usr/local/bin

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/tasks/main.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/tasks/main.yml
@@ -33,8 +33,13 @@
       - /etc/pki/ciao
       - /etc/pki/keystone
 
-  - name: Create /etc/systemd/system if it does not exists
+  - name: Create directories required by root
     file: path=/etc/systemd/system state=directory owner=root group=root
+    with_items:
+      - /etc/systemd
+      - /etc/systemd/system
+      - /usr/local
+      - /usr/local/bin
 
   - include: ceph.yml
     when: not skip_ceph


### PR DESCRIPTION
Some distributions do not have the folder already created by default.
This change ensures the directory is present and owned by root.

Fixes #1140

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>