### PR TITLE
ansible: Install ceph container

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/ciao_controllers.yml
+++ b/_DeploymentAndDistroPackaging/ansible/ciao_controllers.yml
@@ -16,7 +16,9 @@
   - hosts: controllers
     become: yes
     roles:
+      - ciao-common
       - docker
+      - ceph
       - keystone
       - ciao-controller
       - ciao-webui

--- a/_DeploymentAndDistroPackaging/ansible/ciao_networks.yml
+++ b/_DeploymentAndDistroPackaging/ansible/ciao_networks.yml
@@ -16,4 +16,6 @@
   - hosts: networks
     become: yes
     roles:
+      - ciao-common
+      - ceph
       - ciao-launcher

--- a/_DeploymentAndDistroPackaging/ansible/cleanup/ciao.yml
+++ b/_DeploymentAndDistroPackaging/ansible/cleanup/ciao.yml
@@ -108,6 +108,7 @@
       with_items:
         - ciao-webui
         - ciao-keystone
+        - ceph-demo
 
     - name: Stop and disable services
       systemd: name={{ item }} state=stopped enabled=no

--- a/_DeploymentAndDistroPackaging/ansible/doc/development.md
+++ b/_DeploymentAndDistroPackaging/ansible/doc/development.md
@@ -1,4 +1,13 @@
-## Skip ceph configuration
-If you plan to manually setup ceph in your ciao nodes set `skip_ceph = True`
+## Ceph configuration
+Ciao requires a working ceph cluster already in place.
+
+If you already have configured all ciao nodes to be clients of the ceph cluster,
+you can tell ansible to skip the configuration of ceph by setting `ceph_config = none`
 in [group_vars/all](../group_vars/all) file or pass the command line argument
-`--extra-vars "skip_ceph=true"`
+`--extra-vars "ceph_config=none"`
+
+If you don't have a working ceph cluster, ansible can deploy a ceph container in the
+deployment node by setting `ceph_config = container` in [group_vars/all](../group_vars/all)
+file or pass the command line argument `--extra-vars "ceph_config=container"`
+
+Note that this container is for demo/development purposes and should NEVER be used in production.

--- a/_DeploymentAndDistroPackaging/ansible/group_vars/all
+++ b/_DeploymentAndDistroPackaging/ansible/group_vars/all
@@ -1,6 +1,10 @@
 ---
 controller_fqdn: "{{ hostvars[groups['controllers'][0]]['ansible_fqdn'] }}"
 
+# ceph: https://github.com/01org/ciao/tree/master/_DeploymentAndDistroPackaging/ansible/roles/ceph
+ceph_config: files
+ceph_config_dir: ./ceph
+
 # keystone: https://github.com/01org/ciao/tree/master/_DeploymentAndDistroPackaging/ansible/roles/keystone
 keystone_fqdn: "{{ controller_fqdn }}"
 keystone_admin_password: adminUserPassword

--- a/_DeploymentAndDistroPackaging/ansible/roles/ceph/README.md
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ceph/README.md
@@ -1,0 +1,32 @@
+# ceph
+* Optionally installs ceph/demo container on ciao controller node
+* Install and configure ceph client on ciao nodes
+
+## Requirements
+* Docker (When Installing ceph/demo container on ciao controller node)
+
+## Role Variables
+
+Variable  | Default Value | Description
+--------  | ------------- | -----------
+cephx_user | admin | cephx user to login into the ceph cluster
+ceph_config | files | Method to setup ceph. See defaults/main.yml for more info.
+ceph_config_dir | ./ceph | Location for ceph configuration and authentication files (Used with ceph_config=files)
+ceph_ip | default ip | IP Address of ceph container (Used with ceph_config=container)
+ceph_subnet | default subnet | Subnet of ceph network (Used with ceph_config=container)
+
+## Dependencies
+None
+
+## Example Playbook
+  - hosts: controllers
+    become: yes
+    roles:
+      - docker
+      - ceph
+
+## License
+Apache-2.0
+
+## Author Information
+This role was created by [Alberto Murillo](alberto.murillo.silva@intel.com)

--- a/_DeploymentAndDistroPackaging/ansible/roles/ceph/defaults/main.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ceph/defaults/main.yml
@@ -1,0 +1,39 @@
+---
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Select one of the following methods to configure ceph on the ciao cluster
+#   none:       Ceph is already configured in the ciao nodes
+#   container:  A ceph container will be started on the controller node and
+#               configured on the launcher nodes
+#               NOTE: Use this option only for demo purposes
+#   files:      Ceph configuration files stored in {{ ceph_config_dir }} will
+#               be copied to all ciao nodes
+#               NOTE: This option requires an already running ceph cluster
+ceph_config: files
+
+# Location for ceph configuration and authentication files
+# Use with ceph_config: files
+ceph_config_dir: ./ceph
+
+# cephx user
+cephx_user: admin
+
+# IP Address of ceph container
+# Use with ceph_config: container
+ceph_ip: "{{ ansible_default_ipv4['address'] }}"
+
+# Subnet of ceph network
+# Use with ceph_config: container
+ceph_subnet: "{{ (ansible_default_ipv4.network + '/' + ansible_default_ipv4.netmask) | ipaddr }}"

