### PR TITLE
ansible: fix files modes

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/tasks/ceph.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/tasks/ceph.yml
@@ -14,10 +14,10 @@
 # limitations under the License.
 
   - name: Create /etc/ceph directory
-    file: path=/etc/ceph state=directory mode=600
+    file: path=/etc/ceph state=directory mode=0600
 
   - name: Copy ceph files
-    copy: src=ceph/{{ item }} dest=/etc/ceph/{{ item }} mode=400
+    copy: src=ceph/{{ item }} dest=/etc/ceph/{{ item }} mode=0400
     with_items:
       - ceph.conf
       - "ceph.client.{{ cephx_user }}.keyring"

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/install.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/install.yml
@@ -24,7 +24,7 @@
     when: "'Clear linux' in ansible_os_family"
 
   - name: Install CIAO binaries
-    copy: src={{ gopath }}/bin/{{ item }} dest=/usr/local/bin/{{ item }} mode=755
+    copy: src={{ gopath }}/bin/{{ item }} dest=/usr/local/bin/{{ item }} mode=0755
     with_items:
       - ciao-cli
       - ciao-controller

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/startservices.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/startservices.yml
@@ -27,7 +27,7 @@
     file: path=/etc/ciao state=directory owner=ciao group=ciao
 
   - name: Create configuration file
-    template: dest=/etc/ciao/configuration.yaml src=configuration.yaml.j2 owner=ciao group=ciao
+    template: dest=/etc/ciao/configuration.yaml src=configuration.yaml.j2 owner=ciao group=ciao mode=0600
 
   - meta: flush_handlers
 

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-launcher/tasks/install.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-launcher/tasks/install.yml
@@ -24,7 +24,7 @@
     when: "'Clear linux' in ansible_os_family"
 
   - name: Copy CIAO Binaries
-    copy: src={{ gopath }}/bin/{{ item }} dest=/usr/local/bin/{{ item }} mode=755
+    copy: src={{ gopath }}/bin/{{ item }} dest=/usr/local/bin/{{ item }} mode=0755
     with_items:
       - ciao-cli
       - ciao-launcher


### PR DESCRIPTION
This set of patches aim to fix the file modes used when setting file permissions, as Ansible documentation for both the `file`[[1](http://docs.ansible.com/ansible/file_module.html#options)] and `copy`[[2](http://docs.ansible.com/ansible/copy_module.html#options)] modules says:

> Leaving off the leading zero will likely have unexpected results

