### PR TITLE
ansible: Fix bug introduced at 27cdcb9

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/tasks/main.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/tasks/main.yml
@@ -34,7 +34,7 @@
       - /etc/pki/keystone
 
   - name: Create directories required by root
-    file: path=/etc/systemd/system state=directory owner=root group=root
+    file: path={{ item }} state=directory owner=root group=root
     with_items:
       - /etc/systemd
       - /etc/systemd/system


### PR DESCRIPTION
Use {{ item }} as an argument to a task with
`with_items` clause

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>