### PR TITLE
travis: Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
 go_import_path: github.com/01org/ciao
 
 before_install:
+  - sudo apt-get update -qq
   - sudo apt-get install dnsmasq-base
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
Travis's documentation:
https://docs.travis-ci.com/user/installing-dependencies/ says that you
should run apt-get update before trying to install packages. We weren't
doing this and although our builds worked something has changed in
Travis that makes this required.

This change follows their recommendation and calls apt-get update.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>