### PR TITLE
qemu: Add PCI option to the NetDevice

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"context"
@@ -61,6 +62,9 @@ const (
 
 	// VirtioNet is the virt-io networking device driver.
 	VirtioNet = "virtio-net"
+
+	// VirtioNetPCI is the virt-io pci networking device driver.
+	VirtioNetPCI = "virtio-net-pci"
 
 	// VirtioSerial is the serial device driver.
 	VirtioSerial = "virtio-serial-pci"
@@ -341,6 +345,12 @@ type NetDevice struct {
 	// IfName is the interface name,
 	IFName string
 
+	// Bus is the bus path name of a PCI device.
+	Bus string
+
+	// Addr is the address offset of a PCI device.
+	Addr string
+
 	// DownScript is the tap interface deconfiguration script.
 	DownScript string
 
@@ -383,6 +393,19 @@ func (netdev NetDevice) QemuParams(config *Config) []string {
 	deviceParams = append(deviceParams, fmt.Sprintf("%s", netdev.Driver))
 	deviceParams = append(deviceParams, fmt.Sprintf(",netdev=%s", netdev.ID))
 	deviceParams = append(deviceParams, fmt.Sprintf(",mac=%s", netdev.MACAddress))
+
+	if netdev.Driver == VirtioNetPCI {
+		if netdev.Bus != "" {
+			deviceParams = append(deviceParams, fmt.Sprintf(",bus=%s", netdev.Bus))
+		}
+
+		if netdev.Addr != "" {
+			addr, err := strconv.Atoi(netdev.Addr)
+			if err == nil && addr >= 0 {
+				deviceParams = append(deviceParams, fmt.Sprintf(",addr=%x", addr))
+			}
+		}
+	}
 
 	netdevParams = append(netdevParams, string(netdev.Type))
 	netdevParams = append(netdevParams, fmt.Sprintf(",id=%s", netdev.ID))

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -143,6 +143,32 @@ func TestAppendDeviceNetwork(t *testing.T) {
 	testAppend(netdev, deviceNetworkString, t)
 }
 
+var deviceNetworkPCIString = "-device virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,bus=/pci-bus/pcie.0,addr=ff -netdev tap,id=tap0,ifname=ceth0,downscript=no,script=no,fds=3:4,vhost=on"
+
+func TestAppendDeviceNetworkPCI(t *testing.T) {
+	foo, _ := ioutil.TempFile(os.TempDir(), "qemu-ciao-test")
+	bar, _ := ioutil.TempFile(os.TempDir(), "qemu-ciao-test")
+
+	defer os.Remove(foo.Name())
+	defer os.Remove(bar.Name())
+
+	netdev := NetDevice{
+		Driver:     VirtioNetPCI,
+		Type:       TAP,
+		ID:         "tap0",
+		IFName:     "ceth0",
+		Bus:        "/pci-bus/pcie.0",
+		Addr:       "255",
+		Script:     "no",
+		DownScript: "no",
+		FDs:        []*os.File{foo, bar},
+		VHost:      true,
+		MACAddress: "01:02:de:ad:be:ef",
+	}
+
+	testAppend(netdev, deviceNetworkPCIString, t)
+}
+
 var deviceSerialString = "-device virtio-serial-pci,id=serial0"
 
 func TestAppendDeviceSerial(t *testing.T) {


### PR DESCRIPTION
The existing NetDevice relies on virtio-net driver, but there is a
useful PCI variant which was not available: virtio-net-pci.
This patch adds this new driver and adds two parameters specific to
this: "bus" and "addr".