### PR TITLE
ciao-down: Ensure qemu-img is installed

### DIFF
--- a/testutil/ciao-down/deps.go
+++ b/testutil/ciao-down/deps.go
@@ -27,6 +27,7 @@ var ciaoDevClearDeps = []osprepare.PackageRequirement{
 
 var ciaoDevFedoraDeps = []osprepare.PackageRequirement{
 	{BinaryName: "/usr/bin/qemu-system-x86_64", PackageName: "qemu-system-x86"},
+	{BinaryName: "/usr/bin/qemu-img", PackageName: "qemu-img"},
 	{BinaryName: "/usr/bin/xorriso", PackageName: "xorriso"},
 	{BinaryName: "/usr/bin/ssh", PackageName: "openssh-clients"},
 	{BinaryName: "/usr/bin/ssh-keygen", PackageName: "openssh-clients"},
@@ -34,6 +35,7 @@ var ciaoDevFedoraDeps = []osprepare.PackageRequirement{
 
 var ciaoDevUbuntuDeps = []osprepare.PackageRequirement{
 	{BinaryName: "/usr/bin/qemu-system-x86_64", PackageName: "qemu-system-x86"},
+	{BinaryName: "/usr/bin/qemu-img", PackageName: "qemu-utils"},
 	{BinaryName: "/usr/bin/xorriso", PackageName: "xorriso"},
 	{BinaryName: "/usr/bin/ssh", PackageName: "openssh-client"},
 	{BinaryName: "/usr/bin/ssh-keygen", PackageName: "openssh-client"},


### PR DESCRIPTION
This commit updates the deps.go file to ensure that qemu-img is installed on
Ubuntu and Fedora.  It is not part of the qemu-system-x86 package on these
distributions and so we cannot assume that it is installed by virtue of installing
qemu itself.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>