### PR TITLE
Add ability for http services to check for user privilege

### DIFF
--- a/ciao-cli/instance.go
+++ b/ciao-cli/instance.go
@@ -732,13 +732,8 @@ func (cmd *instanceListCommand) run(args []string) error {
 	}
 
 	var servers compute.Servers
-	var url string
 
-	if cmd.workload != "" {
-		url = buildComputeURL("flavors/%s/servers/detail", cmd.workload)
-	} else {
-		url = buildComputeURL("%s/servers/detail", cmd.tenant)
-	}
+	url := buildComputeURL("%s/servers/detail", cmd.tenant)
 
 	var values []queryValue
 	if cmd.limit > 0 {
@@ -759,6 +754,13 @@ func (cmd *instanceListCommand) run(args []string) error {
 		values = append(values, queryValue{
 			name:  "marker",
 			value: cmd.marker,
+		})
+	}
+
+	if cmd.workload != "" {
+		values = append(values, queryValue{
+			name:  "flavor",
+			value: cmd.workload,
 		})
 	}
 

--- a/ciao-controller/api/api.go
+++ b/ciao-controller/api/api.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	"github.com/01org/ciao/ciao-controller/types"
+	"github.com/01org/ciao/service"
 	"github.com/01org/ciao/ssntp/uuid"
 	"github.com/golang/glog"
 	"github.com/gorilla/mux"
@@ -97,10 +98,20 @@ func errorResponse(err error) Response {
 // and pass some package level context into the handler.
 type Handler struct {
 	*Context
-	Handler func(*Context, http.ResponseWriter, *http.Request) (Response, error)
+	Handler    func(*Context, http.ResponseWriter, *http.Request) (Response, error)
+	Privileged bool
 }
 
 func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// check whether we should send permission denied for this route.
+	if h.Privileged {
+		privileged := service.GetPrivilege(r.Context())
+		if !privileged {
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+	}
+
 	// set the content type to whatever was requested.
 	contentType := r.Header.Get("Content-Type")
 
@@ -597,104 +608,104 @@ func Routes(config Config) *mux.Router {
 	r := mux.NewRouter()
 
 	// external IP pools
-	route := r.Handle("/", Handler{context, listResources})
+	route := r.Handle("/", Handler{context, listResources, true})
 	route.Methods("GET")
 
-	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}", Handler{context, listResources})
+	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}", Handler{context, listResources, false})
 	route.Methods("GET")
 
 	matchContent := fmt.Sprintf("application/(%s|json)", PoolsV1)
 
-	route = r.Handle("/pools", Handler{context, listPools})
+	route = r.Handle("/pools", Handler{context, listPools, true})
 	route.Methods("GET")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}", Handler{context, listPools})
+	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}", Handler{context, listPools, false})
 	route.Methods("GET")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/pools", Handler{context, addPool})
+	route = r.Handle("/pools", Handler{context, addPool, true})
 	route.Methods("POST")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/pools/{pool:"+uuid.UUIDRegex+"}", Handler{context, showPool})
+	route = r.Handle("/pools/{pool:"+uuid.UUIDRegex+"}", Handler{context, showPool, true})
 	route.Methods("GET")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/pools/{pool:"+uuid.UUIDRegex+"}", Handler{context, deletePool})
+	route = r.Handle("/pools/{pool:"+uuid.UUIDRegex+"}", Handler{context, deletePool, true})
 	route.Methods("DELETE")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/pools/{pool:"+uuid.UUIDRegex+"}", Handler{context, addToPool})
+	route = r.Handle("/pools/{pool:"+uuid.UUIDRegex+"}", Handler{context, addToPool, true})
 	route.Methods("POST")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/pools/{pool:"+uuid.UUIDRegex+"}/subnets/{subnet:"+uuid.UUIDRegex+"}", Handler{context, deleteSubnet})
+	route = r.Handle("/pools/{pool:"+uuid.UUIDRegex+"}/subnets/{subnet:"+uuid.UUIDRegex+"}", Handler{context, deleteSubnet, true})
 	route.Methods("DELETE")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/pools/{pool:"+uuid.UUIDRegex+"}/external-ips/{ip_id:"+uuid.UUIDRegex+"}", Handler{context, deleteExternalIP})
+	route = r.Handle("/pools/{pool:"+uuid.UUIDRegex+"}/external-ips/{ip_id:"+uuid.UUIDRegex+"}", Handler{context, deleteExternalIP, true})
 	route.Methods("DELETE")
 	route.HeadersRegexp("Content-Type", matchContent)
 
 	// mapped external IPs
 	matchContent = fmt.Sprintf("application/(%s|json)", ExternalIPsV1)
 
-	route = r.Handle("/external-ips", Handler{context, listMappedIPs})
+	route = r.Handle("/external-ips", Handler{context, listMappedIPs, true})
 	route.Methods("GET")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}/external-ips", Handler{context, listMappedIPs})
