### PR TITLE
ansible: Add visibility support for sample images

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/main.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/main.yml
@@ -60,9 +60,12 @@
       - name: '"Clear Cloud"'
         file: "{{ clear_cloud_image }}"
         id: df3768da-31f5-4ba6-82f0-127a1a705169
+        visibility: public
       - name: "CNCI"
         file: "{{ cnci_image }}"
         id: 4e16e743-265a-4bf2-9fd1-57ada0b28904
+        visibility: internal
       - name: '"Fedora 24 Cloud"'
         file: "{{ fedora_cloud_image }}"
         id: 73a86d7e-93c0-480e-9c41-ab42f69b7799
+        visibility: public

--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/upload_images.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/tasks/upload_images.yml
@@ -27,7 +27,7 @@
       CIAO_CA_CERT_FILE: certificates/keystone/keystone_cert.pem
 
   - name: Upload {{ image.name }}
-    shell: "{{ gopath }}/bin/ciao-cli image add --file images/{{ image.file }} --name {{ image.name }} --id {{ image.id }}"
+    shell: "{{ gopath }}/bin/ciao-cli image add --file images/{{ image.file }} --name {{ image.name }} --id {{ image.id }} --visibility {{ image.visibility }}"
     environment:
       CIAO_CONTROLLER: "{{ keystone_fqdn }}"
       CIAO_IDENTITY: "https://{{ keystone_fqdn }}:35357"


### PR DESCRIPTION
This commit add support for defining visibility on initial images
that are created by ansible. CNCI image will be kept as internal
image and for the rest of images, they will remain as public images.

Signed-off-by: Obed N Munoz <obed.n.munoz@intel.com>