### PR TITLE
Migrate away from "legacy" quota checking code

### DIFF
--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -168,7 +168,7 @@ func (c *controller) confirmTenant(tenantID string) error {
 func (c *controller) startWorkload(w types.WorkloadRequest) ([]*types.Instance, error) {
 	var e error
 
-	if instances <= 0 {
+	if w.Instances <= 0 {
 		return nil, errors.New("Missing number of instances to start")
 	}
 

--- a/ciao-controller/compute_test.go
+++ b/ciao-controller/compute_test.go
@@ -716,24 +716,27 @@ func testListTenantQuotas(t *testing.T, httpExpectedStatus int, validToken bool)
 
 	var expected types.CiaoTenantResources
 
-	for _, resource := range tenant.Resources {
-		switch resource.Rtype {
-		case instances:
-			expected.InstanceLimit = resource.Limit
-			expected.InstanceUsage = resource.Usage
+	qds := ctl.qs.DumpQuotas(tenant.ID)
 
-		case vcpu:
-			expected.VCPULimit = resource.Limit
-			expected.VCPUUsage = resource.Usage
-
-		case memory:
-			expected.MemLimit = resource.Limit
-			expected.MemUsage = resource.Usage
-
-		case disk:
-			expected.DiskLimit = resource.Limit
-			expected.DiskUsage = resource.Usage
-		}
+	qd := findQuota(qds, "tenant-instances-quota")
+	if qd != nil {
+		expected.InstanceLimit = qd.Value
+		expected.InstanceUsage = qd.Usage
+	}
+	qd = findQuota(qds, "tenant-vcpu-quota")
+	if qd != nil {
+		expected.VCPULimit = qd.Value
+		expected.VCPUUsage = qd.Usage
+	}
+	qd = findQuota(qds, "tenant-mem-quota")
+	if qd != nil {
+		expected.MemLimit = qd.Value
+		expected.MemUsage = qd.Usage
+	}
+	qd = findQuota(qds, "tenant-storage-quota")
+	if qd != nil {
+		expected.DiskLimit = qd.Value
+		expected.DiskUsage = qd.Usage
 	}
 
 	expected.ID = tenant.ID

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -256,10 +256,10 @@ func TestTenantWithinBounds(t *testing.T) {
 	}
 
 	/* put tenant limit of 1 instance */
-	err = ctl.ds.AddLimit(tenant.ID, 1, 1)
-	if err != nil {
-		t.Fatal(err)
+	quotas := []types.QuotaDetails{
+		{Name: "tenant-instances-quota", Value: 1},
 	}
+	ctl.qs.Update(tenant.ID, quotas)
 
 	wls, err := ctl.ds.GetWorkloads(tenant.ID)
 	if err != nil || len(wls) == 0 {
@@ -275,6 +275,10 @@ func TestTenantWithinBounds(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	quotas = []types.QuotaDetails{
+		{Name: "tenant-instances-quota", Value: -1},
+	}
+	ctl.qs.Update(tenant.ID, quotas)
 }
 
 func TestTenantOutOfBounds(t *testing.T) {
@@ -287,10 +291,10 @@ func TestTenantOutOfBounds(t *testing.T) {
 	}
 
 	/* put tenant limit of 1 instance */
-	err = ctl.ds.AddLimit(tenant.ID, 1, 1)
-	if err != nil {
-		t.Fatal(err)
+	quotas := []types.QuotaDetails{
+		{Name: "tenant-instances-quota", Value: 1},
 	}
+	ctl.qs.Update(tenant.ID, quotas)
 
 	wls, err := ctl.ds.GetWorkloads(tenant.ID)
 	if err != nil || len(wls) == 0 {
@@ -307,6 +311,10 @@ func TestTenantOutOfBounds(t *testing.T) {
 	if err == nil {
 		t.Errorf("Not tracking limits correctly")
 	}
+	quotas = []types.QuotaDetails{
+		{Name: "tenant-instances-quota", Value: -1},
+	}
+	ctl.qs.Update(tenant.ID, quotas)
 }
 
 // TestNewTenantHardwareAddr

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -79,10 +79,6 @@ func (db *MemoryDB) getEventLog() ([]*types.LogEntry, error) {
 	return db.logEntries, nil
 }
 
-func (db *MemoryDB) addLimit(tenantID string, resourceID int, limit int) error {
-	return nil
-}
-
 func (db *MemoryDB) addTenant(id string, MAC string) error {
 	t := &tenant{
 		Tenant: types.Tenant{

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -116,7 +116,6 @@ type Instance struct {
 	SSHIP       string              `json:"ssh_ip"`
 	SSHPort     int                 `json:"ssh_port"`
 	CNCI        bool                `json:"-"`
-	Usage       map[string]int      `json:"-"`
 	Attachments []StorageAttachment `json:"-"`
 	CreateTime  time.Time           `json:"-"`
 }
@@ -137,28 +136,11 @@ func (s SortedComputeNodesByID) Less(i, j int) bool { return s[i].ID < s[j].ID }
 
 // Tenant contains information about a tenant or project.
 type Tenant struct {
-	ID        string
-	Name      string
-	CNCIID    string
-	CNCIMAC   string
-	CNCIIP    string
-	Resources []*Resource
-}
-
-// Resource contains quota or limit information on a resource type.
-type Resource struct {
-	Rname string
-	Rtype int
-	Limit int
-	Usage int
-}
-
-// OverLimit calculates whether a request will put a tenant over it's limit.
-func (r *Resource) OverLimit(request int) bool {
-	if r.Limit > 0 && r.Usage+request > r.Limit {
-		return true
-	}
-	return false
+	ID      string
+	Name    string
+	CNCIID  string
+	CNCIMAC string
+	CNCIIP  string
 }
 
 // LogEntry stores information about events.


### PR DESCRIPTION
Migrate users of the older limit and resources infrastructure to the new quota service and delete the old code.

Fixes: #1115 
Fixes: #1116 