--- a/_DeploymentAndDistroPackaging/ansible/roles/ceph/tasks/container.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ceph/tasks/container.yml
@@ -1,0 +1,48 @@
+---
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+  - name: Start ceph/demo container
+    docker_container:
+      name: ceph-demo
+      image: ceph/demo
+      pull: true
+      network_mode: host
+      volumes:
+        - /etc/ceph:/etc/ceph:rw
+      env:
+        MON_IP: "{{ ceph_ip }}"
+        CEPH_PUBLIC_NETWORK: "{{ ceph_subnet }}"
+      # Ceph uses port 5000 for ceph-rest-api
+      # but we want to keep it available for keystone
+      ports:
+        - 5000:5001
+
+  - name: Change ownership of keyring to ciao
+    file: name="/etc/ceph/ceph.client.{{ cephx_user }}.keyring" owner=ciao mode=0400
+
+  - name: Create ceph_config_dir directory
+    connection: local
+    become: no
+    file: name={{ ceph_config_dir}} state=directory
+
+  - name: Retrieve ceph config files
+    fetch:
+      dest: "{{ ceph_config_dir }}/{{ item }}"
+      fail_on_missing: yes
+      flat: yes
+      src: /etc/ceph/{{ item }}
+    with_items:
+      - ceph.conf
+      - "ceph.client.{{ cephx_user }}.keyring"

--- a/_DeploymentAndDistroPackaging/ansible/roles/ceph/tasks/main.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ceph/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+# Copyright (c) 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+  - include_vars: "{{ ansible_os_family.split(' ') | first }}.yml"
+
+  - name: Create /etc/ceph directory
+    file: path=/etc/ceph state=directory
+
+  - name: Setup ceph/demo container
+    include: container.yml
+    static: yes
+    when:
+      - "ceph_config == 'container'"
+      - "'controllers' in group_names"
+
+  # Ansible 2.3 detects ClearLinux OS and chooses swupd for its package manager
+  # but for now we have to call it explicitly in a separate task.
+  - name: Install ceph (Ubuntu or Fedora)
+    package: name={{ ceph_package }} state=present
+    when: "'Clear linux' not in ansible_os_family"
+
+  - name: Install ceph (ClearLinux)
+    swupd: name={{ ceph_package }} state=present
+    when: "'Clear linux' in ansible_os_family"
+
+  - name: Configure ceph client
+    copy: src={{ ceph_config_dir }}/{{ item }} dest=/etc/ceph/{{ item }} owner=ciao mode=0400
+    with_items:
+      - ceph.conf
+      - "ceph.client.{{ cephx_user }}.keyring"
+    when: (ceph_config == 'files') or
+          (ceph_config == 'container' and 'controllers' not in group_names)

--- a/_DeploymentAndDistroPackaging/ansible/roles/ceph/vars/Clear.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ceph/vars/Clear.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2016 Intel Corporation
+# Copyright (c) 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,11 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  - name: Create /etc/ceph directory
-    file: path=/etc/ceph state=directory owner=ciao mode=0700
-
-  - name: Copy ceph files
-    copy: src=ceph/{{ item }} dest=/etc/ceph/{{ item }} owner=ciao mode=0400
-    with_items:
-      - ceph.conf
-      - "ceph.client.{{ cephx_user }}.keyring"
+ceph_package:
+  - storage-cluster

--- a/_DeploymentAndDistroPackaging/ansible/roles/ceph/vars/Debian.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ceph/vars/Debian.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2016 Intel Corporation
+# Copyright (c) 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,10 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  - hosts: computes
-    become: yes
-    roles:
-      - ciao-common
-      - docker
-      - ceph
-      - ciao-launcher
+ceph_package:
+  - ceph-common

--- a/_DeploymentAndDistroPackaging/ansible/roles/ceph/vars/RedHat.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ceph/vars/RedHat.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 2016 Intel Corporation
+# Copyright (c) 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,10 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-  - hosts: computes
-    become: yes
-    roles:
-      - ciao-common
-      - docker
-      - ceph
-      - ciao-launcher
+ceph_package:
+  - ceph-common

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/README.md
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/README.md
@@ -9,8 +9,6 @@ The following variables are available for all ciao roles
 
 Variable  | Default Value | Description
 --------  | ------------- | -----------
-cephx_user | admin | cephx user to login into the ceph cluster
-skip_ceph | False | When set to true, ansible will not configure ceph on Ciao nodes
 gopath | /tmp/go | golang GOPATH
 ciao_controller_fqdn | `{{ ansible_fqdn }}` | FQDN for CIAO controller node
 

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/defaults/main.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/defaults/main.yml
@@ -18,9 +18,3 @@ gopath: /tmp/go
 
 # Fully Qualified Domain Name for CIAO controller node
 ciao_controller_fqdn: "{{ hostvars[groups['controllers'][0]]['ansible_fqdn'] }}"
-
-# Set to true to skip ceph configuration in ciao nodes
-skip_ceph: False
-
-# cephx user
-cephx_user: admin

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/tasks/main.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/tasks/main.yml
@@ -40,6 +40,3 @@
       - /etc/systemd/system
       - /usr/local
       - /usr/local/bin
-
-  - include: ceph.yml
-    when: not skip_ceph


### PR DESCRIPTION
Introduce ceph_config variable which behaves acordingly to the
following values.

- none: Ceph is already configured and ansible will not setup ceph
- container: Ansible will deploy ceph/demo container on the controller
             node and configure the rest of the nodes to use it.
- files: An existing ceph cluster exists and ansible will configure all
         nodes using the existing ceph configuratino and authentication
         files found in ceph_config_dir variable.

Fixes #1084

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>