### PR TITLE
Workload defaults refactor

### DIFF
--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -794,32 +794,6 @@ func (ds *sqliteDB) getWorkloadDefaults(ID string) ([]payloads.RequestedResource
 }
 
 // lock must be held by caller
-func (ds *sqliteDB) getResources(tx *sql.Tx) (map[string]int, error) {
-	m := make(map[string]int)
-
-	query := `SELECT id, name from resources`
-
-	rows, err := tx.Query(query)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var id int
-		var name string
-		err := rows.Scan(&id, &name)
-		if err != nil {
-			return nil, err
-		}
-
-		m[name] = id
-	}
-
-	return m, nil
-}
-
-// lock must be held by caller
 func (ds *sqliteDB) createWorkloadDefault(tx *sql.Tx, workloadID string, resource payloads.RequestedResource) error {
 
 	_, err := tx.Exec("INSERT INTO workload_resources (workload_id, resource_type, default_value, estimated_value, mandatory) VALUES (?, ?, ?, ?, ?)", workloadID, string(resource.Type), resource.Value, resource.Value, resource.Mandatory)

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -974,7 +974,7 @@ users:
 		ImageID:     uuid.Generate().String(),
 		ImageName:   "",
 		Config:      testConfig,
-		Defaults:    []payloads.RequestedResource{cpus, mem},
+		Defaults:    []payloads.RequestedResource{mem, cpus},
 		Storage:     []types.StorageResource{storage},
 	}
 


### PR DESCRIPTION
This PR addresses #1114 and switches the workload_resources table, used to store the resources needed for a workload to not store the resource type as an integer but as a string. Removing conversion to & fro.