### PR TITLE
Fix bootable volume handling in Open Stack API

### DIFF
--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -1363,6 +1363,34 @@ func TestCreateVolume(t *testing.T) {
 	}
 }
 
+func TestCreateImageVolume(t *testing.T) {
+	tenant, err := addTestTenant()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	imageRef := "test-image-id"
+	req := block.RequestedVolume{
+		ImageRef: &imageRef,
+	}
+
+	vol, err := ctl.CreateVolume(tenant.ID, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// confirm that we can retrieve the volume from
+	// the datastore.
+	bd, err := ctl.ds.GetBlockDevice(vol.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bd.State != types.Available || bd.TenantID != tenant.ID || bd.Bootable == false {
+		t.Fatalf("incorrect volume information stored\n")
+	}
+}
+
 func TestDeleteVolume(t *testing.T) {
 	tenant, err := addTestTenant()
 	if err != nil {

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -53,6 +53,7 @@ func (c *controller) CreateVolume(tenant string, req block.RequestedVolume) (blo
 	if req.ImageRef != nil {
 		// create bootable volume
 		bd, err = c.CreateBlockDeviceFromSnapshot(*req.ImageRef, "ciao-image")
+		bd.Bootable = true
 	} else if req.SourceVolID != nil {
 		// copy existing volume
 		bd, err = c.CopyBlockDevice(*req.SourceVolID)
@@ -113,7 +114,7 @@ func (c *controller) CreateVolume(tenant string, req block.RequestedVolume) (blo
 		CreatedAt:   &data.CreateTime,
 		ID:          bd.ID,
 		Size:        data.Size,
-		Bootable:    strconv.FormatBool(req.ImageRef != nil),
+		Bootable:    strconv.FormatBool(data.Bootable),
 	}, nil
 }
 

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -357,6 +357,7 @@ func (c *controller) ListVolumesDetail(tenant string) ([]block.VolumeDetail, err
 		vol.Size = data.Size
 		vol.OSVolTenantAttr = data.TenantID
 		vol.CreatedAt = &data.CreateTime
+		vol.Bootable = strconv.FormatBool(data.Bootable)
 
 		if data.Name != "" {
 			vol.Name = &data.Name
@@ -404,6 +405,7 @@ func (c *controller) ShowVolumeDetails(tenant string, volume string) (block.Volu
 	vol.Size = data.Size
 	vol.OSVolTenantAttr = data.TenantID
 	vol.CreatedAt = &data.CreateTime
+	vol.Bootable = strconv.FormatBool(data.Bootable)
 
 	if data.Name != "" {
 		vol.Name = &data.Name


### PR DESCRIPTION
* Record that volumes created via the API from an ImageRef are marked bootable as per spec
* Report out volume bootable status via API
* Unit testing of the above

Fixes: #1191 