### PR TITLE
ciao-image, bat: Fix zero listed images in BAT tests

### DIFF
--- a/bat/image.go
+++ b/bat/image.go
@@ -194,7 +194,12 @@ func GetImageCount(ctx context.Context, tenant string) (int, error) {
 		return 0, err
 	}
 
-	return strconv.Atoi(string(data))
+	imageCount := 0
+	if string(data) != "" {
+		imageCount, err = strconv.Atoi(string(data))
+	}
+
+	return imageCount, err
 }
 
 // UploadImage overrides the contents of an existing image with a new file.  It is


### PR DESCRIPTION
This commit fixes the failure of ciao-image BAT tests that runs on a Ciao
cluster that has 0 images.

It will fix the following parsing error:
```
--- FAIL: TestImageList (0.16s)
        image_bat_test.go:110: Unable to count number of images: strconv.ParseInt: parsing "": invalid syntax
```
Signed-off-by: Obed N Munoz <obed.n.munoz@intel.com>