### PR TITLE
ciao-down: Update Go to 1.8

### DIFF
--- a/testutil/ciao-down/cloudinit.go
+++ b/testutil/ciao-down/cloudinit.go
@@ -94,12 +94,12 @@ runcmd:
  - echo "PATH=\"$PATH:/usr/local/go/bin:{{$.GoPath}}/bin:/usr/local/nodejs/bin\""  >> /etc/environment
 
  - curl -X PUT -d "Downloading Go" 10.0.2.2:{{.HTTPServerPort}}
- - {{template "ENV" .}}wget https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz -O /tmp/go1.7.4.linux-amd64.tar.gz
+ - {{template "ENV" .}}wget https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz -O /tmp/go1.8.linux-amd64.tar.gz
  - {{template "CHECK" .}}
  - curl -X PUT -d "Unpacking Go" 10.0.2.2:{{.HTTPServerPort}}
- - tar -C /usr/local -xzf /tmp/go1.7.4.linux-amd64.tar.gz
+ - tar -C /usr/local -xzf /tmp/go1.8.linux-amd64.tar.gz
  - {{template "CHECK" .}}
- - rm /tmp/go1.7.4.linux-amd64.tar.gz
+ - rm /tmp/go1.8.linux-amd64.tar.gz
 
  - groupadd docker
  - sudo gpasswd -a {{.User}} docker


### PR DESCRIPTION
This commit updates the version of Go used in ciao-down ciao VMs from
1.7.4 to 1.8.  The version used in the creation of clearcontainer vms
has not been changed.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>