### PR TITLE
travis: Enable go 1.8 builds on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 go:
     - 1.7
-    - go1.8beta2
+    - 1.8
     - tip
 
 env:


### PR DESCRIPTION
We've been tracking 1.8 development for a while, switch to the stable
release. \o/

Signed-off-by: Rob Bradford <robert.bradford@intel.com>