### PR TITLE
ansible: Improve cleanup script

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/cleanup/ciao.yml
+++ b/_DeploymentAndDistroPackaging/ansible/cleanup/ciao.yml
@@ -17,15 +17,15 @@
   connection: local
   tasks:
     - name: Remove local files
-      local_action: file path={{ item }} state=absent
+      file: path={{ item }} state=absent
       with_items:
-        - ./openrc
-        - ./admin-ciaorc
-        - ./demo-ciaorc
-        - ./clouds.yaml
-        - ./certificates
-        - ./images/.cnci_ready
-        - ./fetch
+        - ../openrc
+        - ../admin-ciaorc
+        - ../demo-ciaorc
+        - ../clouds.yaml
+        - ../certificates
+        - ../images/.cnci_ready
+        - ../fetch
         - /tmp/go
 
 - hosts: controllers

--- a/_DeploymentAndDistroPackaging/ansible/cleanup/ciao.yml
+++ b/_DeploymentAndDistroPackaging/ansible/cleanup/ciao.yml
@@ -55,6 +55,35 @@
 - hosts: controllers
   become: yes
   tasks:
+    - block:
+        - name: List rbds
+          command: rbd ls
+          register: rbds
+          changed_when: false
+
+        - name: List snapshots
+          command: rbd snap ls {{ item }}
+          with_items: "{{ rbds.stdout_lines }}"
+          register: rbds_snaps
+          changed_when: false
+
+        - name: Unprotect snapshots
+          command: rbd snap unprotect {{ item.cmd[3] }}@ciao-image
+          with_items: "{{ rbds_snaps.results }}"
+          when: "{{ 'ciao-image' in item.stdout }}"
+          register: unprotect
+          changed_when: "unprotect.rc == 0"
+
+        - name: Remove snapshots
+          command: rbd snap purge {{ item.cmd[3] }}
+          with_items: "{{ rbds_snaps.results }}"
+          when: "{{ 'ciao-image' in item.stdout }}"
+
+        - name: Remove rbds
+          command: rbd rm {{ item }}
+          with_items: "{{ rbds.stdout_lines }}"
+      ignore_errors: yes
+
     - name: Stop docker containers
       docker_container: name={{ item }} state=absent
       ignore_errors: yes

--- a/_DeploymentAndDistroPackaging/ansible/cleanup/ciao.yml
+++ b/_DeploymentAndDistroPackaging/ansible/cleanup/ciao.yml
@@ -28,6 +28,30 @@
         - ../fetch
         - /tmp/go
 
+- hosts: computes:networks
+  become: yes
+  tasks:
+    - name: Stop services
+      systemd: name={{ item }} enabled=no state=stopped
+      with_items:
+        - ciao-network.service
+        - ciao-compute.service
+        - ciao-launcher.service
+        - docker.service
+        - docker-cor.service
+      ignore_errors: yes
+
+    - name: Run ciao-launcher -hard-reset
+      command: /usr/local/bin/ciao-launcher -hard-reset
+      ignore_errors: yes
+
+    - name: Remove CIAO Service files
+      file: name={{ item }} state=absent
+      with_items:
+        - /etc/systemd/system/ciao-network.service
+        - /etc/systemd/system/ciao-compute.service
+        - /etc/systemd/system/ciao-launcher.service
+
 - hosts: controllers
   become: yes
   tasks:
@@ -45,6 +69,8 @@
         - docker-ciao-webui.service
         - ciao-controller.service
         - ciao-scheduler.service
+        - docker.service
+        - docker-cor.service
       ignore_errors: yes
 
     - name: Remove Files
@@ -61,23 +87,6 @@
 - hosts: controllers:computes:networks
   become: yes
   tasks:
-    - name: Stop services
-      systemd: name={{ item }} enabled=no state=stopped
-      with_items:
-        - ciao-network.service
-        - ciao-compute.service
-        - ciao-launcher.service
-        - docker.service
-        - docker-cor.service
-      ignore_errors: yes
-
-    - name: Remove CIAO Service files
-      file: name={{ item }} state=absent
-      with_items:
-        - /etc/systemd/system/ciao-network.service
-        - /etc/systemd/system/ciao-compute.service
-        - /etc/systemd/system/ciao-launcher.service
-
     - name: Remove CIAO files
       file: path={{ item }} state=absent
       with_items:


### PR DESCRIPTION
This PR Improves the cleanup scripts by 

- Removing the certificates and `images/.cnci_ready` files to ensure new certs and a new cnci image is generated on the next run.
- Run `ciao-launcher -hard-reset` on compute and network nodes to stop qemu instances
- Remove rbd devices from ceph

Fixes https://github.com/01org/ciao/issues/1169
Fixes https://github.com/01org/ciao/issues/1171
Fixes https://github.com/01org/ciao/issues/1172
