### PR TITLE
ciao-down: Only use ciao-down ssh key

### DIFF
--- a/testutil/ciao-down/ciao_down.go
+++ b/testutil/ciao-down/ciao_down.go
@@ -360,6 +360,7 @@ func connect(ctx context.Context, errCh chan error) {
 	err = syscall.Exec(path, []string{path,
 		"-q", "-o", "UserKnownHostsFile=/dev/null",
 		"-o", "StrictHostKeyChecking=no",
+		"-o", "IdentitiesOnly=yes",
 		"-i", ws.keyPath,
 		"127.0.0.1", "-p", "10022"},
 		os.Environ())

--- a/testutil/ciao-down/vm.go
+++ b/testutil/ciao-down/vm.go
@@ -138,7 +138,7 @@ func statusVM(ctx context.Context, instanceDir, keyPath string) {
 	ssh := "N/A"
 	if sshReady(ctx) {
 		status = "ciao up"
-		ssh = fmt.Sprintf("ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i %s 127.0.0.1 -p %d", keyPath, 10022)
+		ssh = fmt.Sprintf("ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i %s 127.0.0.1 -p %d", keyPath, 10022)
 	}
 
 	w := new(tabwriter.Writer)


### PR DESCRIPTION
This commit modifies the ciao-down connect command to only use the
identity key generated by ciao-down.  We've had some reports that
users with a lot of keys in their .ssh directories are unable to
connect to a ciao-down VM, as ssh seems to be trying these keys
in preference to the key supplied by ciao-down, and is giving
up after a number of connection attempts have failed.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>