### PR TITLE
Cleanup ephemeral volumes if instance fails early

### DIFF
--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -84,31 +84,7 @@ func (client *ssntpClient) CommandNotify(command ssntp.Command, frame *ssntp.Fra
 }
 
 func (client *ssntpClient) deleteEphemeralStorage(instanceID string) {
-	attachments := client.ctl.ds.GetStorageAttachments(instanceID)
-	for _, attachment := range attachments {
-		if !attachment.Ephemeral {
-			continue
-		}
-		err := client.ctl.ds.DeleteStorageAttachment(attachment.ID)
-		if err != nil {
-			glog.Warningf("Error deleting attachment from datastore: %v", err)
-		}
-		bd, err := client.ctl.ds.GetBlockDevice(attachment.BlockID)
-		if err != nil {
-			glog.Warningf("Unable to get block device: %v", err)
-		}
-		err = client.ctl.ds.DeleteBlockDevice(attachment.BlockID)
-		if err != nil {
-			glog.Warningf("Error deleting block device from datastore: %v", err)
-		}
-		err = client.ctl.DeleteBlockDevice(attachment.BlockID)
-		if err != nil {
-			glog.Warningf("Error deleting block device: %v", err)
-		}
-		client.ctl.qs.Release(bd.TenantID,
-			payloads.RequestedResource{Type: payloads.Volume, Value: 1},
-			payloads.RequestedResource{Type: payloads.SharedDiskGiB, Value: bd.Size})
-	}
+	client.ctl.deleteEphemeralStorage(instanceID)
 }
 
 func (client *ssntpClient) releaseResources(instanceID string) error {

--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -84,7 +84,10 @@ func (client *ssntpClient) CommandNotify(command ssntp.Command, frame *ssntp.Fra
 }
 
 func (client *ssntpClient) deleteEphemeralStorage(instanceID string) {
-	client.ctl.deleteEphemeralStorage(instanceID)
+	err := client.ctl.deleteEphemeralStorage(instanceID)
+	if err != nil {
+		glog.Warningf("Error deleting ephemeral storage for instance: %s: %v", instanceID, err)
+	}
 }
 
 func (client *ssntpClient) releaseResources(instanceID string) error {

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -268,7 +268,7 @@ func (c *controller) addTenant(id string) error {
 	return c.launchCNCI(id)
 }
 
-func (c *controller) deleteEphemeralStorage(instanceID string) {
+func (c *controller) deleteEphemeralStorage(instanceID string) error {
 	attachments := c.ds.GetStorageAttachments(instanceID)
 	for _, attachment := range attachments {
 		if !attachment.Ephemeral {
@@ -276,22 +276,23 @@ func (c *controller) deleteEphemeralStorage(instanceID string) {
 		}
 		err := c.ds.DeleteStorageAttachment(attachment.ID)
 		if err != nil {
-			glog.Warningf("Error deleting attachment from datastore: %v", err)
+			return errors.Wrap(err, "Error deleting storage attachment from datastore")
 		}
 		bd, err := c.ds.GetBlockDevice(attachment.BlockID)
 		if err != nil {
-			glog.Warningf("Unable to get block device: %v", err)
+			return errors.Wrap(err, "Error getting block device from datastore")
 		}
 		err = c.ds.DeleteBlockDevice(attachment.BlockID)
 		if err != nil {
-			glog.Warningf("Error deleting block device from datastore: %v", err)
+			return errors.Wrap(err, "Error deleting block device from datastore")
 		}
 		err = c.DeleteBlockDevice(attachment.BlockID)
 		if err != nil {
-			glog.Warningf("Error deleting block device: %v", err)
+			return errors.Wrap(err, "Error deleting block device")
 		}
 		c.qs.Release(bd.TenantID,
 			payloads.RequestedResource{Type: payloads.Volume, Value: 1},
 			payloads.RequestedResource{Type: payloads.SharedDiskGiB, Value: bd.Size})
 	}
+	return nil
 }

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -133,7 +133,7 @@ func (i *instance) Clean() error {
 	resources := []payloads.RequestedResource{{Type: payloads.Instance, Value: 1}}
 	resources = append(resources, wl.Defaults...)
 	i.ctl.qs.Release(i.TenantID, resources...)
-
+	i.ctl.deleteEphemeralStorage(i.ID)
 	return nil
 }
 


### PR DESCRIPTION
If an instance fails to get added early in the process (possibly due to a quota based rejection) then the ephemeral volumes for it need to be cleaned up.

Fixes: #1206