### PR TITLE
ciao-controller: Track external IP map/unmap in quota system

### DIFF
--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -219,6 +219,8 @@ func (client *ssntpClient) unassignEvent(payload []byte) {
 		return
 	}
 
+	client.ctl.qs.Release(i.TenantID, payloads.RequestedResource{Type: payloads.ExternalIP, Value: 1})
+
 	msg := fmt.Sprintf("Unmapped %s from %s", event.UnassignedIP.PublicIP, event.UnassignedIP.PrivateIP)
 	client.ctl.ds.LogEvent(i.TenantID, msg)
 }

--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -364,6 +364,8 @@ func (client *ssntpClient) assignError(payload []byte) {
 		glog.Warningf("Error unmapping external IP: %v", err)
 	}
 
+	client.ctl.qs.Release(failure.TenantUUID, payloads.RequestedResource{Type: payloads.ExternalIP, Value: 1})
+
 	msg := fmt.Sprintf("Failed to map %s to %s: %s", failure.PublicIP, failure.InstanceUUID, failure.Reason.String())
 	client.ctl.ds.LogEvent(failure.TenantUUID, msg)
 }


### PR DESCRIPTION
When an external IP is mapped for a tenant consume the resource and
release when IP unmapped.

Fixes: #1234

Signed-off-by: Rob Bradford <robert.bradford@intel.com>