### PR TITLE
ciao-down: cache large files

### DIFF
--- a/testutil/ciao-down/ciao_down.go
+++ b/testutil/ciao-down/ciao_down.go
@@ -43,6 +43,13 @@ const (
 	CLEARCONTAINERS = "clearcontainers"
 )
 
+// Constants for the Guest image used by ciao-down
+
+const (
+	guestDownloadURL       = "https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img"
+	guestImageFriendlyName = "Ubuntu 16.04"
+)
+
 func init() {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage of %s:\n\n", os.Args[0])
@@ -120,14 +127,6 @@ func startFlags() (memGB int, CPUs int, err error) {
 	}
 
 	return memGB, CPUs, nil
-}
-
-func downloadProgress(p progress) {
-	if p.totalMB >= 0 {
-		fmt.Printf("Downloaded %d MB of %d\n", p.downloadedMB, p.totalMB)
-	} else {
-		fmt.Printf("Downloaded %d MB\n", p.downloadedMB)
-	}
 }
 
 func saveInstanceConfig(ws *workspace) error {
@@ -210,7 +209,8 @@ func prepare(ctx context.Context, errCh chan error) {
 		return
 	}
 
-	qcowPath, err := downloadUbuntu(ctx, ws.ciaoDir, downloadProgress)
+	fmt.Printf("Downloading %s\n", guestImageFriendlyName)
+	qcowPath, err := downloadFile(ctx, guestDownloadURL, ws.ciaoDir, downloadProgress)
 	if err != nil {
 		return
 	}
@@ -232,7 +232,7 @@ func prepare(ctx context.Context, errCh chan error) {
 		return
 	}
 
-	err = manageInstallation(ctx, ws.instanceDir, ws)
+	err = manageInstallation(ctx, ws.ciaoDir, ws.instanceDir, ws)
 	if err != nil {
 		return
 	}

--- a/testutil/ciao-down/cloudinit.go
+++ b/testutil/ciao-down/cloudinit.go
@@ -94,7 +94,7 @@ runcmd:
  - echo "PATH=\"$PATH:/usr/local/go/bin:{{$.GoPath}}/bin:/usr/local/nodejs/bin\""  >> /etc/environment
 
  - curl -X PUT -d "Downloading Go" 10.0.2.2:{{.HTTPServerPort}}
- - {{template "ENV" .}}wget https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz -O /tmp/go1.8.linux-amd64.tar.gz
+ - {{download . "https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz" "/tmp/go1.8.linux-amd64.tar.gz"}}
  - {{template "CHECK" .}}
  - curl -X PUT -d "Unpacking Go" 10.0.2.2:{{.HTTPServerPort}}
  - tar -C /usr/local -xzf /tmp/go1.8.linux-amd64.tar.gz
@@ -193,11 +193,11 @@ runcmd:
  - mkdir -p /home/{{.User}}/local
 
  - curl -X PUT -d "Downloading Fedora-Cloud-Base-24-1.2.x86_64.qcow2" 10.0.2.2:{{.HTTPServerPort}}
- - {{template "ENV" .}}wget https://download.fedoraproject.org/pub/fedora/linux/releases/24/CloudImages/x86_64/images/Fedora-Cloud-Base-24-1.2.x86_64.qcow2 -O /home/{{.User}}/local/Fedora-Cloud-Base-24-1.2.x86_64.qcow2
+ - {{download . "https://download.fedoraproject.org/pub/fedora/linux/releases/24/CloudImages/x86_64/images/Fedora-Cloud-Base-24-1.2.x86_64.qcow2" (printf "/home/%%s/local/Fedora-Cloud-Base-24-1.2.x86_64.qcow2" .User)}}
  - {{template "CHECK" .}}
 
  - curl -X PUT -d "Downloading CNCI image" 10.0.2.2:{{.HTTPServerPort}}
- - {{template "ENV" .}}wget https://download.clearlinux.org/demos/ciao/clear-8260-ciao-networking.img.xz -O /home/{{.User}}/local/clear-8260-ciao-networking.img.xz
+ - {{download . "https://download.clearlinux.org/demos/ciao/clear-8260-ciao-networking.img.xz" (printf "/home/%%s/local/clear-8260-ciao-networking.img.xz" .User)}}
  - {{template "CHECK" .}}
 
  - curl -X PUT -d "Downloading latest clear cloud image" 10.0.2.2:{{.HTTPServerPort}}
@@ -323,7 +323,7 @@ runcmd:
  - echo "PATH=\"$PATH:/usr/local/go/bin:{{$.GoPath}}/bin:/usr/local/nodejs/bin\""  >> /etc/environment
 
  - curl -X PUT -d "Downloading Go" 10.0.2.2:{{.HTTPServerPort}}
- - {{template "ENV" .}}wget https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz -O /tmp/go1.7.4.linux-amd64.tar.gz
+ - {{download . "https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz" "/tmp/go1.7.4.linux-amd64.tar.gz"}}
  - {{template "CHECK" .}}
  - curl -X PUT -d "Unpacking Go" 10.0.2.2:{{.HTTPServerPort}}
  - tar -C /usr/local -xzf /tmp/go1.7.4.linux-amd64.tar.gz


### PR DESCRIPTION
This commit adds a new function that can be used when creating
ciao down cloud init files.  The function called download
instructs ciao-down to download and cache the downloaded files on
the host.  The next time a VM requests the same file ciao-down will
serve the file from its cache rather than downloading it
from the Internet.  This speeds up the creation of ciao VMs by 5.5
minutes and clear container VMs by about 20 seconds.

Fixes #957

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>