### PR TITLE
ansible: Do not install OVMF.fd on ClearLinux

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-launcher/tasks/install.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-launcher/tasks/install.yml
@@ -39,3 +39,4 @@
 
   - name: Copy OVMF firmware
     copy: src=images/OVMF.fd dest=/usr/share/qemu/OVMF.fd
+    when: "'Clear linux' not in ansible_os_family"


### PR DESCRIPTION
OVMF.fd is already shipped in the kvm-host bundle in ClearLinux

Fixes #1167

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>