### PR TITLE
database: Add tables listing functionality

### DIFF
--- a/database/boltdb.go
+++ b/database/boltdb.go
@@ -125,6 +125,26 @@ func (db *BoltDB) DbTablesInit(tables []string) (err error) {
 	return err
 }
 
+// DbTablesList retrieves list of existing buckets
+func (db *BoltDB) DbTablesList() ([]string, error) {
+
+	dbTables := []string{}
+	Logger.Infof("dbTablesList Tables")
+
+	err := db.DB.View(func(tx *bolt.Tx) error {
+		return tx.ForEach(func(name []byte, _ *bolt.Bucket) error {
+			dbTables = append(dbTables, string(name))
+			return nil
+		})
+	})
+
+	if err != nil {
+		Logger.Errorf("Tables listing error %v", err)
+	}
+
+	return dbTables, err
+}
+
 // DbAdd adds a new element to table in Bolt database
 func (db *BoltDB) DbAdd(table string, key string, value interface{}) (err error) {
 

--- a/database/dbprovider.go
+++ b/database/dbprovider.go
@@ -36,6 +36,8 @@ type DbProvider interface {
 	DbClose() error
 	// Creates the tables if the tables do not already exist in the database
 	DbTablesInit(tables []string) error
+	// Retrieves list of existing tables
+	DbTablesList() ([]string, error)
 	// Populates the in-memory table from the database
 	DbTableRebuild(table DbTable) error
 	// Adds the key/value pair to the table

--- a/database/dbprovider_test.go
+++ b/database/dbprovider_test.go
@@ -122,6 +122,20 @@ func testDbTableInit(t *testing.T, provider Provider) {
 	}
 }
 
+func testDbTablesList(t *testing.T, provider Provider) {
+	defer closeDb(&provider)
+
+	err := provider.Db.DbInit(provider.DbDir, provider.DbFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = provider.Db.DbTablesList()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func testDbAdd(t *testing.T, provider Provider) {
 	defer closeDb(&provider)
 
@@ -235,6 +249,12 @@ func TestBoltDbClose(t *testing.T) {
 func TestBoltDbTableInit(t *testing.T) {
 	provider := initProvider(NewBoltDBProvider())
 	testDbTableInit(t, provider)
+	_ = os.Remove(path.Join(dbDir, dbFile))
+}
+
+func TestBoltDbTablesList(t *testing.T) {
+	provider := initProvider(NewBoltDBProvider())
+	testDbTablesList(t, provider)
 	_ = os.Remove(path.Join(dbDir, dbFile))
 }
 


### PR DESCRIPTION
New features is added in order to list all tables that exists
in a database. For now, it will be useful for ciao-image service which
is storing each tenant's images in a single table (bucket).

It will help on automation when a full database scan or search
is required. Once you have the list of tables (buckets), you can
go and search for the specific element's ID.

Signed-off-by: Obed N Munoz <obed.n.munoz@intel.com>