### PR TITLE
update ansible requirements for fedora

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/doc/requirements.md
+++ b/_DeploymentAndDistroPackaging/ansible/doc/requirements.md
@@ -2,12 +2,12 @@
 ## Ansible requirements
 Ansible requires the following packages to be present on fedora managed nodes:
 * python-dnf
-* netaddr
+* python-netaddr
 * libselinux-python
 
 You can install them with the following command
 ```
-sudo dnf install python-dnf netaddr libselinux-python
+sudo dnf install python-dnf python-netaddr libselinux-python
 ```
 
 # Proxies


### PR DESCRIPTION
update ansible requirements for fedora, netaddr needs to be changed to python-netaddr