### PR TITLE
Instance migration refinements

### DIFF
--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -283,14 +283,14 @@ func (client *ssntpClient) startFailure(payload []byte) {
 		glog.Warningf("Error unmarshalling StartFailure: %v", err)
 		return
 	}
-	if failure.Reason.IsFatal() && !failure.Migration {
+	if failure.Reason.IsFatal() && !failure.Restart {
 		client.deleteEphemeralStorage(failure.InstanceUUID)
 		err = client.releaseResources(failure.InstanceUUID)
 		if err != nil {
 			glog.Warningf("Error when releasing resources for start failed instance: %v", err)
 		}
 	}
-	err = client.ctl.ds.StartFailure(failure.InstanceUUID, failure.Reason, failure.Migration)
+	err = client.ctl.ds.StartFailure(failure.InstanceUUID, failure.Reason, failure.Restart)
 	if err != nil {
 		glog.Warningf("Error adding StartFailure to datastore: %v", err)
 	}
@@ -480,7 +480,7 @@ func (client *ssntpClient) StopInstance(instanceID string, nodeID string) error 
 		Delete: payloads.StopCmd{
 			InstanceUUID:      instanceID,
 			WorkloadAgentUUID: nodeID,
-			Migration:         true,
+			Stop:              true,
 		},
 	}
 
@@ -515,8 +515,8 @@ func (client *ssntpClient) RestartInstance(i *types.Instance, w *types.Workload,
 			Subnet:           i.Subnet,
 			PrivateIP:        i.IPAddress,
 		},
