### PR TITLE
ciao-down: single vm: Provide external network access for ciao instances

### DIFF
--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -13,6 +13,7 @@ sudo iptables -D FORWARD -i ciao_br -j ACCEPT
 sudo iptables -D FORWARD -i ciaovlan -j ACCEPT
 if [ "$ciao_host" == "singlevm" ]; then
 	sudo iptables -D FORWARD -i ens2 -j ACCEPT
+	sudo iptables -t nat -D POSTROUTING -o ens2 -j MASQUERADE
 fi
 sudo ip link del ciao_br
 sudo pkill -F /tmp/dnsmasq.ciaovlan.pid

--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -3,12 +3,17 @@
 . ~/local/demo.sh
 
 ciao_gobin="$GOPATH"/bin
+ciao_host=$(hostname)
 sudo killall ciao-scheduler
 sudo killall ciao-controller
 sudo killall ciao-launcher
 sleep 2
 sudo "$ciao_gobin"/ciao-launcher --alsologtostderr -v 3 --hard-reset
-sudo iptables -D FORWARD -p all -i ciao_br -j ACCEPT
+sudo iptables -D FORWARD -i ciao_br -j ACCEPT
+sudo iptables -D FORWARD -i ciaovlan -j ACCEPT
+if [ "$ciao_host" == "singlevm" ]; then
+	sudo iptables -D FORWARD -i ens2 -j ACCEPT
+fi
 sudo ip link del ciao_br
 sudo pkill -F /tmp/dnsmasq.ciaovlan.pid
 sudo docker rm -v -f keystone

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -608,6 +608,14 @@ if [ -x "$(command -v ip)" ]; then
     sudo ip -d link show ciaovlan
     sudo ip link set dev "$ciao_bridge" up
     sudo ip -d link show "$ciao_bridge"
+    sudo iptables -A FORWARD -p all -i ciaovlan -j ACCEPT
+    #Do this only in the case of ciao-down as it can potentially
+    #open up the machine. On bare metal the user will need to explicitly
+    #add this rule
+    if [ "$ciao_host" == "singlevm" ]; then
+	sudo iptables -A FORWARD -p all -i ens2 -j ACCEPT
+    fi
+
 else
     echo 'ip command is not supported'
 fi

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -614,6 +614,8 @@ if [ -x "$(command -v ip)" ]; then
     #add this rule
     if [ "$ciao_host" == "singlevm" ]; then
 	sudo iptables -A FORWARD -p all -i ens2 -j ACCEPT
+	#NAT out all the traffic departing ciao-down
+	sudo iptables -t nat -A POSTROUTING -o ens2 -j MASQUERADE
     fi
 
 else


### PR DESCRIPTION
The firewall rules within a ciao-down virtual machine prevent traffic
from instances launched within ciao-down using ciao from gaining
external connectivity. This is due to the absence for iptables rules
that allow connectivity between the physical network and the ciao
network.

Explicitly enable packet forwarding between the external network and
the logical ciao-down network by adding firewall rules.

However do not allow forwarding between the external network and ciao
network in the case of a bare metal deployment. This ensures that
user defined firewall rules are not violated. The user in this case
needs to explicitly enable forwarding of traffic from the external
network.

Fixes https://github.com/01org/ciao/issues/1258

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>