### PR TITLE
Add instance tracking to quotas

### DIFF
--- a/_release/bat/quotas_bat/quotas_bat_test.go
+++ b/_release/bat/quotas_bat/quotas_bat_test.go
@@ -19,6 +19,7 @@ package quotasbat
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -94,5 +95,173 @@ func TestQuotas(t *testing.T) {
 	err = restoreQuotas(ctx, tenantID, origQuotas, updatedQuotas)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func getUsage(qds []bat.QuotaDetails, name string) int {
+	qd := findQuota(qds, name)
+	if qd == nil {
+		return -1
+	}
+
+	value, err := strconv.Atoi(qd.Usage)
+	if err != nil {
+		return -1
+	}
+
+	return value
+}
+
+func checkUsage(qds []bat.QuotaDetails, wl bat.Workload, count int) bool {
+	expectedMem := wl.Mem * count
+	expectedCPU := wl.CPUs * count
+	expectedInstances := count
+
+	actualMem := getUsage(qds, "tenant-mem-quota")
+	actualCPU := getUsage(qds, "tenant-vcpu-quota")
+	actualInstances := getUsage(qds, "tenant-instances-quota")
+	return actualMem == expectedMem &&
+		actualCPU == expectedCPU &&
+		actualInstances == expectedInstances
+}
+
+// Test reporting of instance usage
+//
+// Starts 3 copies of a workload and checks that the usage matches
+// 3 * workload defaults
+//
+// Gets a workload, launches 3 instances from that workloads, gets the
+// quota and usage information and then checks that the usage is as
+// expected. Deletes the instances and checks the usage reflects that.
+func TestInstanceUsage(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+	tenants, err := bat.GetUserTenants(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(tenants) < 1 {
+		t.Fatal("Expected user to have access to at least one tenant")
+	}
+	tenantID := tenants[0].ID
+
+	wls, err := bat.GetAllWorkloads(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wls) < 1 {
+		t.Fatal("Expected at least one workload")
+	}
+
+	wl := wls[0]
+
+	instances, err := bat.LaunchInstances(ctx, "", wl.ID, 3)
+	if err != nil {
+		t.Error(err)
+	}
+
+	scheduled, err := bat.WaitForInstancesLaunch(ctx, "", instances, false)
+	if err != nil {
+		t.Errorf("Instances failed to launch: %v", err)
+	}
+
+	updatedQuotas, err := bat.ListQuotas(ctx, tenantID, "")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !checkUsage(updatedQuotas, wl, 3) {
+		t.Error("Usage not recorded correctly")
+	}
+
+	for _, i := range scheduled {
+		err = bat.DeleteInstanceAndWait(ctx, "", i)
+		if err != nil {
+			t.Errorf("Failed to delete instances: %v", err)
+		}
+	}
+	updatedQuotas, err = bat.ListQuotas(ctx, tenantID, "")
+	if err != nil {
+		t.Error(err)
+	}
+	if !checkUsage(updatedQuotas, wl, 0) {
+		t.Error("Usage not recorded correctly")
+	}
+}
+
+// Workaround for https://github.com/01org/ciao/issues/1203
+func launchMultipleInstances(ctx context.Context, t *testing.T, count int) error {
+	wls, err := bat.GetAllWorkloads(ctx, "")
+	if err != nil {
+		return err
+	}
+	if len(wls) < 1 {
+		t.Fatal("Expected at least one workload")
+	}
+
+	wl := wls[0]
+	for i := 0; i < count; i++ {
+		instances, err := bat.LaunchInstances(ctx, "", wl.ID, 1)
+		if err != nil {
+			return err
+		}
+
+		scheduled, err := bat.WaitForInstancesLaunch(ctx, "", instances, false)
+		defer func() {
+			_, err := bat.DeleteInstances(ctx, "", scheduled)
+			if err != nil {
+				t.Errorf("Failed to delete instances: %v", err)
+			}
+		}()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Try launching instances with a quota.
+//
+// Sets a quota on the number of instances that can be launched and exceeds
+// that.
+//
+// Set a quota of two instances, "tenant-instances-quota", and then try and
+// start a set of three instances and check that the launch fails.
+func TestInstanceLimited(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), standardTimeout)
+	defer cancelFunc()
+	tenants, err := bat.GetUserTenants(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(tenants) < 1 {
+		t.Fatal("Expected user to have access to at least one tenant")
+	}
+	tenantID := tenants[0].ID
+	origQuotas, err := bat.ListQuotas(ctx, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = bat.UpdateQuota(ctx, "", tenantID, "tenant-instances-quota", "2")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = launchMultipleInstances(ctx, t, 3)
+	if err == nil {
+		t.Errorf("Expected launch of instances to fail")
+	}
+
+	updatedQuotas, err := bat.ListQuotas(ctx, tenantID, "")
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = restoreQuotas(ctx, tenantID, origQuotas, updatedQuotas)
+	if err != nil {
+		t.Error(err)
 	}
 }

--- a/ciao-controller/quotas.go
+++ b/ciao-controller/quotas.go
@@ -50,7 +50,6 @@ func populateQuotasFromDatastore(qs *quotas.Quotas, ds *datastore.Datastore) err
 		qs.Update(t.ID, qds)
 
 		// Populate volume usage
-		// TODO: populate instance usage
 		// TODO: populate image usage
 		// TODO: populate external IP usage
 		bds, err := ds.GetBlockDevices(t.ID)
@@ -62,11 +61,25 @@ func populateQuotasFromDatastore(qs *quotas.Quotas, ds *datastore.Datastore) err
 			size += bd.Size
 			count++
 		}
-
 		// With initial population we disregard the result of consumption
 		<-qs.Consume(t.ID,
 			payloads.RequestedResource{Type: payloads.Volume, Value: count},
 			payloads.RequestedResource{Type: payloads.SharedDiskGiB, Value: size})
+
+		instances, err := ds.GetAllInstancesFromTenant(t.ID)
+		if err != nil {
+			return errors.Wrapf(err, "error getting tenant instances")
+		}
+
+		for _, instance := range instances {
+			wl, err := ds.GetWorkload(t.ID, instance.WorkloadID)
+			if err != nil {
+				return errors.Wrapf(err, "error getting workload")
+			}
+			resources := []payloads.RequestedResource{{Type: payloads.Instance, Value: 1}}
+			resources = append(resources, wl.Defaults...)
+			<-qs.Consume(t.ID, resources...)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR adds quota tracking for instances. When instances are created the resources specified in the workload are consumed. When the instance is deleted (or fails to start) then the resources are released.

On controller startup any existing instances also have their resources consumed.