-		Storage:   make([]payloads.StorageResource, len(i.Attachments)),
-		Migration: true,
+		Storage: make([]payloads.StorageResource, len(i.Attachments)),
+		Restart: true,
 	}
 
 	if w.VMType == payloads.Docker {

--- a/ciao-launcher/instance.go
+++ b/ciao-launcher/instance.go
@@ -61,7 +61,7 @@ type insDeleteCmd struct {
 	suicide         bool
 	skipDeleteEvent bool
 	running         ovsRunningState
-	migration       bool
+	stop            bool
 }
 type insMonitorCmd struct{}
 
@@ -94,7 +94,7 @@ There's always the possibility new commands will be received for the
 instance while it is waiting to be killed.  We'll just fail those.
 */
 
-func killMe(instance string, skipDeleteEvent, migration bool, doneCh chan struct{},
+func killMe(instance string, skipDeleteEvent, stop bool, doneCh chan struct{},
 	ac *agentClient, wg *sync.WaitGroup) {
 	wg.Add(1)
 	go func() {
@@ -103,7 +103,7 @@ func killMe(instance string, skipDeleteEvent, migration bool, doneCh chan struct
 			&insDeleteCmd{
 				suicide:         true,
 				skipDeleteEvent: skipDeleteEvent,
-				migration:       migration,
+				stop:            stop,
 			},
 		}
 		select {
@@ -117,7 +117,7 @@ func killMe(instance string, skipDeleteEvent, migration bool, doneCh chan struct
 func (id *instanceData) startCommand(cmd *insStartCmd) {
 	glog.Info("Found start command")
 	if id.monitorCh != nil {
-		startErr := &startError{nil, payloads.AlreadyRunning, cmd.cfg.Migration}
+		startErr := &startError{nil, payloads.AlreadyRunning, cmd.cfg.Restart}
 		glog.Errorf("Unable to start instance[%s]", string(startErr.code))
 		startErr.send(id.ac.conn, id.instance)
 		return
@@ -205,7 +205,7 @@ func (id *instanceData) deleteCommand(cmd *insDeleteCmd) bool {
 	id.unmapVolumes()
 
 	if !cmd.skipDeleteEvent {
-		if cmd.migration {
+		if cmd.stop {
 			id.sendInstanceStoppedEvent()
 		} else {
 			id.sendInstanceDeletedEvent()

--- a/ciao-launcher/instance.go
+++ b/ciao-launcher/instance.go
@@ -58,10 +58,25 @@ type insStartCmd struct {
 	rcvStamp time.Time
 }
 type insDeleteCmd struct {
-	suicide         bool
+	// Indicates that the delete command originated in launcher rather
+	// than controller.  Launcher may generate a delete command if a
+	// START command fails or an instance stops executing.
+	suicide bool
+
+	// Set to true if we don't want to send an InstanceDeleted or
+	// InstanceStopped event.  This is the case when we delete an
+	// instance that has failed to start.  We're sending StartFailure
+	// so InstanceDeleted is not needed.
 	skipDeleteEvent bool
-	running         ovsRunningState
-	stop            bool
+
+	// The running state of the instance as provided by the overseer.
+	// Used to determine whether we need to delete networking artifacts.
+	running ovsRunningState
+
+	// Indicates whether we are deleting or stopping an instance.  The
+	// two operations are almost identical for launcher.  The only difference
+	// is in the events that get sent back to controller.
+	stop bool
 }
 type insMonitorCmd struct{}
 

--- a/ciao-launcher/instance_test.go
+++ b/ciao-launcher/instance_test.go
@@ -277,11 +277,11 @@ func (v *instanceTestState) deleteInstance(t *testing.T, ovsCh chan interface{},
 }
 
 func (v *instanceTestState) checkDeleteEvent(t *testing.T, cmd *insDeleteCmd) {
-	if cmd.migration != v.deMigration {
+	if cmd.stop != v.deMigration {
 		t.Errorf("Incorrect delete event recevied")
 	}
 	var instance string
-	if cmd.migration {
+	if cmd.stop {
 		instance = v.se.InstanceStopped.InstanceUUID
 	} else {
 		instance = v.de.InstanceDeleted.InstanceUUID
@@ -804,7 +804,7 @@ func TestStartRunningInstance(t *testing.T) {
 //
 // We start the instance loop and then try to start an instance.  Our test virtualizer
 // closes the connected channel to indicate that the instance is running.  We then
-// delete the instance setting the migration flag in the insDelCmd.
+// delete the instance setting the stop flag in the insDelCmd.
 //
 // The instanceLoop and then instance should start correctly.  The instance should
 // then be deleted correctly and the InstanceStopped ssntp event should be received.
@@ -814,7 +814,7 @@ func TestMigrateInstance(t *testing.T) {
 	cfg := standardCfg
 	state, ovsCh, cmdCh, doneCh := startVMWithCFG(t, &wg, &cfg, true, false)
 
-	if !state.deleteInstanceEx(t, ovsCh, cmdCh, &insDeleteCmd{migration: true}) {
+	if !state.deleteInstanceEx(t, ovsCh, cmdCh, &insDeleteCmd{stop: true}) {
 		cleanupShutdownFail(t, cfg.Instance, doneCh, ovsCh, &wg)
 	}
 

--- a/ciao-launcher/main.go
+++ b/ciao-launcher/main.go
@@ -170,7 +170,7 @@ func processCommand(conn serverConn, cmd *cmdWrapper, ovsCh chan<- interface{}) 
 		if !addResult.canAdd {
 			glog.Errorf("Instance will make node full: Disk %d Mem %d CPUs %d",
 				insCmd.cfg.Disk, insCmd.cfg.Mem, insCmd.cfg.Cpus)
-			se := startError{nil, payloads.FullComputeNode, insCmd.cfg.Migration}
+			se := startError{nil, payloads.FullComputeNode, insCmd.cfg.Restart}
 			se.send(conn, cmd.instance)
 			return
 		}

--- a/ciao-launcher/payload.go
+++ b/ciao-launcher/payload.go
@@ -67,7 +67,7 @@ func printCloudinit(data *payloads.Start) {
 	glog.Infof("SubnetIP:             %v", net.Subnet)
 	glog.Infof("ConcUUID:             %v", net.ConcentratorUUID)
 	glog.Infof("VnicUUID:             %v", net.VnicUUID)
-	glog.Infof("Migration:            %t", start.Migration)
+	glog.Infof("Restart:              %t", start.Restart)
 
 	glog.Info("Requested resources:")
 	for i := range start.RequestedResources {
@@ -191,7 +191,7 @@ func parseStartPayload(data []byte) (*vmConfig, *payloadError) {
 		VnicUUID:    strings.TrimSpace(net.VnicUUID),
 		SSHPort:     sshPort,
 		Volumes:     volumes,
-		Migration:   clouddata.Start.Migration,
+		Restart:     clouddata.Start.Restart,
 	}, nil
 }
 
@@ -199,7 +199,7 @@ func generateStartError(instance string, startErr *startError) (out []byte, err 
 	sf := &payloads.ErrorStartFailure{
 		InstanceUUID: instance,
 		Reason:       startErr.code,
-		Migration:    startErr.migration,
+		Restart:      startErr.restart,
 	}
 	return yaml.Marshal(sf)
 }
@@ -272,7 +272,7 @@ func parseDeletePayload(data []byte) (string, bool, *payloadError) {
 		err = fmt.Errorf("Invalid instance id received: %s", instance)
 		return "", false, &payloadError{err, payloads.DeleteInvalidData}
 	}
-	return instance, clouddata.Delete.Migration, nil
+	return instance, clouddata.Delete.Stop, nil
 }
 
 func extractVolumeInfo(cmd *payloads.VolumeCmd, errString string) (string, string, *payloadError) {

--- a/ciao-launcher/payload_test.go
+++ b/ciao-launcher/payload_test.go
@@ -309,7 +309,7 @@ func TestGenerateNetEventPayload(t *testing.T) {
 // The payload should parse without any error and the instance UUID in the
 // resulting payloads data structure should be as expected.
 func TestParseDeletePayload(t *testing.T) {
-	instance, migration, err := parseDeletePayload([]byte(testutil.DeleteYaml))
+	instance, stop, err := parseDeletePayload([]byte(testutil.DeleteYaml))
 	if err != nil {
 		t.Fatalf("Failed to parse delete payload : %v", err.err)
 	}
@@ -317,7 +317,7 @@ func TestParseDeletePayload(t *testing.T) {
 		t.Errorf("Wrong instance UUID.  Expected %s found %s", instance,
 			testutil.InstanceUUID)
 	}
-	if migration {
-		t.Errorf("Expected migration to be false")
+	if stop {
+		t.Errorf("Expected stop to be false")
 	}
 }

--- a/ciao-launcher/ssntp.go
+++ b/ciao-launcher/ssntp.go
@@ -111,7 +111,7 @@ func (client *agentClient) CommandNotify(cmd ssntp.Command, frame *ssntp.Frame) 
 		}
 		client.cmdCh <- &cmdWrapper{cfg.Instance, &insStartCmd{cn, md, frame, cfg, time.Now()}}
 	case ssntp.DELETE:
-		instance, migration, payloadErr := parseDeletePayload(payload)
+		instance, stop, payloadErr := parseDeletePayload(payload)
 		if payloadErr != nil {
 			deleteError := &deleteError{
 				payloadErr.err,
@@ -121,7 +121,7 @@ func (client *agentClient) CommandNotify(cmd ssntp.Command, frame *ssntp.Frame) 
 			glog.Errorf("Unable to parse YAML: %s", payloadErr.err)
 			return
 		}
-		client.cmdCh <- &cmdWrapper{instance, &insDeleteCmd{migration: migration}}
+		client.cmdCh <- &cmdWrapper{instance, &insDeleteCmd{stop: stop}}
 	case ssntp.AttachVolume:
 		instance, volume, payloadErr := parseAttachVolumePayload(payload)
 		if payloadErr != nil {

--- a/ciao-launcher/start_error.go
+++ b/ciao-launcher/start_error.go
@@ -23,9 +23,9 @@ import (
 )
 
 type startError struct {
-	err       error
-	code      payloads.StartFailureReason
-	migration bool
+	err     error
+	code    payloads.StartFailureReason
+	restart bool
 }
 
 func (se *startError) send(conn serverConn, instance string) {

--- a/ciao-launcher/start_instance.go
+++ b/ciao-launcher/start_instance.go
@@ -83,12 +83,12 @@ func processStart(cmd *insStartCmd, instanceDir string, vm virtualizer, conn ser
 	_, err = os.Stat(instanceDir)
 	if err == nil {
 		err = fmt.Errorf("Instance %s has already been created", cfg.Instance)
-		return nil, &startError{err, payloads.InstanceExists, cmd.cfg.Migration}
+		return nil, &startError{err, payloads.InstanceExists, cmd.cfg.Restart}
 	}
 
 	err = vm.ensureBackingImage()
 	if err != nil {
-		return nil, &startError{err, payloads.ImageFailure, cmd.cfg.Migration}
+		return nil, &startError{err, payloads.ImageFailure, cmd.cfg.Restart}
 	}
 
 	st.backingImageCheck = time.Now()
@@ -97,14 +97,14 @@ func processStart(cmd *insStartCmd, instanceDir string, vm virtualizer, conn ser
 		vnicCfg, err = createVnicCfg(cfg)
 		if err != nil {
 			glog.Errorf("Could not create VnicCFG: %s", err)
-			return nil, &startError{err, payloads.InvalidData, cmd.cfg.Migration}
+			return nil, &startError{err, payloads.InvalidData, cmd.cfg.Restart}
 		}
 	}
 
 	if vnicCfg != nil {
 		vnicName, bridge, err = createVnic(conn, vnicCfg)
 		if err != nil {
-			return nil, &startError{err, payloads.NetworkFailure, cmd.cfg.Migration}
+			return nil, &startError{err, payloads.NetworkFailure, cmd.cfg.Restart}
 		}
 	}
 
@@ -112,14 +112,14 @@ func processStart(cmd *insStartCmd, instanceDir string, vm virtualizer, conn ser
 
 	err = createInstance(vm, instanceDir, cfg, bridge, cmd.userData, cmd.metaData)
 	if err != nil {
-		return nil, &startError{err, payloads.ImageFailure, cmd.cfg.Migration}
+		return nil, &startError{err, payloads.ImageFailure, cmd.cfg.Restart}
 	}
 
 	st.creationStamp = time.Now()
 
 	err = vm.startVM(vnicName, getNodeIPAddress(), cephID)
 	if err != nil {
-		return nil, &startError{err, payloads.LaunchFailure, cmd.cfg.Migration}
+		return nil, &startError{err, payloads.LaunchFailure, cmd.cfg.Restart}
 	}
 
 	st.runStamp = time.Now()

--- a/ciao-launcher/tests/ciaolc/ciaolc.go
+++ b/ciao-launcher/tests/ciaolc/ciaolc.go
@@ -409,7 +409,7 @@ func startf(host string) error {
 	return err
 }
 
-func postDeleteCommand(host string, migration bool) error {
+func postDeleteCommand(host string, stop bool) error {
 	var del payloads.Delete
 
 	client, instance, err := getSimplePostArgs("delete")
@@ -418,7 +418,7 @@ func postDeleteCommand(host string, migration bool) error {
 	}
 
 	del.Delete.InstanceUUID = instance
-	del.Delete.Migration = migration
+	del.Delete.Stop = stop
 	return postYaml(host, "delete", client, &del)
 }
 

--- a/ciao-launcher/vmconfig.go
+++ b/ciao-launcher/vmconfig.go
@@ -47,7 +47,7 @@ type vmConfig struct {
 	VnicUUID    string
 	SSHPort     int
 	Volumes     []volumeConfig
-	Migration   bool
+	Restart     bool
 }
 
 func loadVMConfig(instanceDir string) (*vmConfig, error) {

--- a/ciao-scheduler/scheduler_internal_test.go
+++ b/ciao-scheduler/scheduler_internal_test.go
@@ -180,28 +180,28 @@ func TestPickComputeNode(t *testing.T) {
 	}
 
 	// no compute nodes
-	node := PickComputeNode(sched, "", &resources)
+	node := PickComputeNode(sched, "", &resources, false)
 	if node != nil {
 		t.Error("found compute fit in empty node list")
 	}
 
 	// 1st compute node, with little memory
 	spinUpComputeNodeVerySmall(sched, 1)
-	node = PickComputeNode(sched, "", &resources)
+	node = PickComputeNode(sched, "", &resources, false)
 	if node != nil {
 		t.Error("found compute fit when none should exist")
 	}
 
 	// 2nd compute node, with little memory
 	spinUpComputeNodeVerySmall(sched, 2)
-	node = PickComputeNode(sched, "", &resources)
+	node = PickComputeNode(sched, "", &resources, false)
 	if node != nil {
 		t.Error("found compute fit when none should exist")
 	}
 
 	// 3rd compute node, with a lot of memory
 	spinUpComputeNodeLarge(sched, 3)
-	node = PickComputeNode(sched, "", &resources)
+	node = PickComputeNode(sched, "", &resources, false)
 	if node == nil {
 		t.Error("found no compute fit when one should exist")
 	}
@@ -210,14 +210,14 @@ func TestPickComputeNode(t *testing.T) {
 	for i := 4; i < 100; i++ {
 		spinUpComputeNode(sched, i, 256*i)
 	}
-	node = PickComputeNode(sched, "", &resources)
+	node = PickComputeNode(sched, "", &resources, false)
 	if node == nil {
 		t.Error("failed to fit in hundred compute node list")
 	}
 
 	// compute MRU set somewhere arbitrary
 	sched.cnMRUIndex = 42
-	node = PickComputeNode(sched, "", &resources)
+	node = PickComputeNode(sched, "", &resources, false)
 	if node == nil {
 		t.Error("failed to find compute fit after MRU")
 	}
@@ -244,7 +244,7 @@ func benchmarkPickComputeNode(b *testing.B, nodecount int) {
 	// setup complete
 
 	for i := 0; i < b.N; i++ {
-		PickComputeNode(sched, "", &resources)
+		PickComputeNode(sched, "", &resources, false)
 	}
 }
 
@@ -298,28 +298,28 @@ func TestPickNetworkNode(t *testing.T) {
 	}
 
 	// no network nodes
-	node := PickNetworkNode(sched, "", &resources)
+	node := PickNetworkNode(sched, "", &resources, false)
 	if node != nil {
 		t.Error("found network fit in empty node list")
 	}
 
 	// 1st network node, with little memory
 	spinUpNetworkNodeVerySmall(sched, 1, testutil.MultipleComputeNetworks)
-	node = PickNetworkNode(sched, "", &resources)
+	node = PickNetworkNode(sched, "", &resources, false)
 	if node != nil {
 		t.Error("found network fit when none should exist")
 	}
 
 	// 2nd network node, with even less resources
 	spinUpNetworkNodeVerySmall(sched, 2, testutil.PartialComputeNetworks)
-	node = PickNetworkNode(sched, "", &resources)
+	node = PickNetworkNode(sched, "", &resources, false)
 	if node != nil {
 		t.Error("found network fit when none should exist")
 	}
 
 	// 3rd network node, with a lot of memory, well connected
 	spinUpNetworkNodeLarge(sched, 3, testutil.MultipleComputeNetworks)
-	node = PickNetworkNode(sched, "", &resources)
+	node = PickNetworkNode(sched, "", &resources, false)
 	if node == nil {
 		t.Error("found no network fit when one should exist")
 	}
@@ -333,7 +333,7 @@ func TestPickNetworkNode(t *testing.T) {
 			spinUpNetworkNode(sched, i, 256*i, testutil.PartialComputeNetworks)
 		}
 	}
-	node = PickNetworkNode(sched, "", &resources)
+	node = PickNetworkNode(sched, "", &resources, false)
 	if node == nil {
 		t.Error("failed to fit in hundred network node list")
 	}
@@ -342,11 +342,11 @@ func TestPickNetworkNode(t *testing.T) {
 	// requested network connectivity after network MRU is set somewhere
 	// arbitrary
 	sched.nnMRUIndex = 42
-	node = PickNetworkNode(sched, "", &resources)
+	node = PickNetworkNode(sched, "", &resources, false)
 	if node == nil {
 		t.Error("failed to find network fit after MRU")
 	}
-	node = PickNetworkNode(sched, "", &resources)
+	node = PickNetworkNode(sched, "", &resources, false)
 	if node == nil {
 		t.Error("failed to find network fit when many should exist")
 	}
@@ -373,7 +373,7 @@ func benchmarkPickNetworkNode(b *testing.B, nodecount int) {
 	// setup complete
 
 	for i := 0; i < b.N; i++ {
-		PickNetworkNode(sched, "", &resources)
+		PickNetworkNode(sched, "", &resources, false)
 	}
 }
 

--- a/payloads/start.go
+++ b/payloads/start.go
@@ -243,9 +243,9 @@ type StartCmd struct {
 	// from storage for the new instance.
 	Storage []StorageResource `yaml:"storage,omitempty"`
 
-	// Migration is set to true if the payload represents a request to
+	// Restart is set to true if the payload represents a request to
 	// restart an existing instance on a new node.
-	Migration bool
+	Restart bool
 }
 
 // Start represents the unmarshalled version of the contents of a SSNTP START

--- a/payloads/startfailure.go
+++ b/payloads/startfailure.go
@@ -89,9 +89,9 @@ type ErrorStartFailure struct {
 	// LaunchFailure.
 	Reason StartFailureReason `yaml:"reason"`
 
-	// Migration is true if the failed start command was attempting to
+	// Restart is true if the failed start command was attempting to
 	// restart an existing instance.
-	Migration bool
+	Restart bool
 }
 
 func (r StartFailureReason) String() string {

--- a/payloads/stop.go
+++ b/payloads/stop.go
@@ -26,10 +26,10 @@ type StopCmd struct {
 	// the command to the correct CN/NN.
 	WorkloadAgentUUID string `yaml:"workload_agent_uuid"`
 
-	// Migration is true if the instance is being migrated to another node.
+	// Stop is true if the instance is being stopped rather than deleted.
 	// In this case the delete command should only delete the instance from
 	// the node to which it is sent and not the entire cluster.
-	Migration bool
+	Stop bool
 }
 
 // Stop represents the unmarshalled version of the contents of a SSNTP STOP

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -174,7 +174,7 @@ const StartYaml = `start:
     subnet_uuid: ""
     private_ip: ""
     public_ip: false
-  migration: false
+  restart: false
 `
 
 // CNCIStartYaml is a sample CNCI workload START ssntp.Command payload for test cases
@@ -225,7 +225,7 @@ const PartialStartYaml = `start:
 // StartFailureYaml is a sample workload StartFailure ssntp.Error payload for test cases
 const StartFailureYaml = `instance_uuid: ` + InstanceUUID + `
 reason: full_cloud
-migration: false
+restart: false
 `
 
 // RestartYaml is a sample workload RESTART ssntp.Command payload for test cases
@@ -281,7 +281,7 @@ reason: already_running
 const StopYaml = `stop:
   instance_uuid: ` + InstanceUUID + `
   workload_agent_uuid: ` + AgentUUID + `
-  migration: false
+  stop: false
 `
 
 // StopFailureYaml is a sample workload StopFailure ssntp.Error payload for test cases
@@ -293,7 +293,7 @@ reason: already_stopped
 const DeleteYaml = `delete:
   instance_uuid: ` + InstanceUUID + `
   workload_agent_uuid: ` + AgentUUID + `
-  migration: false
+  stop: false
 `
 
 // MigrateYaml is a sample workload DELETE ssntp.Command payload for test cases
@@ -301,7 +301,7 @@ const DeleteYaml = `delete:
 const MigrateYaml = `delete:
   instance_uuid: ` + InstanceUUID + `
   workload_agent_uuid: ` + AgentUUID + `
-  migration: true
+  stop: true
 `
 
 // EvacuateYaml is a sample node EVACUATE ssntp.Command payload for test cases


### PR DESCRIPTION
This PR addresses some of the comments made on PR #1226.  It renames some variables, factorizes some code, adds comment to some confusing parts of launcher and fixes a nasty bug in scheduler that could have lead to restarted instances being deleted if the attempt to restart them failed in scheduler.