### PR TITLE
ciao-cli: Fix privilege related error reporting for quotas command

### DIFF
--- a/ciao-cli/quotas.go
+++ b/ciao-cli/quotas.go
@@ -72,7 +72,7 @@ func (cmd *quotasUpdateCommand) parseArgs(args []string) []string {
 
 func (cmd *quotasUpdateCommand) run(args []string) error {
 	if !checkPrivilege() {
-		errorf("Updating quotas is only available for privileged users")
+		fatalf("Updating quotas is only available for privileged users")
 	}
 
 	if cmd.name == "" {
@@ -179,11 +179,16 @@ func (cmd *quotasListCommand) run(args []string) error {
 	}
 
 	if cmd.tenantID != "" {
+		if !checkPrivilege() {
+			fatalf("Listing quotas for other tenants is for privileged users only")
+		}
+
 		url = fmt.Sprintf("%s/%s/quotas", url, cmd.tenantID)
 	} else {
-		if !checkPrivilege() {
-			errorf("Listing quotas for other tenants is for privileged users only")
+		if checkPrivilege() {
+			fatalf("Admin user must specify the tenant with -for-tenant")
 		}
+
 		url = fmt.Sprintf("%s/quotas", url)
 	}
 	ver := api.TenantsV1


### PR DESCRIPTION
This change switches the error messages to use fatalf() and terminate
execution if there is a problem with the user privileges.

It also works to ensure that if the user is an admin then they must
specify a tenant id to check as the Ciao API url creation never embeds
the url for the the admin tenant and so the unprivileged path does not
work the admin user.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>