### PR TITLE
ciao-controller: api: fix route for tenant pools list

### DIFF
--- a/ciao-controller/api/api.go
+++ b/ciao-controller/api/api.go
@@ -620,7 +620,7 @@ func Routes(config Config) *mux.Router {
 	route.Methods("GET")
 	route.HeadersRegexp("Content-Type", matchContent)
 
-	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}", Handler{context, listPools, false})
+	route = r.Handle("/{tenant:"+uuid.UUIDRegex+"}/pools", Handler{context, listPools, false})
 	route.Methods("GET")
 	route.HeadersRegexp("Content-Type", matchContent)
 


### PR DESCRIPTION
The route for {tenant_id}/pools GET was not being exposed. Correct
the route to allow unprivileged GET calls to work for pools.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>