### PR TITLE
ansible: Add sysadmin-remote bundle as dependency for ClearLinux

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/vars/Clear.yml
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-common/vars/Clear.yml
@@ -15,8 +15,10 @@
 
 controller_deps:
   - cloud-control
+  - sysadmin-remote
   # - storage-cluster
   # - kvm-host
 
 launcher_deps:
   - cloud-control
+  - sysadmin-remote


### PR DESCRIPTION
This bundle contains docker-py which is required on the controller
node by ansible in order to launch containers

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>