### PR TITLE
identity: Add tenantID get and set for service calls

### DIFF
--- a/openstack/identity/identity.go
+++ b/openstack/identity/identity.go
@@ -253,6 +253,7 @@ func (h Handler) validateToken(ctx context.Context, r *http.Request) (context.Co
 
 	if tenantFromVars == "" {
 		glog.V(2).Infof("Token validation for [%s]", tenantFromToken)
+		ctx = service.SetTenantID(ctx, tenantFromToken)
 		return h.checkToken(ctx, r, tenantFromToken, tokenResult)
 	}
 	// verify that tenant from token is consistent with the tenant
@@ -262,6 +263,7 @@ func (h Handler) validateToken(ctx context.Context, r *http.Request) (context.Co
 		return ctx, false
 	}
 
+	ctx = service.SetTenantID(ctx, tenantFromVars)
 	glog.V(2).Infof("Token validation for [%s]", tenantFromVars)
 	return h.checkToken(ctx, r, tenantFromVars, tokenResult)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -16,6 +16,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 )
 
 type key int
@@ -23,6 +24,10 @@ type key int
 // PrivKey is the index of the context map which indicates whether a
 // service API has been called by a privileged user or not.
 const PrivKey key = 0
+
+// TenantIDKey is the index of the context map which indicates the
+// tenant id which is being used in the API call
+const TenantIDKey key = 1
 
 // GetPrivilege returns the value of PrivKey
 func GetPrivilege(ctx context.Context) bool {
@@ -33,4 +38,18 @@ func GetPrivilege(ctx context.Context) bool {
 // SetPrivilege is used to set the value of PrivKey
 func SetPrivilege(ctx context.Context, privileged bool) context.Context {
 	return context.WithValue(ctx, PrivKey, privileged)
+}
+
+// GetTenantID returns the value of TenantIDKey
+func GetTenantID(ctx context.Context) (string, error) {
+	tenantID, ok := ctx.Value(TenantIDKey).(string)
+	if ok {
+		return tenantID, nil
+	}
+	return tenantID, fmt.Errorf("There's no tenant on this Context")
+}
+
+// SetTenantID sets the value of Tenant ID
+func SetTenantID(ctx context.Context, tenantID string) context.Context {
+	return context.WithValue(ctx, TenantIDKey, tenantID)
 }


### PR DESCRIPTION
This commit adds tenant ID setting and getting from the identity
middleware, it will add tenant ID to the service call context in
order to be used on each service separately.

Signed-off-by: Obed N Munoz <obed.n.munoz@intel.com>