### PR TITLE
ciao-controller: Fix workload's image ID reference in ciao-cli output

### DIFF
--- a/bat/compute.go
+++ b/bat/compute.go
@@ -56,11 +56,10 @@ type Tenant struct {
 
 // Workload contains detailed information about a workload
 type Workload struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	ImageUUID string `json:"disk"`
-	CPUs      int    `json:"vcpus"`
-	Mem       int    `json:"ram"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	CPUs int    `json:"vcpus"`
+	Mem  int    `json:"ram"`
 }
 
 // Instance contains detailed information about an instance

--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -97,8 +97,8 @@ func (cmd *workloadListCommand) run(args []string) error {
 
 	for i, flavor := range flavors.Flavors {
 		fmt.Printf("Workload %d\n", i+1)
-		fmt.Printf("\tName: %s\n\tUUID:%s\n\tImage UUID: %s\n\tCPUs: %d\n\tMemory: %d MB\n",
-			flavor.Name, flavor.ID, flavor.Disk, flavor.Vcpus, flavor.RAM)
+		fmt.Printf("\tName: %s\n\tUUID:%s\n\tCPUs: %d\n\tMemory: %d MB\n",
+			flavor.Name, flavor.ID, flavor.Vcpus, flavor.RAM)
 	}
 	return nil
 }

--- a/ciao-controller/compute_test.go
+++ b/ciao-controller/compute_test.go
@@ -618,7 +618,6 @@ func testShowFlavorDetails(t *testing.T, httpExpectedStatus int, validToken bool
 		details := compute.FlavorDetails{
 			OsFlavorAccessIsPublic: true,
 			ID:   w.ID,
-			Disk: w.ImageID,
 			Name: w.Description,
 		}
 

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -571,7 +571,6 @@ func buildFlavorDetails(workload types.Workload) (compute.FlavorDetails, error) 
 
 	details.OsFlavorAccessIsPublic = true
 	details.ID = workload.ID
-	details.Disk = workload.ImageID
 	details.Name = workload.Description
 
 	for r := range defaults {

--- a/openstack/compute/api.go
+++ b/openstack/compute/api.go
@@ -185,7 +185,7 @@ func NewComputeFlavors() (flavors Flavors) {
 // FlavorDetails contains information about a specific flavor.
 type FlavorDetails struct {
 	OSFLVDISABLEDDisabled  bool   `json:"OS-FLV-DISABLED:disabled"`
-	Disk                   string `json:"disk"` /* OpenStack API says this is an int */
+	Disk                   int    `json:"disk"`
 	OSFLVEXTDATAEphemeral  int    `json:"OS-FLV-EXT-DATA:ephemeral"`
 	OsFlavorAccessIsPublic bool   `json:"os-flavor-access:is_public"`
 	ID                     string `json:"id"`

--- a/openstack/compute/api_test.go
+++ b/openstack/compute/api_test.go
@@ -107,7 +107,7 @@ var tests = []test{
 		listFlavorsDetails,
 		"",
 		http.StatusOK,
-		`{"flavors":[{"OS-FLV-DISABLED:disabled":false,"disk":"imageUUID","OS-FLV-EXT-DATA:ephemeral":0,"os-flavor-access:is_public":true,"id":"workloadUUID","links":null,"name":"testflavor","ram":256,"swap":"","vcpus":2}]}`,
+		`{"flavors":[{"OS-FLV-DISABLED:disabled":false,"disk":1024,"OS-FLV-EXT-DATA:ephemeral":0,"os-flavor-access:is_public":true,"id":"workloadUUID","links":null,"name":"testflavor","ram":256,"swap":"","vcpus":2}]}`,
 	},
 	{
 		"GET",
@@ -115,7 +115,7 @@ var tests = []test{
 		showFlavorDetails,
 		"",
 		http.StatusOK,
-		`{"flavor":{"OS-FLV-DISABLED:disabled":false,"disk":"imageUUID","OS-FLV-EXT-DATA:ephemeral":0,"os-flavor-access:is_public":true,"id":"workloadUUID","links":null,"name":"testflavor","ram":256,"swap":"","vcpus":2}}`,
+		`{"flavor":{"OS-FLV-DISABLED:disabled":false,"disk":1024,"OS-FLV-EXT-DATA:ephemeral":0,"os-flavor-access:is_public":true,"id":"workloadUUID","links":null,"name":"testflavor","ram":256,"swap":"","vcpus":2}}`,
 	},
 }
 
@@ -217,7 +217,7 @@ func (cs testComputeService) ListFlavorsDetail(string) (FlavorsDetails, error) {
 
 	details.OsFlavorAccessIsPublic = true
 	details.ID = "workloadUUID"
-	details.Disk = "imageUUID"
+	details.Disk = 1024
 	details.Name = "testflavor"
 	details.Vcpus = 2
 	details.RAM = 256
@@ -233,7 +233,7 @@ func (cs testComputeService) ShowFlavorDetails(string, string) (Flavor, error) {
 
 	details.OsFlavorAccessIsPublic = true
 	details.ID = "workloadUUID"
-	details.Disk = "imageUUID"
+	details.Disk = 1024
 	details.Name = "testflavor"
 	details.Vcpus = 2
 	details.RAM = 256


### PR DESCRIPTION
This commit fixes OpenStack's compatibility for Disk variable, it's not the Image ID, it refers to the primary disk's size according to OpenStack [Flavor Details API method](https://developer.openstack.org/api-ref/compute/?expanded=list-flavors-with-details-detail#list-flavors-with-details).

A new CIAO specific API will be required in order to show image and storage details. This should be addressed in a separate PR.

Addresses part of #1232

Signed-off-by: Obed N Munoz <obed.n.munoz@intel.com>