### PR TITLE
Improve partial instance launching

### DIFF
--- a/ciao-cli/instance.go
+++ b/ciao-cli/instance.go
@@ -519,9 +519,14 @@ func (cmd *instanceAddCommand) run(args []string) error {
 		fatalf(err.Error())
 	}
 
+	if len(servers.Servers) < cmd.instances {
+		fmt.Println("Some instances failed to start - check the event log for details.")
+	}
+
 	for _, server := range servers.Servers {
 		fmt.Printf("Created new (pending) instance: %s\n", server.ID)
 	}
+
 	return nil
 }
 

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -1433,6 +1433,11 @@ func (ds *Datastore) LogEvent(tenant string, msg string) {
 	ds.db.logEvent(tenant, string(userInfo), msg)
 }
 
+// LogError will add a message to the persistent event log as an error
+func (ds *Datastore) LogError(tenant string, msg string) {
+	ds.db.logEvent(tenant, string(userError), msg)
+}
+
 // AddBlockDevice will store information about new BlockData into
 // the datastore.
 func (ds *Datastore) AddBlockDevice(device types.BlockData) error {

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -381,19 +381,25 @@ func (c *controller) CreateServer(tenant string, server compute.CreateServerRequ
 		TraceLabel: label,
 		Volumes:    volumes,
 	}
+	var e error
 	instances, err := c.startWorkload(w)
 	if err != nil {
-		return server, err
+		e = err
 	}
 
 	var servers compute.Servers
 
 	for _, instance := range instances {
 		server, err := instanceToServer(c, instance)
-		if err != nil {
-			return server, err
+		if err != nil && e == nil {
+			e = err
 		}
 		servers.Servers = append(servers.Servers, server)
+	}
+
+	// If no instances launcher or if none converted bail early
+	if e != nil && len(servers.Servers) == 0 {
+		return server, e
 	}
 
 	servers.TotalServers = len(instances)
@@ -416,6 +422,9 @@ func (c *controller) CreateServer(tenant string, server compute.CreateServerRequ
 		},
 	}
 
+	if e != nil {
+		c.ds.LogError(tenant, fmt.Sprintf("Error launching instance(s): %v", e))
+	}
 	return builtServers, nil
 }
 


### PR DESCRIPTION
If launching some instances out of the request fail then we can end up in situating with unexpected "dangling" instances where an error is returned but also some instances started.

With this change if some instances did get launched correctly then report then out and asynchronously send an event. If only one instance was started if or no instances got launched correctly then return the error directly

With a quota volume limit:

```
rob@singlevm:~/go/src/github.com/01org/ciao/testutil/singlevm$ ciao-cli instance add -workload ed39a2c3-19f2-48ee-a650-483426d44760 --instances 8
Some instances failed to start - check the event log for details.
Created new (pending) instance: 08b78ca4-4fd1-445e-bce6-dd91ff5d9408
Created new (pending) instance: 804abebd-c112-45c7-9c74-3d27ed137922
Created new (pending) instance: 9ee79eb6-927b-46af-9620-5a6febc6c4df
Created new (pending) instance: 31e91e94-acd0-4913-99c1-012c2b2d8fda
rob@singlevm:~/go/src/github.com/01org/ciao/testutil/singlevm$ ciao-cli event list
1 Ciao event(s):
        [1] 2017-02-27 19:01:36 +0000 UTC: error:Error launching instance(s): Error creating instance: Error creating volume: Over quota (Tenant 56342297a18946a6b1863c6697449cf9)
```