### PR TITLE
Support naming instances

### DIFF
--- a/ciao-cli/instance.go
+++ b/ciao-cli/instance.go
@@ -448,7 +448,11 @@ func validateCreateServerRequest(server compute.CreateServerRequest) error {
 }
 
 func populateCreateServerRequest(cmd *instanceAddCommand, server *compute.CreateServerRequest) {
-	server.Server.Name = cmd.label
+	if cmd.label != "" {
+		server.Server.Metadata = make(map[string]string)
+		server.Server.Metadata["label"] = cmd.label
+	}
+
 	server.Server.Flavor = cmd.workload
 	server.Server.MaxInstances = cmd.instances
 	server.Server.MinInstances = 1

--- a/ciao-cli/instance.go
+++ b/ciao-cli/instance.go
@@ -424,10 +424,9 @@ func (cmd *instanceAddCommand) validateAddCommandArgs() {
 	}
 
 	if cmd.name != "" {
-		r := regexp.MustCompile("^[a-z0-9-]*$")
+		r := regexp.MustCompile("^[a-z0-9-]{1,64}?$")
 		if !r.MatchString(cmd.name) {
-			errorf("Name must only contain lowercase letters, numbers and hyphens.")
-			cmd.usage()
+			errorf("Requested name must be between 1 and 64 lowercase letters, numbers and hyphens")
 		}
 	}
 

--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -499,9 +499,14 @@ func (client *ssntpClient) RestartInstance(i *types.Instance, w *types.Workload,
 		return errors.Wrapf(err, "Unable to update instance state before restarting")
 	}
 
+	hostname := i.ID
+	if i.Name != "" {
+		hostname = i.Name
+	}
+
 	metaData := userData{
 		UUID:     i.ID,
-		Hostname: i.ID,
+		Hostname: hostname,
 	}
 
 	restartCmd := payloads.StartCmd{

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -196,19 +196,10 @@ func (c *controller) startWorkload(w types.WorkloadRequest) ([]*types.Instance, 
 		startTime := time.Now()
 
 		name := w.Name
-		if w.Instances > 1 {
-			name = fmt.Sprintf("%s-%d", name, i)
-		}
-
-		id, err := c.ds.ResolveInstance(w.TenantID, name)
-		if err != nil {
-			e = errors.Wrap(err, "error trying to resolve name")
-			continue
-		}
-
-		if id != "" {
-			e = fmt.Errorf("Instance name already in use: %s", name)
-			continue
+		if name != "" {
+			if w.Instances > 1 {
+				name = fmt.Sprintf("%s-%d", name, i)
+			}
 		}
 
 		instance, err := newInstance(c, w.TenantID, &wl, w.Volumes, name)

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -194,7 +194,13 @@ func (c *controller) startWorkload(w types.WorkloadRequest) ([]*types.Instance, 
 
 	for i := 0; i < w.Instances && e == nil; i++ {
 		startTime := time.Now()
-		instance, err := newInstance(c, w.TenantID, &wl, w.Volumes)
+
+		name := w.Name
+		if w.Instances > 1 {
+			name = fmt.Sprintf("%s-%d", name, i)
+		}
+
+		instance, err := newInstance(c, w.TenantID, &wl, w.Volumes, name)
 		if err != nil {
 			e = errors.Wrap(err, "Error creating instance")
 			continue

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -200,6 +200,17 @@ func (c *controller) startWorkload(w types.WorkloadRequest) ([]*types.Instance, 
 			name = fmt.Sprintf("%s-%d", name, i)
 		}
 
+		id, err := c.ds.ResolveInstance(w.TenantID, name)
+		if err != nil {
+			e = errors.Wrap(err, "error trying to resolve name")
+			continue
+		}
+
+		if id != "" {
+			e = fmt.Errorf("Instance name already in use: %s", name)
+			continue
+		}
+
 		instance, err := newInstance(c, w.TenantID, &wl, w.Volumes, name)
 		if err != nil {
 			e = errors.Wrap(err, "Error creating instance")

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -336,6 +336,30 @@ func TestStartWorkload(t *testing.T) {
 	defer client.Shutdown()
 }
 
+func TestNamedWorkload(t *testing.T) {
+	var reason payloads.StartFailureReason
+
+	client, instances := testStartWorkload(t, 1, false, reason)
+	defer client.Shutdown()
+
+	if len(instances) != 1 {
+		t.Errorf("Expected one instance created")
+	}
+
+	sds, err := ctl.ListServersDetail(instances[0].TenantID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(sds) != 1 {
+		t.Errorf("Expected one server detail")
+	}
+
+	if sds[0].Name != "test" {
+		t.Errorf("Instance name not as expected: %s", sds[0].Name)
+	}
+}
+
 func TestStartTracedWorkload(t *testing.T) {
 	client := testStartTracedWorkload(t)
 	defer client.Shutdown()
@@ -1046,6 +1070,7 @@ func testStartWorkload(t *testing.T, num int, fail bool, reason payloads.StartFa
 		WorkloadID: wls[0].ID,
 		TenantID:   tenant.ID,
 		Instances:  num,
+		Name:       "test",
 	}
 	instances, err := ctl.startWorkload(w)
 	if err != nil {

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -240,7 +240,7 @@ func BenchmarkNewConfig(b *testing.B) {
 	b.ResetTimer()
 	noVolumes := []storage.BlockDevice{}
 	for n := 0; n < b.N; n++ {
-		_, err := newConfig(ctl, &wls[0], id.String(), tenant.ID, noVolumes)
+		_, err := newConfig(ctl, &wls[0], id.String(), tenant.ID, noVolumes, fmt.Sprintf("test-%d", n))
 		if err != nil {
 			b.Error(err)
 		}
@@ -1340,7 +1340,7 @@ func TestStorageConfig(t *testing.T) {
 	id := uuid.Generate()
 
 	noVolumes := []storage.BlockDevice{}
-	_, err = newConfig(ctl, &wls[0], id.String(), tenant.ID, noVolumes)
+	_, err = newConfig(ctl, &wls[0], id.String(), tenant.ID, noVolumes, "test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -62,7 +62,7 @@ func isCNCIWorkload(workload *types.Workload) bool {
 }
 
 func newInstance(ctl *controller, tenantID string, workload *types.Workload,
-	volumes []storage.BlockDevice) (*instance, error) {
+	volumes []storage.BlockDevice, name string) (*instance, error) {
 	id := uuid.Generate()
 
 	config, err := newConfig(ctl, workload, id.String(), tenantID, volumes)
@@ -81,6 +81,7 @@ func newInstance(ctl *controller, tenantID string, workload *types.Workload,
 		Subnet:     config.sc.Start.Networking.Subnet,
 		MACAddress: config.mac,
 		CreateTime: time.Now(),
+		Name:       name,
 	}
 
 	i := &instance{

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -65,6 +65,17 @@ func newInstance(ctl *controller, tenantID string, workload *types.Workload,
 	volumes []storage.BlockDevice, name string) (*instance, error) {
 	id := uuid.Generate()
 
+	if name != "" {
+		existingID, err := ctl.ds.ResolveInstance(tenantID, name)
+		if err != nil {
+			return nil, errors.Wrap(err, "error trying to resolve name")
+		}
+
+		if existingID != "" {
+			return nil, fmt.Errorf("Instance name already in use: %s", name)
+		}
+	}
+
 	config, err := newConfig(ctl, workload, id.String(), tenantID, volumes)
 	if err != nil {
 		return nil, err

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -384,14 +384,12 @@ func newConfig(ctl *controller, wl *types.Workload, instanceID string, tenantID 
 	}
 
 	// handle storage resources in workload definition
-	if len(wl.Storage) > 0 {
-		for i := range wl.Storage {
-			workloadStorage, err := getStorage(ctl, wl.Storage[i], tenantID, instanceID)
-			if err != nil {
-				return config, err
-			}
-			storage = append(storage, workloadStorage)
+	for i := range wl.Storage {
+		workloadStorage, err := getStorage(ctl, wl.Storage[i], tenantID, instanceID)
+		if err != nil {
+			return config, err
 		}
+		storage = append(storage, workloadStorage)
 	}
 
 	// hardcode persistence until changes can be made to workload

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -76,7 +76,7 @@ func newInstance(ctl *controller, tenantID string, workload *types.Workload,
 		}
 	}
 
-	config, err := newConfig(ctl, workload, id.String(), tenantID, volumes)
+	config, err := newConfig(ctl, workload, id.String(), tenantID, volumes, name)
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +286,7 @@ func controllerStorageResourceFromPayload(volume payloads.StorageResource) (s ty
 }
 
 func newConfig(ctl *controller, wl *types.Workload, instanceID string, tenantID string,
-	volumes []storage.BlockDevice) (config, error) {
+	volumes []storage.BlockDevice, name string) (config, error) {
 
 	var metaData userData
 	var config config
@@ -336,6 +336,9 @@ func newConfig(ctl *controller, wl *types.Workload, instanceID string, tenantID 
 		// set the hostname and uuid for userdata
 		metaData.UUID = instanceID
 		metaData.Hostname = instanceID
+		if name != "" {
+			metaData.Hostname = name
+		}
 
 		// handle storage resources for just this instance
 		for _, volume := range volumes {

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -2393,3 +2393,23 @@ func (ds *Datastore) GetQuotas(tenantID string) ([]types.QuotaDetails, error) {
 func (ds *Datastore) UpdateQuotas(tenantID string, qds []types.QuotaDetails) error {
 	return ds.db.updateQuotas(tenantID, qds)
 }
+
+// ResolveInstance maps an instance name to an uuid, returning "" if not found
+// TODO: Replace this O(n) algorithm with another name to id map.
+func (ds *Datastore) ResolveInstance(tenantID string, name string) (string, error) {
+	ds.tenantsLock.RLock()
+	defer ds.tenantsLock.RUnlock()
+
+	t, ok := ds.tenants[tenantID]
+	if !ok {
+		return "", fmt.Errorf("Tenant not found: %s", tenantID)
+	}
+
+	for _, i := range t.instances {
+		if i.Name == name || i.ID == name {
+			return i.ID, nil
+		}
+	}
+
+	return "", nil
+}

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -2654,6 +2654,15 @@ func TestAddNamedInstance(t *testing.T) {
 	if instances[0].Name != "test-instance" {
 		t.Fatalf("Instance does not have expected name")
 	}
+
+	id, err := ds.ResolveInstance(tenant.ID, "test-instance")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if id != instances[0].ID {
+		t.Fatalf("Failed to resolve instance name to ID")
+	}
 }
 
 var ds *Datastore

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -43,7 +43,7 @@ func newTenantHardwareAddr(ip net.IP) (hw net.HardwareAddr) {
 	return
 }
 
-func addTestInstance(tenant *types.Tenant, workload types.Workload) (instance *types.Instance, err error) {
+func addInstance(tenant *types.Tenant, workload types.Workload, name string) (instance *types.Instance, err error) {
 	id := uuid.Generate()
 
 	ip, err := ds.AllocateTenantIP(tenant.ID)
@@ -68,6 +68,7 @@ func addTestInstance(tenant *types.Tenant, workload types.Workload) (instance *t
 		CNCI:       false,
 		IPAddress:  ip.String(),
 		MACAddress: mac.String(),
+		Name:       name,
 	}
 
 	err = ds.AddInstance(instance)
@@ -76,6 +77,22 @@ func addTestInstance(tenant *types.Tenant, workload types.Workload) (instance *t
 	}
 
 	return
+}
+
+func addTestInstance(tenant *types.Tenant, workload types.Workload) (*types.Instance, error) {
+	return addInstance(tenant, workload, "test")
+}
+
+func addTestInstances(tenant *types.Tenant, workload types.Workload, count int) ([]*types.Instance, error) {
+	instances := make([]*types.Instance, 0)
+	for i := 0; i < count; i++ {
+		instance, err := addInstance(tenant, workload, fmt.Sprintf("test-%d", i))
+		if err != nil {
+			return make([]*types.Instance, 0), err
+		}
+		instances = append(instances, instance)
+	}
+	return instances, nil
 }
 
 func addTestWorkload(tenantID string) error {
@@ -164,14 +181,9 @@ func addTestInstanceStats(t *testing.T) ([]*types.Instance, payloads.Stat) {
 		t.Fatal("No Workloads Found")
 	}
 
-	var instances []*types.Instance
-
-	for i := 0; i < 10; i++ {
-		instance, err := addTestInstance(tenant, wls[0])
-		if err != nil {
-			t.Fatal(err)
-		}
-		instances = append(instances, instance)
+	instances, err := addTestInstances(tenant, wls[0], 10)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	var stats []payloads.InstanceStat
@@ -374,11 +386,9 @@ func TestGetAllInstances(t *testing.T) {
 		t.Fatal("No Workloads Found")
 	}
 
-	for i := 0; i < 10; i++ {
-		_, err = addTestInstance(tenant, wls[0])
-		if err != nil {
-			t.Fatal(err)
-		}
+	_, err = addTestInstances(tenant, wls[0], 10)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	instances, err := ds.GetAllInstances()
@@ -409,11 +419,9 @@ func TestGetAllInstancesFromTenant(t *testing.T) {
 		t.Fatal("No Workloads Found")
 	}
 
-	for i := 0; i < 10; i++ {
-		_, err = addTestInstance(tenant, wls[0])
-		if err != nil {
-			t.Fatal(err)
-		}
+	_, err = addTestInstances(tenant, wls[0], 10)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// if we don't get 10 eventually, the test will timeout and fail
@@ -491,14 +499,9 @@ func TestHandleStats(t *testing.T) {
 		t.Fatal("No Workloads Found")
 	}
 
-	var instances []*types.Instance
-
-	for i := 0; i < 10; i++ {
-		instance, err := addTestInstance(tenant, wls[0])
-		if err != nil {
-			t.Fatal(err)
-		}
-		instances = append(instances, instance)
+	instances, err := addTestInstances(tenant, wls[0], 10)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	var stats []payloads.InstanceStat
@@ -565,14 +568,9 @@ func TestGetInstanceLastStats(t *testing.T) {
 		t.Fatal("No Workloads Found")
 	}
 
-	var instances []*types.Instance
-
-	for i := 0; i < 10; i++ {
-		instance, err := addTestInstance(tenant, wls[0])
-		if err != nil {
-			t.Fatal(err)
-		}
-		instances = append(instances, instance)
+	instances, err := addTestInstances(tenant, wls[0], 10)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	var stats []payloads.InstanceStat
@@ -628,14 +626,9 @@ func TestGetNodeLastStats(t *testing.T) {
 		t.Fatal("No Workloads Found")
 	}
 
-	var instances []*types.Instance
-
-	for i := 0; i < 10; i++ {
-		instance, err := addTestInstance(tenant, wls[0])
-		if err != nil {
-			t.Fatal(err)
-		}
-		instances = append(instances, instance)
+	instances, err := addTestInstances(tenant, wls[0], 10)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	var stats []payloads.InstanceStat

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -2622,6 +2622,40 @@ func TestDeleteWorkload(t *testing.T) {
 	}
 }
 
+func TestAddNamedInstance(t *testing.T) {
+	tenant, err := addTestTenant()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wls, err := ds.GetWorkloads(tenant.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(wls) == 0 {
+		t.Fatal("No Workloads Found")
+	}
+
+	_, err = addInstance(tenant, wls[0], "test-instance")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	instances, err := ds.GetAllInstancesFromTenant(tenant.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(instances) != 1 {
+		t.Fatalf("Expected one instance added")
+	}
+
+	if instances[0].Name != "test-instance" {
+		t.Fatalf("Instance does not have expected name")
+	}
+}
+
 var ds *Datastore
 
 var workloadsPath = flag.String("workloads_path", "../../workloads", "path to yaml files")

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -473,7 +473,7 @@ func (ds *sqliteDB) exec(db *sql.DB, cmd string) error {
 		return err
 	}
 
-	tx.Commit()
+	err = tx.Commit()
 
 	return err
 }

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -128,7 +128,8 @@ func (d instanceData) Init() error {
 		name string,
 		foreign key(tenant_id) references tenants(id),
 		foreign key(workload_id) references workload_template(id),
-		unique(tenant_id, ip, mac_address)
+		unique(tenant_id, ip, mac_address),
+		unique(tenant_id, name)
 		);`
 
 	return d.ds.exec(d.db, cmd)

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -505,7 +505,7 @@ func (ds *sqliteDB) create(tableName string, record ...interface{}) error {
 	}
 
 	args := strings.Join(values, ",")
-	cmd := "INSERT or IGNORE into " + tableName + " VALUES (" + args + ");"
+	cmd := "INSERT into " + tableName + " VALUES (" + args + ");"
 
 	return ds.exec(db, cmd)
 }

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -125,6 +125,7 @@ func (d instanceData) Init() error {
 		subnet string,
 		ip string,
 		create_time DATETIME,
+		name string,
 		foreign key(tenant_id) references tenants(id),
 		foreign key(workload_id) references workload_template(id),
 		unique(tenant_id, ip, mac_address)
@@ -1283,7 +1284,8 @@ func (ds *sqliteDB) getInstances() ([]*types.Instance, error) {
 		mac_address,
 		vnic_uuid,
 		subnet,
-		ip
+		ip,
+		name
 	FROM instances
 	LEFT JOIN latest
 	ON instances.id = latest.instance_id
@@ -1302,7 +1304,7 @@ func (ds *sqliteDB) getInstances() ([]*types.Instance, error) {
 
 		var sshPort sql.NullInt64
 
-		err = rows.Scan(&i.ID, &i.TenantID, &i.State, &i.WorkloadID, &i.SSHIP, &sshPort, &i.NodeID, &i.MACAddress, &i.VnicUUID, &i.Subnet, &i.IPAddress)
+		err = rows.Scan(&i.ID, &i.TenantID, &i.State, &i.WorkloadID, &i.SSHIP, &sshPort, &i.NodeID, &i.MACAddress, &i.VnicUUID, &i.Subnet, &i.IPAddress, &i.Name)
 		if err != nil {
 			tx.Rollback()
 			ds.tdbLock.RUnlock()
@@ -1362,7 +1364,8 @@ func (ds *sqliteDB) getTenantInstances(tenantID string) (map[string]*types.Insta
 		mac_address,
 		vnic_uuid,
 		subnet,
-		ip
+		ip,
+		name
 	FROM instances
 	LEFT JOIN latest
 	ON instances.id = latest.instance_id
@@ -1385,7 +1388,7 @@ func (ds *sqliteDB) getTenantInstances(tenantID string) (map[string]*types.Insta
 
 		i := &types.Instance{}
 
-		err = rows.Scan(&i.ID, &i.TenantID, &i.State, &sshIP, &sshPort, &i.WorkloadID, &nodeID, &i.MACAddress, &i.VnicUUID, &i.Subnet, &i.IPAddress)
+		err = rows.Scan(&i.ID, &i.TenantID, &i.State, &sshIP, &sshPort, &i.WorkloadID, &nodeID, &i.MACAddress, &i.VnicUUID, &i.Subnet, &i.IPAddress, &i.Name)
 		if err != nil {
 			tx.Rollback()
 			ds.tdbLock.RUnlock()
@@ -1423,7 +1426,7 @@ func (ds *sqliteDB) getTenantInstances(tenantID string) (map[string]*types.Insta
 func (ds *sqliteDB) addInstance(instance *types.Instance) error {
 	ds.dbLock.Lock()
 
-	err := ds.create("instances", instance.ID, instance.TenantID, instance.WorkloadID, instance.MACAddress, instance.VnicUUID, instance.Subnet, instance.IPAddress, instance.CreateTime.Format(time.RFC3339Nano))
+	err := ds.create("instances", instance.ID, instance.TenantID, instance.WorkloadID, instance.MACAddress, instance.VnicUUID, instance.Subnet, instance.IPAddress, instance.CreateTime.Format(time.RFC3339Nano), instance.Name)
 
 	ds.dbLock.Unlock()
 	return err

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -32,8 +32,8 @@ var dbCount = 1
 func getPersistentStore() (persistentStore, error) {
 	ps := &sqliteDB{}
 	config := Config{
-		PersistentURI:     "file:memdb" + string(dbCount) + "?mode=memory&cache=shared",
-		TransientURI:      "file:memdb" + string(dbCount+1) + "?mode=memory&cache=shared",
+		PersistentURI:     fmt.Sprintf("file:memdb%d?mode=memory&cache=shared", dbCount),
+		TransientURI:      fmt.Sprintf("file:memdb%d?mode=memory&cache=shared", dbCount+1),
 		InitWorkloadsPath: *workloadsPath,
 	}
 	err := ps.init(config)

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -1127,3 +1127,38 @@ func TestSQLiteDBUpdateQuotas(t *testing.T) {
 		t.Fatal("Added quota not found")
 	}
 }
+
+func TestInstanceNameConstraint(t *testing.T) {
+	db, err := getPersistentStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tenantID := uuid.Generate().String()
+	i := types.Instance{
+		ID:         uuid.Generate().String(),
+		TenantID:   tenantID,
+		WorkloadID: uuid.Generate().String(),
+		IPAddress:  "172.16.0.2",
+		Name:       "test",
+	}
+
+	err = db.addInstance(&i)
+	if err != nil {
+		t.Fatal("unable to store instance")
+	}
+
+	i2 := types.Instance{
+		ID:         uuid.Generate().String(),
+		TenantID:   tenantID,
+		WorkloadID: uuid.Generate().String(),
+		IPAddress:  "172.16.0.3",
+		Name:       "test",
+	}
+
+	err = db.addInstance(&i2)
+
+	if err == nil {
+		t.Fatal("Expected instance add to fail (duplicate name)")
+	}
+}

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -69,6 +69,7 @@ func instanceToServer(ctl *controller, instance *types.Instance) (compute.Server
 		SSHIP:   instance.SSHIP,
 		SSHPort: instance.SSHPort,
 		Created: instance.CreateTime,
+		Name:    instance.Name,
 	}
 
 	return server, nil
@@ -374,6 +375,7 @@ func (c *controller) CreateServer(tenant string, server compute.CreateServerRequ
 		Instances:  nInstances,
 		TraceLabel: label,
 		Volumes:    volumes,
+		Name:       server.Server.Name,
 	}
 	var e error
 	instances, err := c.startWorkload(w)

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -366,13 +366,7 @@ func (c *controller) CreateServer(tenant string, server compute.CreateServerRequ
 	}
 	volumes := abstractBlockDevices(blockDeviceMappings)
 
-	// openstack doesn't allow us to use our traced start workload
-	// functionality. So we use the name field in our cli to indicate
-	// that we want to trace this workload.
-	label := ""
-	if server.Server.Name != "" {
-		label = server.Server.Name
-	}
+	label := server.Server.Metadata["label"]
 
 	w := types.WorkloadRequest{
 		WorkloadID: server.Server.Flavor,

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"sort"
 	"strconv"
 
@@ -358,6 +359,13 @@ func (c *controller) CreateServer(tenant string, server compute.CreateServerRequ
 		nInstances = server.Server.MaxInstances
 	} else if server.Server.MinInstances > 0 {
 		nInstances = server.Server.MinInstances
+	}
+
+	if server.Server.Name != "" {
+		r := regexp.MustCompile("^[a-z0-9-]*$")
+		if !r.MatchString(server.Server.Name) {
+			return server, fmt.Errorf("Requested name must only contain lowercase letters, numbers and hyphens")
+		}
 	}
 
 	blockDeviceMappings := server.Server.BlockDeviceMappings

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -362,9 +362,10 @@ func (c *controller) CreateServer(tenant string, server compute.CreateServerRequ
 	}
 
 	if server.Server.Name != "" {
-		r := regexp.MustCompile("^[a-z0-9-]*$")
+		// Between 1 and 64 (HOST_NAME_MAX) alphanum (+ "-")
+		r := regexp.MustCompile("^[a-z0-9-]{1,64}?$")
 		if !r.MatchString(server.Server.Name) {
-			return server, fmt.Errorf("Requested name must only contain lowercase letters, numbers and hyphens")
+			return server, fmt.Errorf("Requested name must be between 1 and 64 lowercase letters, numbers and hyphens")
 		}
 	}
 

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -120,6 +120,7 @@ type Instance struct {
 	CNCI        bool                `json:"-"`
 	Attachments []StorageAttachment `json:"-"`
 	CreateTime  time.Time           `json:"-"`
+	Name        string              `json:"name"`
 }
 
 // SortedInstancesByID implements sort.Interface for Instance by ID string

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -102,6 +102,7 @@ type WorkloadRequest struct {
 	Instances  int
 	TraceLabel string
 	Volumes    []storage.BlockDevice
+	Name       string
 }
 
 // Instance contains information about an instance of a workload.

--- a/openstack/compute/api.go
+++ b/openstack/compute/api.go
@@ -274,6 +274,7 @@ type CreateServerRequest struct {
 		MaxInstances        int                    `json:"max_count"`
 		MinInstances        int                    `json:"min_count"`
 		BlockDeviceMappings []BlockDeviceMappingV2 `json:"block_device_mapping_v2,omitempty"`
+		Metadata            map[string]string      `json:"metadata,omitempty"`
 	} `json:"server"`
 }
 

--- a/openstack/compute/api_test.go
+++ b/openstack/compute/api_test.go
@@ -43,7 +43,7 @@ var tests = []test{
 		createServer,
 		`{"server":{"name":"new-server-test","imageRef": "http://glance.openstack.example.com/images/70a599e0-31e7-49b7-b260-868f441e862b","flavorRef":"http://openstack.example.com/flavors/1","metadata":{"My Server Name":"Apache1"}}}`,
 		http.StatusAccepted,
-		`{"server":{"id":"validServerID","name":"new-server-test","imageRef":"http://glance.openstack.example.com/images/70a599e0-31e7-49b7-b260-868f441e862b","flavorRef":"http://openstack.example.com/flavors/1","max_count":0,"min_count":0}}`,
+		`{"server":{"id":"validServerID","name":"new-server-test","imageRef":"http://glance.openstack.example.com/images/70a599e0-31e7-49b7-b260-868f441e862b","flavorRef":"http://openstack.example.com/flavors/1","max_count":0,"min_count":0,"metadata":{"My Server Name":"Apache1"}}}`,
 	},
 	{
 		"GET",


### PR DESCRIPTION
This PR implements some basic support for names for instances. These names must be tenant unique and will be used for the hostname inside the instance (and thus the DHCP created DNS entry.)