+	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}/external-ips", Handler{context, listMappedIPs, false})
 	route.Methods("GET")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/external-ips", Handler{context, mapExternalIP})
+	route = r.Handle("/external-ips", Handler{context, mapExternalIP, true})
 	route.Methods("POST")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}/external-ips", Handler{context, mapExternalIP})
+	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}/external-ips", Handler{context, mapExternalIP, false})
 	route.Methods("POST")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/external-ips/{mapping_id:"+uuid.UUIDRegex+"}", Handler{context, unmapExternalIP})
+	route = r.Handle("/external-ips/{mapping_id:"+uuid.UUIDRegex+"}", Handler{context, unmapExternalIP, true})
 	route.Methods("DELETE")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}/external-ips/{mapping_id:"+uuid.UUIDRegex+"}", Handler{context, unmapExternalIP})
+	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}/external-ips/{mapping_id:"+uuid.UUIDRegex+"}", Handler{context, unmapExternalIP, false})
 	route.Methods("DELETE")
 	route.HeadersRegexp("Content-Type", matchContent)
 
 	// workloads
 	matchContent = fmt.Sprintf("application/(%s|json)", WorkloadsV1)
 
-	route = r.Handle("/workloads", Handler{context, addWorkload})
+	route = r.Handle("/workloads", Handler{context, addWorkload, true})
 	route.Methods("POST")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/workloads/{workload_id:"+uuid.UUIDRegex+"}", Handler{context, deleteWorkload})
+	route = r.Handle("/workloads/{workload_id:"+uuid.UUIDRegex+"}", Handler{context, deleteWorkload, true})
 	route.Methods("DELETE")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}/workloads", Handler{context, addWorkload})
+	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}/workloads", Handler{context, addWorkload, false})
 	route.Methods("POST")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}/workloads/{workload_id:"+uuid.UUIDRegex+"}", Handler{context, deleteWorkload})
+	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}/workloads/{workload_id:"+uuid.UUIDRegex+"}", Handler{context, deleteWorkload, false})
 	route.Methods("DELETE")
 	route.HeadersRegexp("Content-Type", matchContent)
 
 	// tenant quotas
 	matchContent = fmt.Sprintf("application/(%s|json)", TenantsV1)
 
-	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}/tenants/quotas", Handler{context, listQuotas})
+	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}/tenants/quotas", Handler{context, listQuotas, false})
 	route.Methods("GET")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/tenants/{for_tenant:"+uuid.UUIDRegex+"}/quotas", Handler{context, listQuotas})
+	route = r.Handle("/tenants/{for_tenant:"+uuid.UUIDRegex+"}/quotas", Handler{context, listQuotas, true})
 	route.Methods("GET")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/tenants/{for_tenant:"+uuid.UUIDRegex+"}/quotas", Handler{context, updateQuotas})
