### PR TITLE
Add support for deleting workloads

### DIFF
--- a/_release/bat/workload_bat/workload_bat_test.go
+++ b/_release/bat/workload_bat/workload_bat_test.go
@@ -40,9 +40,6 @@ users:
 const vmWorkloadImageName = "Fedora Cloud Base 24-1.2"
 
 func testCreateWorkload(t *testing.T, public bool) {
-	// until we support delete workload, we will explicitly skip this test.
-	t.Skip()
-
 	// we'll use empty string for now
 	tenant := ""
 
@@ -114,6 +111,23 @@ func testCreateWorkload(t *testing.T, public bool) {
 
 	if w.Name != opt.Description || w.CPUs != opt.Defaults.VCPUs || w.Mem != opt.Defaults.MemMB {
 		t.Fatalf("Workload not defined correctly")
+	}
+
+	// delete the workload.
+	if public {
+		err = bat.DeletePublicWorkload(ctx, w.ID)
+	} else {
+		err = bat.DeleteWorkload(ctx, tenant, w.ID)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// now try to retrieve the workload from controller.
+	_, err = bat.GetWorkloadByID(ctx, "", ID)
+	if err == nil {
+		t.Fatalf("Workload not deleted correctly")
 	}
 }
 

--- a/bat/workload.go
+++ b/bat/workload.go
@@ -151,6 +151,17 @@ func createWorkload(ctx context.Context, tenant string, opt WorkloadOptions, con
 	return strings.TrimSpace(s[1]), nil
 }
 
+func deleteWorkload(ctx context.Context, tenant string, workload string, public bool) (err error) {
+	args := []string{"workload", "delete", "-workload", workload}
+	if public {
+		_, err = RunCIAOCLIAsAdmin(ctx, tenant, args)
+	} else {
+		_, err = RunCIAOCLI(ctx, tenant, args)
+	}
+
+	return err
+}
+
 // CreatePublicWorkload will call ciao-cli as admin to create a workload.
 // It will first output the cloud init yaml file to the current working
 // directory. Then it will output the workload definition to the current
@@ -159,6 +170,16 @@ func createWorkload(ctx context.Context, tenant string, opt WorkloadOptions, con
 // created when it is done.
 func CreatePublicWorkload(ctx context.Context, tenant string, opt WorkloadOptions, config string) (string, error) {
 	return createWorkload(ctx, "", opt, config, true)
+}
+
+// DeletePublicWorkload will call ciao-cli as admin to delete a workload.
+func DeletePublicWorkload(ctx context.Context, workload string) error {
+	return deleteWorkload(ctx, "", workload, true)
+}
+
+// DeleteWorkload will call ciao-cli as a tenant to delete a workload.
+func DeleteWorkload(ctx context.Context, tenant string, workload string) error {
+	return deleteWorkload(ctx, tenant, workload, false)
 }
 
 // CreateWorkload will call ciao-cli to create a workload definition.

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -150,6 +150,15 @@ var tests = []test{
 		`{"workload":{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_id":"73a86d7e-93c0-480e-9c41-ab42f69b7799","image_name":"","config":"this will totally work!","defaults":[],"storage":null},"link":{"rel":"self","href":"/workloads/ba58f471-0735-4773-9550-188e2d012941"}}`,
 	},
 	{
+		"DELETE",
+		"/workloads/validID",
+		deleteWorkload,
+		"",
+		"application/x.ciao.v1.workloads",
+		http.StatusNoContent,
+		"null",
+	},
+	{
 		"GET",
 		"/tenants/test-tenant-id/quotas/",
 		listQuotas,
@@ -266,6 +275,10 @@ func (ts testCiaoService) UnMapAddress(string) error {
 func (ts testCiaoService) CreateWorkload(req types.Workload) (types.Workload, error) {
 	req.ID = "ba58f471-0735-4773-9550-188e2d012941"
 	return req, nil
+}
+
+func (ts testCiaoService) DeleteWorkload(tenant string, workload string) error {
+	return nil
 }
 
 func (ts testCiaoService) ListQuotas(tenantID string) []types.QuotaDetails {

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/01org/ciao/ciao-controller/types"
 	"github.com/01org/ciao/payloads"
-	"github.com/01org/ciao/ssntp/uuid"
 )
 
 // MemoryDB is a memory backed persistentStore implementation for unit testing
@@ -41,54 +40,7 @@ type MemoryDB struct {
 
 func (db *MemoryDB) fillWorkloads() error {
 	// add dummy public tenant.
-	_ = db.addTenant("public", "")
-
-	// add a public workload for test cases
-	testConfig := `
----
-#cloud-config
-users:
-  - name: demouser
-    gecos: CIAO Demo User
-    lock-passwd: false
-    passwd: $6$rounds=4096$w9I3hR4g/hu$AnYjaC2DfznbPSG3vxsgtgAS4mJwWBkcR74Y/KHNB5OsfAlA4gpU5j6CHWMOkkt9j.9d7OYJXJ4icXHzKXTAO.
-    sudo: ALL=(ALL) NOPASSWD:ALL
-    ssh-authorized-keys:
-    - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDerQfD+qkb0V0XdQs8SBWqy4sQmqYFP96n/kI4Cq162w4UE8pTxy0ozAPldOvBJjljMvgaNKSAddknkhGcrNUvvJsUcZFm2qkafi32WyBdGFvIc45A+8O7vsxPXgHEsS9E3ylEALXAC3D0eX7pPtRiAbasLlY+VcACRqr3bPDSZTfpCmIkV2334uZD9iwOvTVeR+FjGDqsfju4DyzoAIqpPasE0+wk4Vbog7osP+qvn1gj5kQyusmr62+t0wx+bs2dF5QemksnFOswUrv9PGLhZgSMmDQrRYuvEfIAC7IdN/hfjTn0OokzljBiuWQ4WIIba/7xTYLVujJV65qH3heaSMxJJD7eH9QZs9RdbbdTXMFuJFsHV2OF6wZRp18tTNZZJMqiHZZSndC5WP1WrUo3Au/9a+ighSaOiVddHsPG07C/TOEnr3IrwU7c9yIHeeRFHmcQs9K0+n9XtrmrQxDQ9/mLkfje80Ko25VJ/QpAQPzCKh2KfQ4RD+/PxBUScx/lHIHOIhTSCh57ic629zWgk0coSQDi4MKSa5guDr3cuDvt4RihGviDM6V68ewsl0gh6Z9c0Hw7hU0vky4oxak5AiySiPz0FtsOnAzIL0UON+yMuKzrJgLjTKodwLQ0wlBXu43cD+P8VXwQYeqNSzfrhBnHqsrMf4lTLtc7kDDTcw== ciao@ciao
-...
-	`
-	cpus := payloads.RequestedResource{
-		Type:      payloads.VCPUs,
-		Value:     2,
-		Mandatory: false,
-	}
-
-	mem := payloads.RequestedResource{
-		Type:      payloads.MemMB,
-		Value:     512,
-		Mandatory: false,
-	}
-
-	storage := types.StorageResource{
-		ID:        "",
-		Ephemeral: true,
-		Size:      20,
-	}
-
-	wl := types.Workload{
-		ID:          uuid.Generate().String(),
-		TenantID:    "public",
-		Description: "testWorkload",
-		FWType:      string(payloads.EFI),
-		VMType:      payloads.QEMU,
-		ImageID:     uuid.Generate().String(),
-		ImageName:   "",
-		Config:      testConfig,
-		Defaults:    []payloads.RequestedResource{cpus, mem},
-		Storage:     []types.StorageResource{storage},
-	}
-
-	return db.updateWorkload(wl)
+	return db.addTenant("public", "")
 }
 
 func (db *MemoryDB) init(config Config) error {
@@ -292,13 +244,10 @@ func (db *MemoryDB) getMappedIPs() map[string]types.MappedIP {
 }
 
 func (db *MemoryDB) updateWorkload(wl types.Workload) error {
-	tenant, ok := db.tenants[wl.TenantID]
-	if !ok {
-		return fmt.Errorf("Tenant %s not found", wl.TenantID)
-	}
+	return nil
+}
 
-	// just add for now.
-	tenant.workloads = append(tenant.workloads, wl)
+func (db *MemoryDB) deleteWorkload(ID string) error {
 	return nil
 }
 

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -926,7 +926,7 @@ func TestSQLiteDBInstanceStats(t *testing.T) {
 	}
 }
 
-func TestSQLiteDBUpdateWorkload(t *testing.T) {
+func TestSQLiteDBUpdateDeleteWorkload(t *testing.T) {
 	db, err := getPersistentStore()
 	if err != nil {
 		t.Fatal(err)
@@ -1002,6 +1002,21 @@ users:
 		fmt.Fprintf(os.Stderr, "got %v\n", wl2)
 		fmt.Fprintf(os.Stderr, "expected %v\n", wl)
 		t.Fatal("Expected workload equality")
+	}
+
+	// now try to delete the workload
+	err = db.deleteWorkload(wl.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tenant, err = db.getTenant(tn.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(tenant.workloads) != 0 {
+		t.Fatal("Expected no workloads associated with tenant")
 	}
 
 	db.disconnect()

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -573,6 +573,9 @@ var (
 
 	// ErrWorkloadNotFound is returned when a workload ID cannot be found
 	ErrWorkloadNotFound = errors.New("Workload not found")
+
+	// ErrWorkloadInUse is returned by DeleteWorkload when an instance of a workload is still active.
+	ErrWorkloadInUse = errors.New("Workload definition still in use")
 )
 
 // Link provides a url and relationship for a resource.

--- a/ciao-controller/workload.go
+++ b/ciao-controller/workload.go
@@ -202,3 +202,7 @@ func (c *controller) CreateWorkload(req types.Workload) (types.Workload, error) 
 	err = c.ds.AddWorkload(req)
 	return req, err
 }
+
+func (c *controller) DeleteWorkload(tenantID string, workloadID string) error {
+	return c.ds.DeleteWorkload(tenantID, workloadID)
+}


### PR DESCRIPTION
Create the API and ciao-cli support for deleting unused public or private workloads. Modify BAT tests to delete the test workload.

Fixes: #949, #950, #951, #952, #1135 