### PR TITLE
ciao-controller: Ensure quota errors are flagged as such

### DIFF
--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -95,7 +95,7 @@ func (c *controller) CreateVolume(tenant string, req block.RequestedVolume) (blo
 	if !res.Allowed() {
 		c.DeleteBlockDevice(bd.ID)
 		c.qs.Release(tenant, res.Resources()...)
-		return block.Volume{}, fmt.Errorf("Error creating volume: %s", res.Reason())
+		return block.Volume{}, block.ErrQuota
 	}
 
 	err = c.ds.AddBlockDevice(data)

--- a/openstack/block/api.go
+++ b/openstack/block/api.go
@@ -375,7 +375,7 @@ type APIHandler struct {
 func (h APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	resp, err := h.Handler(h.Context, w, r)
 	if err != nil {
-		http.Error(w, http.StatusText(resp.status), resp.status)
+		http.Error(w, err.Error(), resp.status)
 	}
 
 	b, err := json.Marshal(resp.response)


### PR DESCRIPTION
With this change the user gets clear feedback that the error came from
an over quota situation.

In order to facilitate this change it was necessary to report the
error's message to the user in the HTTP error message.

Fixes: #1088

Signed-off-by: Rob Bradford <robert.bradford@intel.com>