### PR TITLE
ciao-cli: Fix template handling of ciao-cli image list

### DIFF
--- a/ciao-cli/image.go
+++ b/ciao-cli/image.go
@@ -206,26 +206,30 @@ func (cmd *imageListCommand) run(args []string) error {
 
 	pager := images.List(client, images.ListOpts{})
 
+	var allImages []images.Image
 	err = pager.EachPage(func(page pagination.Page) (bool, error) {
 		imageList, err := images.ExtractImages(page)
 		if err != nil {
 			errorf("Could not extract image [%s]\n", err)
 		}
+		allImages = append(allImages, imageList...)
 
-		if t != nil {
-			if err = t.Execute(os.Stdout, &imageList); err != nil {
-				fatalf(err.Error())
-			}
-			return false, nil
-		}
-
-		for k, i := range imageList {
-			fmt.Printf("Image #%d\n", k+1)
-			dumpImage(&i)
-			fmt.Printf("\n")
-		}
 		return false, nil
 	})
+
+	if t != nil {
+		if err = t.Execute(os.Stdout, &allImages); err != nil {
+			fatalf(err.Error())
+		}
+		return nil
+	}
+
+	for k, i := range allImages {
+		fmt.Printf("Image #%d\n", k+1)
+		dumpImage(&i)
+		fmt.Printf("\n")
+	}
+
 	return err
 }
 


### PR DESCRIPTION
ciao-cli image list was not handling templates correctly.  It was
calling the template function once for each page rather than once
for the entire list.  This breaks scripts such as {{len .}} which
attempt to compute the total number of images.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>