+	route = r.Handle("/tenants/{for_tenant:"+uuid.UUIDRegex+"}/quotas", Handler{context, updateQuotas, true})
 	route.Methods("PUT")
 	route.HeadersRegexp("Content-Type", matchContent)
 

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -307,7 +307,7 @@ func TestResponse(t *testing.T) {
 		req.Header.Set("Content-Type", tt.media)
 
 		rr := httptest.NewRecorder()
-		handler := Handler{context, tt.handler}
+		handler := Handler{context, tt.handler, false}
 
 		handler.ServeHTTP(rr, req)
 

--- a/openstack/compute/api.go
+++ b/openstack/compute/api.go
@@ -574,10 +574,19 @@ func ListServersDetails(c *Context, w http.ResponseWriter, r *http.Request) (API
 	vars := mux.Vars(r)
 	tenant := vars["tenant"]
 
-	// flavor will never have a valid value. This is left over from
-	// when this function could be used by a different endpoint.
-	// the function needs to be rewritten with no pager.
-	flavor := vars["flavor"]
+	values := r.URL.Query()
+
+	var flavor string
+
+	// if this function is called via an admin context, we might
+	// have {flavor} on the URL. If it's called from a user context,
+	// we might have flavor as a query value.
+	flavor, ok := vars["flavor"]
+	if !ok {
+		if values["flavor"] != nil {
+			flavor = values["flavor"][0]
+		}
+	}
 
 	DumpRequest(r)
 

--- a/openstack/identity/identity.go
+++ b/openstack/identity/identity.go
@@ -15,8 +15,10 @@
 package identity
 
 import (
+	"context"
 	"net/http"
 
+	"github.com/01org/ciao/service"
 	"github.com/golang/glog"
 	"github.com/gorilla/mux"
 	"github.com/mitchellh/mapstructure"
@@ -204,33 +206,34 @@ func validateProjectRole(tokenResult getResult, project string, role string) boo
 // checkToken verifies that given the token, the request is performed as
 // a valid admin and that such token is consistent with the services
 // attempted to be used in the received request
-func (h Handler) checkToken(r *http.Request, tenant string, tokenGetResult getResult) bool {
+func (h Handler) checkToken(ctx context.Context, r *http.Request, tenant string, tokenGetResult getResult) (context.Context, bool) {
 
 	/* TODO Caching or PKI */
 	for _, a := range h.ValidAdmins {
 		if validateProjectRole(tokenGetResult, a.Project, a.Role) == true {
-			return true
+			ctx = service.SetPrivilege(ctx, true)
+			return ctx, true
 		}
 	}
 
 	for _, s := range h.ValidServices {
 		if validateService(tokenGetResult, tenant, s.ServiceType, s.ServiceName) == true {
-			return true
+			return ctx, true
 		} else if validateService(tokenGetResult, tenant, s.ServiceType, "") == true {
-			return true
+			return ctx, true
 		}
 
 	}
 
 	glog.V(2).Infof("Invalid token for [%s]", tenant)
-	return false
+	return ctx, false
 }
 
-func (h Handler) validateToken(r *http.Request) bool {
+func (h Handler) validateToken(ctx context.Context, r *http.Request) (context.Context, bool) {
 
 	token := r.Header["X-Auth-Token"]
 	if len(token) == 0 {
-		return false
+		return ctx, false
 	}
 
 	vars := mux.Vars(r)
@@ -244,23 +247,23 @@ func (h Handler) validateToken(r *http.Request) bool {
 	p, err := tokenResult.extractProject()
 	if err != nil {
 		glog.V(2).Infof("Unable to retrieve tenant from token [%s]", token)
-		return false
+		return ctx, false
 	}
 	tenantFromToken := p.ID
 
 	if tenantFromVars == "" {
 		glog.V(2).Infof("Token validation for [%s]", tenantFromToken)
-		return h.checkToken(r, tenantFromToken, tokenResult)
+		return h.checkToken(ctx, r, tenantFromToken, tokenResult)
 	}
 	// verify that tenant from token is consistent with the tenant
 	// obtained from the URI endpoint request
 	if tenantFromVars != tenantFromToken {
 		glog.Errorf("expected tenant %v, got %v\n", tenantFromToken, tenantFromVars)
-		return false
+		return ctx, false
 	}
 
 	glog.V(2).Infof("Token validation for [%s]", tenantFromVars)
-	return h.checkToken(r, tenantFromVars, tokenResult)
+	return h.checkToken(ctx, r, tenantFromVars, tokenResult)
 }
 
 // ValidService defines service name and type of the api service
@@ -289,10 +292,11 @@ type Handler struct {
 // It will check to make sure that the api caller is validated with
 // keystone before allowing the next handler in the chain to be called.
 func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if h.validateToken(r) == false {
+	ctx, valid := h.validateToken(r.Context(), r)
+	if valid == false {
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
 	}
 
-	h.Next.ServeHTTP(w, r)
+	h.Next.ServeHTTP(w, r.WithContext(ctx))
 }

--- a/service/service.go
+++ b/service/service.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package service
+
+import (
+	"context"
+)
+
+type key int
+
+// PrivKey is the index of the context map which indicates whether a
+// service API has been called by a privileged user or not.
+const PrivKey key = 0
+
+// GetPrivilege returns the value of PrivKey
+func GetPrivilege(ctx context.Context) bool {
+	privilege, ok := ctx.Value(PrivKey).(bool)
+	return privilege && ok
+}
+
+// SetPrivilege is used to set the value of PrivKey
+func SetPrivilege(ctx context.Context, privileged bool) context.Context {
+	return context.WithValue(ctx, PrivKey, privileged)
+}

--- a/testutil/singlevm/verify.sh
+++ b/testutil/singlevm/verify.sh
@@ -103,7 +103,12 @@ function restoreIPTables {
 }
 
 function clearAllEvents() {
-	#Clear out all prior events
+	#Clear out all prior events. Currently this is an admin only operation.
+	ciao_user=$CIAO_USERNAME
+	ciao_passwd=$CIAO_PASSWORD
+	export CIAO_USERNAME=$CIAO_ADMIN_USERNAME
+	export CIAO_PASSWORD=$CIAO_ADMIN_PASSWORD
+
 	"$ciao_gobin"/ciao-cli event delete
 
 	#Wait for the event count to drop to 0
@@ -121,6 +126,9 @@ function clearAllEvents() {
 		let retry=retry+1
 		sleep 1
 	done
+
+	export CIAO_USERNAME=$ciao_user
+	export CIAO_PASSWORD=$ciao_passwd
 
 	exitOnError $ciao_events "ciao events not deleted properly"
 }


### PR DESCRIPTION
Let the identity middleware communicate privilege to the service handlers via context. Modify the ciao API and the legacy ciao API to specify whether routes should be for privileged users only, and send http status Unauthorized if the user doesn't have sufficient privilege.

Fixes: #1158 