### PR TITLE
ciao-cli: Fix node, tenant and volume list commands

### DIFF
--- a/ciao-cli/node.go
+++ b/ciao-cli/node.go
@@ -76,9 +76,13 @@ func (cmd *nodeListCommand) parseArgs(args []string) []string {
 }
 
 func (cmd *nodeListCommand) run(args []string) error {
-	t, err := templateutils.CreateTemplate("node-list", cmd.template, nil)
-	if err != nil {
-		fatalf(err.Error())
+	var t *template.Template
+	if cmd.template != "" {
+		var err error
+		t, err = templateutils.CreateTemplate("node-list", cmd.template, nil)
+		if err != nil {
+			fatalf(err.Error())
+		}
 	}
 
 	if cmd.compute {

--- a/ciao-cli/tenant.go
+++ b/ciao-cli/tenant.go
@@ -85,9 +85,13 @@ func (cmd *tenantListCommand) parseArgs(args []string) []string {
 }
 
 func (cmd *tenantListCommand) run(args []string) error {
-	t, err := templateutils.CreateTemplate("tenant-list", cmd.template, nil)
-	if err != nil {
-		fatalf(err.Error())
+	var t *template.Template
+	if cmd.template != "" {
+		var err error
+		t, err = templateutils.CreateTemplate("tenant-list", cmd.template, nil)
+		if err != nil {
+			fatalf(err.Error())
+		}
 	}
 
 	if cmd.all {

--- a/ciao-cli/volume.go
+++ b/ciao-cli/volume.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"text/template"
 	"time"
 
 	"github.com/01org/ciao/templateutils"
@@ -148,9 +149,12 @@ func (cmd *volumeListCommand) run(args []string) error {
 		fatalf("Could not get volume service client [%s]\n", err)
 	}
 
-	t, err := templateutils.CreateTemplate("volume-list", cmd.template, nil)
-	if err != nil {
-		fatalf(err.Error())
+	var t *template.Template
+	if cmd.template != "" {
+		t, err = templateutils.CreateTemplate("volume-list", cmd.template, nil)
+		if err != nil {
+			fatalf(err.Error())
+		}
 	}
 
 	pager := volumes.List(client, volumes.ListOpts{})


### PR DESCRIPTION
These command were broken by the PR that moved the template code into
a separate package, templateutils.  The old implementation of createTemplate
returned nil, nil if the template script was an empty string and the commands
listed above relied on this behaviour.  The templateutils version of
CreateTemplate returns an error if the template string is "" and this is what
was causing those commands to fail.  This commit adds a check to each of these
commands to ensure that the template script is not empty before caling
templateutils.CreateTemplate.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>