### PR TITLE
ciao-scheduler: remove unused code

### DIFF
--- a/ciao-scheduler/export_test.go
+++ b/ciao-scheduler/export_test.go
@@ -16,10 +16,6 @@
 
 package main
 
-type SsntpSchedulerServer ssntpSchedulerServer
-type NodeStat nodeStat
-type WorkResources workResources
-
 var PickComputeNode = pickComputeNode
 var PickNetworkNode = pickNetworkNode
 
@@ -30,5 +26,4 @@ var DisconnectComputeNode = disconnectComputeNode
 var ConnectNetworkNode = connectNetworkNode
 var DisconnectNetworkNode = disconnectNetworkNode
 
-var StartWorkload = startWorkload
 var GetWorkloadAgentUUID = getWorkloadAgentUUID

--- a/ciao-scheduler/scheduler_internal_test.go
+++ b/ciao-scheduler/scheduler_internal_test.go
@@ -82,9 +82,6 @@ func spinUpComputeNode(sched *ssntpSchedulerServer, ident int, RAM int) {
 func spinUpComputeNodeLarge(sched *ssntpSchedulerServer, ident int) {
 	spinUpComputeNode(sched, ident, 141312)
 }
-func spinUpComputeNodeSmall(sched *ssntpSchedulerServer, ident int) {
-	spinUpComputeNode(sched, ident, 16384)
-}
 func spinUpComputeNodeVerySmall(sched *ssntpSchedulerServer, ident int) {
 	spinUpComputeNode(sched, ident, 200)
 }
@@ -114,9 +111,6 @@ func spinUpNetworkNode(sched *ssntpSchedulerServer, ident int, RAM int, networks
 
 func spinUpNetworkNodeLarge(sched *ssntpSchedulerServer, ident int, networks []payloads.NetworkStat) {
 	spinUpNetworkNode(sched, ident, 141312, networks)
-}
-func spinUpNetworkNodeSmall(sched *ssntpSchedulerServer, ident int, networks []payloads.NetworkStat) {
-	spinUpNetworkNode(sched, ident, 16384, networks)
 }
 func spinUpNetworkNodeVerySmall(sched *ssntpSchedulerServer, ident int, networks []payloads.NetworkStat) {
 	spinUpNetworkNode(sched, ident, 200, networks)


### PR DESCRIPTION
There's a small amount of test code that was originally intended to
support some test coverage, but that didn't end up being used.  Remove
it for cleanliness.

Signed-off-by: Tim Pepper <timothy.c.pepper@linux.intel.com>