### PR TITLE
ciao-controller: Delete ephemeral volumes on start failure

### DIFF
--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -254,6 +254,9 @@ func (client *ssntpClient) startFailure(payload []byte) {
 		glog.Warningf("Error unmarshalling StartFailure: %v", err)
 		return
 	}
+	if failure.Reason.IsFatal() {
+		client.deleteEphemeralStorage(failure.InstanceUUID)
+	}
 	err = client.ctl.ds.StartFailure(failure.InstanceUUID, failure.Reason)
 	if err != nil {
 		glog.Warningf("Error adding StartFailure to datastore: %v", err)

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -957,21 +957,8 @@ func (ds *Datastore) StartFailure(instanceID string, reason payloads.StartFailur
 		return errors.Wrapf(err, "error getting instance (%v)", instanceID)
 	}
 
-	switch reason {
-	case payloads.FullCloud,
-		payloads.FullComputeNode,
-		payloads.NoComputeNodes,
-		payloads.NoNetworkNodes,
-		payloads.InvalidPayload,
-		payloads.InvalidData,
-		payloads.ImageFailure,
-		payloads.NetworkFailure:
-
+	if reason.IsFatal() {
 		ds.deleteInstance(instanceID)
-
-	case payloads.LaunchFailure,
-		payloads.AlreadyRunning,
-		payloads.InstanceExists:
 	}
 
 	msg := fmt.Sprintf("Start Failure %s: %s", instanceID, reason.String())

--- a/payloads/startfailure.go
+++ b/payloads/startfailure.go
@@ -16,6 +16,10 @@
 
 package payloads
 
+import (
+	"github.com/golang/glog"
+)
+
 // StartFailureReason denotes the underlying error that prevented
 // an SSNTP START command from launching a new instance on a CN
 // or a NN.  Most, but not all, of these errors are returned by
@@ -112,4 +116,28 @@ func (r StartFailureReason) String() string {
 	}
 
 	return ""
+}
+
+// IsFatal indicates that the failure should be treated as a fatal failure
+// indicating the instance did not start.
+func (r StartFailureReason) IsFatal() bool {
+	switch r {
+	case FullCloud,
+		FullComputeNode,
+		NoComputeNodes,
+		NoNetworkNodes,
+		InvalidPayload,
+		InvalidData,
+		ImageFailure,
+		NetworkFailure:
+		return true
+
+	case LaunchFailure,
+		AlreadyRunning,
+		InstanceExists:
+		return false
+	}
+
+	glog.Errorf("Unexpected StartFailureReason: %s", r)
+	return false
 }


### PR DESCRIPTION
If the instance start fails due to e.g. the cloud being full then the
ephemeral volume needs to be deleted. This change makes controller
delete the ephemeral volume if it receives a start failure messagef from
scheduler.

Tested by starting 60 instances on a small cluster and then observing
that without the patches the volumes for the rejected instances remain
after deleting all; with the patch no residual volumes remain.

Fixes: #1173

Signed-off-by: Rob Bradford robert.bradford@intel.com