### PR TITLE
ansible: Fix logging on systemd units

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/templates/ciao-controller.service.j2
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/templates/ciao-controller.service.j2
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 ExecStart=/usr/local/bin/ciao-controller --cacert=/etc/pki/ciao/CAcert-{{ ciao_controller_fqdn }}.pem \
                                    --cert=/etc/pki/ciao/cert-Controller-localhost.pem \
-                                   --logtostderr -v 2
+                                   --v 3
 Restart=always
 
 [Install]

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/templates/ciao-scheduler.service.j2
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/templates/ciao-scheduler.service.j2
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 ExecStart=/usr/local/bin/ciao-scheduler --cacert=/etc/pki/ciao/CAcert-{{ ciao_controller_fqdn }}.pem \
                                   --cert=/etc/pki/ciao/cert-Scheduler-{{ ciao_controller_fqdn }}.pem \
-                                  --logtostderr -v 2
+                                  --v 3
 User=ciao
 Restart=always
 

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-launcher/templates/ciao-launcher.service.j2
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-launcher/templates/ciao-launcher.service.j2
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 ExecStart=/usr/local/bin/ciao-launcher --cacert=/etc/pki/ciao/CAcert-{{ ciao_controller_fqdn }}.pem \
                                  --cert=/etc/pki/ciao/{{ agent_key }} \
-                                 --logtostderr -v 2
+                                 --v 3
 Restart=always
 KillMode=process
 


### PR DESCRIPTION
Fix systemd units for ciao-launcher, ciao-scheduler and ciao-controller
to log to the default location instead of stderr.

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>