### PR TITLE
Volume resizing at creation time

### DIFF
--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -54,15 +54,16 @@ func (c *controller) CreateVolume(tenant string, req block.RequestedVolume) (blo
 		// create bootable volume
 		bd, err = c.CreateBlockDeviceFromSnapshot(*req.ImageRef, "ciao-image")
 		bd.Bootable = true
-		if err == nil && req.Size > 0 {
-			bd.Size, err = c.Resize(bd.ID, req.Size)
-		}
 	} else if req.SourceVolID != nil {
 		// copy existing volume
 		bd, err = c.CopyBlockDevice(*req.SourceVolID)
 	} else {
 		// create empty volume
 		bd, err = c.CreateBlockDevice("", "", req.Size)
+	}
+
+	if err == nil && req.Size > bd.Size {
+		bd.Size, err = c.Resize(bd.ID, req.Size)
 	}
 
 	if err != nil {

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -54,6 +54,9 @@ func (c *controller) CreateVolume(tenant string, req block.RequestedVolume) (blo
 		// create bootable volume
 		bd, err = c.CreateBlockDeviceFromSnapshot(*req.ImageRef, "ciao-image")
 		bd.Bootable = true
+		if err == nil && req.Size > 0 {
+			bd.Size, err = c.Resize(bd.ID, req.Size)
+		}
 	} else if req.SourceVolID != nil {
 		// copy existing volume
 		bd, err = c.CopyBlockDevice(*req.SourceVolID)

--- a/ciao-controller/workload.go
+++ b/ciao-controller/workload.go
@@ -54,11 +54,6 @@ func validateWorkloadStorage(req types.Workload) error {
 			return types.ErrBadRequest
 		}
 
-		// you may not request a sized volume unless it's empty.
-		if req.Storage[i].Size > 0 && req.Storage[i].SourceType != types.Empty {
-			return types.ErrBadRequest
-		}
-
 		// you may not request a bootable empty volume.
 		if req.Storage[i].Bootable && req.Storage[i].SourceType == types.Empty {
 			return types.ErrBadRequest

--- a/ciao-launcher/docker_test.go
+++ b/ciao-launcher/docker_test.go
@@ -111,6 +111,10 @@ func (s dockerTestStorage) IsValidSnapshotUUID(string) error {
 	return nil
 }
 
+func (s dockerTestStorage) Resize(string, int) (int, error) {
+	return 0, nil
+}
+
 type dockerTestClient struct {
 	err               error
 	images            []types.Image

--- a/ciao-storage/block.go
+++ b/ciao-storage/block.go
@@ -36,6 +36,7 @@ type BlockDriver interface {
 	CopyBlockDevice(string) (BlockDevice, error)
 	GetBlockDeviceSize(volumeUUID string) (uint64, error)
 	IsValidSnapshotUUID(string) error
+	Resize(volumeUUID string, sizeGiB int) (int, error)
 }
 
 // BlockDevice contains information about a block device

--- a/ciao-storage/ceph.go
+++ b/ciao-storage/ceph.go
@@ -276,3 +276,17 @@ func (d CephDriver) IsValidSnapshotUUID(snapshotUUID string) error {
 
 	return nil
 }
+
+// Resize the underlying rbd image. Only extending is permitted. Returns the new size in GiB.
+func (d CephDriver) Resize(volumeUUID string, sizeGiB int) (int, error) {
+	args := append(d.getCredentials(), "resize", volumeUUID, "--no-progress", "-s", fmt.Sprintf("%dG", sizeGiB))
+	cmd := exec.Command("rbd", args...)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		err = fmt.Errorf("Error when running: %v: %v: %s", cmd.Args, err, out)
+	}
+
+	size, _ := d.getBlockDeviceSizeGiB(volumeUUID)
+	return size, err
+}

--- a/ciao-storage/noop.go
+++ b/ciao-storage/noop.go
@@ -94,3 +94,8 @@ func (d *NoopDriver) IsValidSnapshotUUID(snapshotUUID string) error {
 
 	return nil
 }
+
+// Resize the underlying rbd image. Only extending is permitted.
+func (d *NoopDriver) Resize(volumeUUID string, sizeGiB int) (int, error) {
+	return sizeGiB, nil
+}


### PR DESCRIPTION
Add support for resizing volumes via the Open Stack API (ciao-cli volume add) and via workload definitions when the source for the volume is either another volume or an image.