### PR TITLE
Add support for workload show

### DIFF
--- a/bat/workload.go
+++ b/bat/workload.go
@@ -208,6 +208,18 @@ func GetAllWorkloads(ctx context.Context, tenant string) ([]Workload, error) {
 	return workloads, nil
 }
 
+func getWorkload(ctx context.Context, tenant string, wl string) (Workload, error) {
+	var workload Workload
+
+	args := []string{"workload", "show", "-f", "{{tojson .}}"}
+	err := RunCIAOCLIJS(ctx, tenant, args, &workload)
+	if err != nil {
+		return workload, err
+	}
+
+	return workload, nil
+}
+
 // GetWorkloadByName will return a specific workload referenced by name.
 // An error will be returned if either no workloads exist in the cluster,
 // or if the specific workload does not exist. It inherits all error

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/01org/ciao/ciao-controller/types"
+	"github.com/01org/ciao/payloads"
 )
 
 type test struct {
@@ -160,6 +161,15 @@ var tests = []test{
 	},
 	{
 		"GET",
+		"/workloads/ba58f471-0735-4773-9550-188e2d012941",
+		showWorkload,
+		"",
+		"application/x.ciao.v1.workloads",
+		http.StatusOK,
+		`{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_id":"73a86d7e-93c0-480e-9c41-ab42f69b7799","image_name":"","config":"this will totally work!","defaults":null,"storage":null}`,
+	},
+	{
+		"GET",
 		"/tenants/test-tenant-id/quotas/",
 		listQuotas,
 		"",
@@ -279,6 +289,18 @@ func (ts testCiaoService) CreateWorkload(req types.Workload) (types.Workload, er
 
 func (ts testCiaoService) DeleteWorkload(tenant string, workload string) error {
 	return nil
+}
+
+func (ts testCiaoService) ShowWorkload(tenant string, ID string) (types.Workload, error) {
+	return types.Workload{
+		ID:          "ba58f471-0735-4773-9550-188e2d012941",
+		TenantID:    tenant,
+		Description: "testWorkload",
+		FWType:      payloads.Legacy,
+		VMType:      payloads.QEMU,
+		ImageID:     "73a86d7e-93c0-480e-9c41-ab42f69b7799",
+		Config:      "this will totally work!",
+	}, nil
 }
 
 func (ts testCiaoService) ListQuotas(tenantID string) []types.QuotaDetails {

--- a/ciao-controller/workload.go
+++ b/ciao-controller/workload.go
@@ -206,3 +206,7 @@ func (c *controller) CreateWorkload(req types.Workload) (types.Workload, error) 
 func (c *controller) DeleteWorkload(tenantID string, workloadID string) error {
 	return c.ds.DeleteWorkload(tenantID, workloadID)
 }
+
+func (c *controller) ShowWorkload(tenantID string, workloadID string) (types.Workload, error) {
+	return c.ds.GetWorkload(tenantID, workloadID)
+}


### PR DESCRIPTION
Modify controller and ciao-cli to support a "workload show" command. This command will display a workload definition and config in yaml format.

Fixes: #1012 #1013 #1134 