### PR TITLE
ansible: Run ciao-controller as ciao user

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/cleanup/ciao.yml
+++ b/_DeploymentAndDistroPackaging/ansible/cleanup/ciao.yml
@@ -141,6 +141,10 @@
         - /etc/pki/ciao
         - /etc/pki/keystone
         - /var/lib/ciao
+        - /tmp/lock/ciao
+        - /tmp/ciao-controller-stats.db
+        - /tmp/ciao-controller-stats.db-shm
+        - /tmp/ciao-controller-stats.db-wal
         # ClearLinux cers
         - /etc/ssl/certs/keystone_cert.pem
         # Ubuntu certs

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/tasks/ceph.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/tasks/ceph.yml
@@ -14,10 +14,10 @@
 # limitations under the License.
 
   - name: Create /etc/ceph directory
-    file: path=/etc/ceph state=directory mode=0600
+    file: path=/etc/ceph state=directory owner=ciao mode=0700
 
   - name: Copy ceph files
-    copy: src=ceph/{{ item }} dest=/etc/ceph/{{ item }} mode=0400
+    copy: src=ceph/{{ item }} dest=/etc/ceph/{{ item }} owner=ciao mode=0400
     with_items:
       - ceph.conf
       - "ceph.client.{{ cephx_user }}.keyring"

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/templates/ciao-controller.service.j2
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/templates/ciao-controller.service.j2
@@ -7,6 +7,7 @@ Type=simple
 ExecStart=/usr/local/bin/ciao-controller --cacert=/etc/pki/ciao/CAcert-{{ ciao_controller_fqdn }}.pem \
                                    --cert=/etc/pki/ciao/cert-Controller-localhost.pem \
                                    --v 3
+User=ciao
 Restart=always
 
 [Install]


### PR DESCRIPTION
ciao-controller was run as root to allow it to run ceph commands.

By changing the ownership of /etc/ceph and its content to be owned by
ciao, ciao-controller can be run without root privileges.

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>