### PR TITLE
kubicle: A tool for installing kubernetes clusters on ciao

### DIFF
--- a/_release/bat/workload_bat/workload_bat_test.go
+++ b/_release/bat/workload_bat/workload_bat_test.go
@@ -38,7 +38,7 @@ users:
 ...
 `
 
-const vmWorkloadImageName = "Fedora Cloud Base 24-1.2"
+const vmWorkloadImageName = "Ubuntu Server 16.04"
 
 func getWorkloadSource(ctx context.Context, t *testing.T, tenant string) bat.Source {
 	// get the Image ID to use.

--- a/bat/external_ip.go
+++ b/bat/external_ip.go
@@ -1,0 +1,94 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package bat
+
+import "context"
+
+// ExternalIP contains information about a single external ip.
+type ExternalIP struct {
+	ExternalIP string `json:"external_ip"`
+	InternalIP string `json:"internal_ip"`
+	InstanceID string `json:"instance_id"`
+	TenantID   string `json:"tenant_id"`
+	PoolName   string `json:"pool_name"`
+}
+
+// CreateExternalIPPool creates a new pool for external ips.  The pool is created
+// using the ciao-cli pool create command.  An error will be returned if the
+// following environment are not set;  CIAO_IDENTITY,  CIAO_CONTROLLER,
+// CIAO_ADMIN_USERNAME, CIAO_ADMIN_PASSWORD.
+func CreateExternalIPPool(ctx context.Context, tenant, name string) error {
+	args := []string{"pool", "create", "-name", name}
+	_, err := RunCIAOCLIAsAdmin(ctx, tenant, args)
+	return err
+}
+
+// AddExternalIPToPool adds an external ips to an existing pool.  The address
+// is added using the ciao-cli pool add command.  An error will be returned if the
+// following environment are not set;  CIAO_IDENTITY,  CIAO_CONTROLLER,
+// CIAO_ADMIN_USERNAME, CIAO_ADMIN_PASSWORD.
+func AddExternalIPToPool(ctx context.Context, tenant, name, ip string) error {
+	args := []string{"pool", "add", "-name", name, ip}
+	_, err := RunCIAOCLIAsAdmin(ctx, tenant, args)
+	return err
+}
+
+// MapExternalIP maps an external ip from a given pool to an instance.  The
+// address is mapped using the ciao-cli external-ip map command.  An error
+// will be returned if the following environment are not set;  CIAO_IDENTITY,
+// CIAO_CONTROLLER, CIAO_USERNAME, CIAO_PASSWORD.
+func MapExternalIP(ctx context.Context, tenant, pool, instance string) error {
+	args := []string{"external-ip", "map", "-instance", instance, "-pool", pool}
+	_, err := RunCIAOCLI(ctx, tenant, args)
+	return err
+}
+
+// UnmapExternalIP unmaps an external ip from an instance.  The address is unmapped
+// using the ciao-cli external-ip unmap command.  An error will be returned if the
+// following environment are not set;  CIAO_IDENTITY, CIAO_CONTROLLER, CIAO_USERNAME,
+// CIAO_PASSWORD.
+func UnmapExternalIP(ctx context.Context, tenant, address string) error {
+	args := []string{"external-ip", "unmap", "-address", address}
+	_, err := RunCIAOCLI(ctx, tenant, args)
+	return err
+}
+
+// DeleteExternalIPPool deletes an external-ip pool.  The pool is deleted using
+// the ciao-cli pool delete command.  An error will be returned if the
+// following environment are not set;  CIAO_IDENTITY,  CIAO_CONTROLLER,
+// CIAO_ADMIN_USERNAME, CIAO_ADMIN_PASSWORD.
+func DeleteExternalIPPool(ctx context.Context, tenant, name string) error {
+	args := []string{"pool", "delete", "-name", name}
+	_, err := RunCIAOCLIAsAdmin(ctx, tenant, args)
+	return err
+}
+
+// ListExternalIPs returns detailed information about all the external ips
+// defined for the given tenant.  The information is retrieved using the
+// ciao-cli external-ip list command.  An error will be returned if the
+// following environment are not set;  CIAO_IDENTITY,  CIAO_CONTROLLER,
+// CIAO_ADMIN_USERNAME, CIAO_ADMIN_PASSWORD.
+func ListExternalIPs(ctx context.Context, tenant string) ([]*ExternalIP, error) {
+	var externalIPs []*ExternalIP
+	args := []string{"external-ip", "list", "-f", "{{tojson .}}"}
+	err := RunCIAOCLIAsAdminJS(ctx, tenant, args, &externalIPs)
+	if err != nil {
+		return nil, err
+	}
+
+	return externalIPs, nil
+}

--- a/k8s/kubicle/cloudinit.go
+++ b/k8s/kubicle/cloudinit.go
@@ -21,13 +21,13 @@ vm_type: qemu
 fw_type: legacy
 defaults:
     vcpus: {{.VCPUs}}
-    mem_mb: {{.RAM}}
+    mem_mb: {{.RAMMiB}}
 cloud_init: "{{.UserDataFile}}"
 disks:
   - source:
        service: image
        id: "{{.ImageUUID}}"
-    size: {{.Disk}}
+    size: {{.DiskGiB}}
     ephemeral: true
     bootable: true
 `

--- a/k8s/kubicle/cloudinit.go
+++ b/k8s/kubicle/cloudinit.go
@@ -1,0 +1,106 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+const workloadTemplate = `description: "{{.Description}}"
+vm_type: qemu
+fw_type: legacy
+defaults:
+    vcpus: {{.VCPUs}}
+    mem_mb: {{.RAM}}
+cloud_init: "{{.UserDataFile}}"
+disks:
+  - source:
+       service: image
+       id: "{{.ImageUUID}}"
+    size: {{.Disk}}
+    ephemeral: true
+    bootable: true
+`
+
+const udCommonTemplate = `{{- define "PROXIES" -}}
+{{if len .HTTPSProxy }}https_proxy={{.HTTPSProxy}} {{end -}}
+{{if len .HTTPProxy }}http_proxy={{.HTTPProxy}} {{end -}}
+{{end -}}
+---
+#cloud-config
+{{- if len (or $.HTTPProxy $.HTTPSProxy "")}}
+write_files:
+ - content: |
+     [Service]
+     Environment={{if len .HTTPProxy}}"HTTP_PROXY={{$.HTTPProxy}}" {{end}}{{if len .HTTPSProxy}}"HTTPS_PROXY={{.HTTPSProxy}}{{end}}"{{if len .NoProxy}} "NO_PROXY={{.NoProxy}}{{end}}"
+   path: /etc/systemd/system/docker.service.d/http-proxy.conf
+{{- end}}
+
+apt:
+{{- if len $.HTTPProxy }}
+  proxy: "{{$.HTTPProxy}}"
+{{- end}}
+{{- if len $.HTTPSProxy }}
+  https_proxy: "{{$.HTTPSProxy}}"
+{{- end}}
+
+users:
+  - name: {{.User}}
+    gecos: k8s Demo User
+    groups: docker
+    lock-passwd: true
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh-authorized-keys:
+      - {{.PublicKey}}
+
+runcmd:
+ - systemctl restart networking`
+
+const udMasterTemplate = `
+ - echo "export KUBECONFIG=/home/{{.User}}/admin.conf" > /home/{{.User}}/.bash_aliases
+{{- if len .HTTPSProxy }}
+ - echo "export https_proxy={{.HTTPSProxy}}" >> /home/{{.User}}/.bash_aliases
+{{- end}}
+{{- if len .HTTPProxy }}
+ - echo "export http_proxy={{.HTTPProxy}}" >> /home/{{.User}}/.bash_aliases
+{{- end}}
+ - echo "export no_proxy={{if len .NoProxy}}{{.NoProxy}},{{end}}` + "`hostname -i`" + `" >> /home/{{.User}}/.bash_aliases
+ - chown {{.User}}:{{.User}} /home/{{.User}}/.bash_aliases
+ - apt-get update && apt-get install -y apt-transport-https
+ - {{template "PROXIES" .}}curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+ - echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" >/etc/apt/sources.list.d/kubernetes.list
+ - apt-get update
+ - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y docker-engine
+ - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+ - {{template "PROXIES" .}}no_proxy=` + "`hostname -i`" + ` kubeadm init --pod-network-cidr 10.244.0.0/16 --token {{.Token}} {{if len .ExternalIP}}--apiserver-cert-extra-sans={{.ExternalIP}}{{end}}
+ - cp /etc/kubernetes/admin.conf /home/{{.User}}/
+ - chown {{.User}}:{{.User}} /home/{{.User}}/admin.conf
+ - {{template "PROXIES" .}}wget https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel-rbac.yml
+ - KUBECONFIG=/home/{{.User}}/admin.conf kubectl create -f kube-flannel-rbac.yml
+ - {{template "PROXIES" .}}wget https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+ - KUBECONFIG=/home/{{.User}}/admin.conf kubectl create --namespace kube-system -f kube-flannel.yml
+ - cat /home/{{.User}}/admin.conf | sed -E 's/\/\/[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/\/\/{{.ExternalIP}}/' | curl -T - {{.PhoneHomeIP}}:9000
+...
+`
+
+const udNodeTemplate = `
+ - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get update && apt-get install -y apt-transport-https
+ - {{template "PROXIES" .}} curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+ - echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" >/etc/apt/sources.list.d/kubernetes.list
+ - apt-get update
+ - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y docker-engine
+ - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+ - kubeadm join --token {{.Token}} {{.MasterIP}}:6443
+...
+`

--- a/k8s/kubicle/create.go
+++ b/k8s/kubicle/create.go
@@ -563,6 +563,20 @@ func (c *creator) waitForAdminConf(ctx context.Context) error {
 	return err
 }
 
+func (c *creator) alreadyExists(ctx context.Context) bool {
+	_, err := getWorkloadUUIDs(ctx, workerWorkloadName)
+	if err == nil {
+		return true
+	}
+
+	_, err = getWorkloadUUIDs(ctx, masterWorkloadName)
+	if err == nil {
+		return true
+	}
+
+	return false
+}
+
 func newCreator() (*creator, error) {
 	c := &creator{}
 
@@ -601,6 +615,10 @@ func createCluster(ctx context.Context) (err error) {
 	c, err = newCreator()
 	if err != nil {
 		return err
+	}
+
+	if c.alreadyExists(ctx) {
+		return fmt.Errorf("kubicle has already created a cluster for this tenant")
 	}
 
 	defer func() {

--- a/k8s/kubicle/create.go
+++ b/k8s/kubicle/create.go
@@ -187,8 +187,8 @@ func (c *creator) createMasterConfig() {
 	mc := &masterConfig{
 		baseConfig: baseConfig{
 			VCPUs:        c.opts.masterVM.vCPUs,
-			RAM:          c.opts.masterVM.mem,
-			Disk:         c.opts.masterVM.disk,
+			RAMMiB:       c.opts.masterVM.memMiB,
+			DiskGiB:      c.opts.masterVM.diskGiB,
 			User:         c.opts.user,
 			ImageUUID:    c.opts.imageUUID,
 			PublicKey:    c.pk,
@@ -212,9 +212,9 @@ func (c *creator) createMasterConfig() {
 func (c *creator) createWorkerConfig() {
 	wc := &workerConfig{
 		baseConfig: baseConfig{
-			VCPUs:        c.opts.masterVM.vCPUs,
-			RAM:          c.opts.masterVM.mem,
-			Disk:         c.opts.masterVM.disk,
+			VCPUs:        c.opts.workerVM.vCPUs,
+			RAMMiB:       c.opts.workerVM.memMiB,
+			DiskGiB:      c.opts.workerVM.diskGiB,
 			User:         c.opts.user,
 			ImageUUID:    c.opts.imageUUID,
 			PublicKey:    c.pk,

--- a/k8s/kubicle/create.go
+++ b/k8s/kubicle/create.go
@@ -1,0 +1,644 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/01org/ciao/bat"
+	"github.com/vishvananda/netlink"
+)
+
+const externalIPPool = "k8s-pool"
+
+var masterUDTmpl *template.Template
+var workerUDTmpl *template.Template
+var workloadTmpl *template.Template
+
+type masterConfig struct {
+	baseConfig
+	ExternalIP  string
+	PhoneHomeIP string
+}
+
+type workerConfig struct {
+	baseConfig
+	MasterIP string
+}
+
+type creator struct {
+	opts            *options
+	pk              string
+	token           string
+	pc              *proxyConfig
+	mc              *masterConfig
+	wc              *workerConfig
+	cwd             string
+	masterPath      string
+	masterUDPath    string
+	masterWkldUUID  string
+	masterInstUUID  string
+	masterIP        string
+	workerPath      string
+	workerUDPath    string
+	workerWkldUUID  string
+	workerInstUUIDs []string
+	pool            string
+	externalIP      string
+	listener        net.Listener
+	errCh           chan error
+	adminPath       string
+}
+
+func init() {
+	masterUDTmpl = template.Must(template.New("masterUD").Parse(
+		udCommonTemplate + udMasterTemplate))
+	workerUDTmpl = template.Must(template.New("workerUD").Parse(
+		udCommonTemplate + udNodeTemplate))
+	workloadTmpl = template.Must(template.New("workloadTmpl").Parse(workloadTemplate))
+}
+
+// TODO: Code copied from ciao-down needs to be refactored
+func getProxy(upper, lower string) (string, error) {
+	proxy := os.Getenv(upper)
+	if proxy == "" {
+		proxy = os.Getenv(lower)
+	}
+
+	if proxy == "" {
+		return "", nil
+	}
+
+	if proxy[len(proxy)-1] == '/' {
+		proxy = proxy[:len(proxy)-1]
+	}
+
+	proxyURL, err := url.Parse(proxy)
+	if err != nil {
+		return "", fmt.Errorf("Failed to parse %s : %v", proxy, err)
+	}
+	return proxyURL.String(), nil
+}
+
+func getProxyConfig() (*proxyConfig, error) {
+	var err error
+	pc := &proxyConfig{}
+	pc.httpProxy, err = getProxy("http_proxy", "HTTP_PROXY")
+	if err != nil {
+		return nil, err
+	}
+	pc.httpsProxy, err = getProxy("https_proxy", "HTTPS_PROXY")
+	if err != nil {
+		return nil, err
+	}
+	pc.noProxy = os.Getenv("no_proxy")
+	return pc, nil
+}
+
+// TODO: Code copied from networking
+
+func validPhysicalLink(link netlink.Link) bool {
+	phyDevice := true
+
+	switch link.Type() {
+	case "device":
+	case "bond":
+	case "vlan":
+	case "macvlan":
+	case "bridge":
+		if strings.HasPrefix(link.Attrs().Name, "docker") ||
+			strings.HasPrefix(link.Attrs().Name, "virbr") {
+			phyDevice = false
+		}
+	default:
+		phyDevice = false
+	}
+
+	if (link.Attrs().Flags & net.FlagLoopback) != 0 {
+		return false
+	}
+
+	return phyDevice
+}
+
+func getFirstPhyDevice() string {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return ""
+	}
+
+	for _, link := range links {
+		if !validPhysicalLink(link) {
+			continue
+		}
+
+		addrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+		if err != nil || len(addrs) == 0 {
+			continue
+		}
+
+		return addrs[0].IP.String()
+	}
+
+	return ""
+}
+
+func genToken() (string, error) {
+	var buf [11]byte
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	_, err := io.ReadFull(r, buf[:])
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s.%s",
+		hex.EncodeToString(buf[:3]), hex.EncodeToString(buf[3:])), nil
+}
+
+func (c *creator) createMasterConfig() {
+	mc := &masterConfig{
+		baseConfig: baseConfig{
+			VCPUs:        c.opts.masterVM.vCPUs,
+			RAM:          c.opts.masterVM.mem,
+			Disk:         c.opts.masterVM.disk,
+			User:         c.opts.user,
+			ImageUUID:    c.opts.imageUUID,
+			PublicKey:    c.pk,
+			Token:        c.token,
+			UserDataFile: "k8s-master-ci.yaml",
+			Description:  masterWorkloadName,
+		},
+		ExternalIP: c.opts.externalIP,
+	}
+
+	if mc.ExternalIP != "" {
+		mc.PhoneHomeIP = getFirstPhyDevice()
+	}
+
+	mc.HTTPSProxy = c.pc.httpsProxy
+	mc.HTTPProxy = c.pc.httpProxy
+	mc.NoProxy = c.pc.noProxy
+	c.mc = mc
+}
+
+func (c *creator) createWorkerConfig() {
+	wc := &workerConfig{
+		baseConfig: baseConfig{
+			VCPUs:        c.opts.masterVM.vCPUs,
+			RAM:          c.opts.masterVM.mem,
+			Disk:         c.opts.masterVM.disk,
+			User:         c.opts.user,
+			ImageUUID:    c.opts.imageUUID,
+			PublicKey:    c.pk,
+			Token:        c.token,
+			UserDataFile: "k8s-worker-ci.yaml",
+			Description:  workerWorkloadName,
+		},
+		MasterIP: c.masterIP,
+	}
+
+	wc.HTTPSProxy = c.pc.httpsProxy
+	wc.HTTPProxy = c.pc.httpProxy
+	wc.NoProxy = c.pc.noProxy
+	c.wc = wc
+}
+
+func (c *creator) createMasterWorkloadDefinition() error {
+	var buf bytes.Buffer
+
+	err := workloadTmpl.Execute(&buf, c.mc)
+	if err != nil {
+		return err
+	}
+
+	// TODO might want to check to see if these files already
+	// exist and error if a -f is not provided.
+
+	c.masterPath = filepath.Join(c.cwd, "k8s-master.yaml")
+	err = ioutil.WriteFile(c.masterPath, buf.Bytes(), 0600)
+	if err != nil {
+		return err
+	}
+
+	buf.Reset()
+
+	err = masterUDTmpl.Execute(&buf, c.mc)
+	if err != nil {
+		_ = os.Remove(c.masterPath)
+		return err
+	}
+
+	c.masterUDPath = filepath.Join(c.cwd, c.mc.UserDataFile)
+
+	err = ioutil.WriteFile(c.masterUDPath, buf.Bytes(), 0600)
+	if err != nil {
+		_ = os.Remove(c.masterPath)
+		return err
+	}
+
+	return nil
+}
+
+func (c *creator) createWorkerWorkloadDefinition() error {
+	var buf bytes.Buffer
+
+	err := workloadTmpl.Execute(&buf, c.wc)
+	if err != nil {
+		return err
+	}
+
+	// TODO might want to check to see if these files already
+	// exist and error if a -f is not provided.
+
+	c.workerPath = filepath.Join(c.cwd, "k8s-worker.yaml")
+	err = ioutil.WriteFile(c.workerPath, buf.Bytes(), 0600)
+	if err != nil {
+		return err
+	}
+
+	buf.Reset()
+
+	err = workerUDTmpl.Execute(&buf, c.wc)
+	if err != nil {
+		_ = os.Remove(c.workerPath)
+		return err
+	}
+
+	c.workerUDPath = filepath.Join(c.cwd, c.wc.UserDataFile)
+
+	err = ioutil.WriteFile(c.workerUDPath, buf.Bytes(), 0600)
+	if err != nil {
+		_ = os.Remove(c.workerPath)
+		return err
+	}
+
+	return nil
+}
+
+func (c *creator) createMaster(ctx context.Context) error {
+	c.createMasterConfig()
+	c.startServer()
+	err := c.createMasterWorkloadDefinition()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if !c.opts.keep {
+			_ = os.Remove(c.masterPath)
+			_ = os.Remove(c.masterUDPath)
+		}
+	}()
+
+	id, err := bat.CreateWorkloadFromFile(ctx, false, "", c.masterPath)
+	if err != nil {
+		return fmt.Errorf("Failed to create master workload: %s", c.masterPath)
+	}
+	c.masterWkldUUID = id
+
+	ids, err := bat.LaunchInstances(ctx, "", c.masterWkldUUID, 1)
+	if err != nil {
+		return fmt.Errorf("Failed to launch master instance")
+	}
+	c.masterInstUUID = ids[0]
+
+	_, err = bat.WaitForInstancesLaunch(ctx, "", ids, true)
+	if err != nil {
+		return fmt.Errorf("Master instance failed to launch")
+	}
+
+	instance, err := bat.GetInstance(ctx, "", c.masterInstUUID)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve information about master instance")
+	}
+	c.masterIP = instance.PrivateIP
+
+	return err
+}
+
+func (c *creator) createWorkers(ctx context.Context) error {
+	c.createWorkerConfig()
+	err := c.createWorkerWorkloadDefinition()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if !c.opts.keep {
+			_ = os.Remove(c.workerPath)
+			_ = os.Remove(c.workerUDPath)
+		}
+	}()
+
+	id, err := bat.CreateWorkloadFromFile(ctx, false, "", c.workerPath)
+	if err != nil {
+		return err
+	}
+	c.workerWkldUUID = id
+
+	ids, err := bat.LaunchInstances(ctx, "", c.workerWkldUUID, c.opts.workers)
+	if err != nil {
+		return err
+	}
+	c.workerInstUUIDs = ids
+
+	_, err = bat.WaitForInstancesLaunch(ctx, "", c.workerInstUUIDs, true)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func (c *creator) createExternalIP(ctx context.Context) error {
+	err := bat.CreateExternalIPPool(ctx, "", externalIPPool)
+	if err != nil {
+		return fmt.Errorf("Unable to create external-ip pool %s", externalIPPool)
+	}
+
+	c.pool = externalIPPool
+
+	err = bat.AddExternalIPToPool(ctx, "", c.pool, c.mc.ExternalIP)
+	if err != nil {
+		return fmt.Errorf("Unable to add external-ip %s to pool %s",
+			c.mc.ExternalIP, externalIPPool)
+	}
+
+	err = bat.MapExternalIP(ctx, "", c.pool, c.masterInstUUID)
+	if err != nil {
+		return fmt.Errorf("Unable to map external-ip %s to instance %s",
+			c.mc.ExternalIP, c.masterInstUUID)
+	}
+	c.externalIP = c.mc.ExternalIP
+
+	return nil
+}
+
+func (c *creator) status() {
+	fmt.Println("\nk8s cluster successfully created")
+	fmt.Println("--------------------------------")
+	if c.opts.keep {
+		fmt.Println("Created workload definition files:")
+		fmt.Println(c.masterPath)
+		fmt.Println(c.masterUDPath)
+		fmt.Println(c.workerPath)
+		fmt.Println(c.workerUDPath)
+	}
+	fmt.Println("Created master:")
+	fmt.Printf(" - %s\n", c.masterInstUUID)
+	fmt.Printf("Created %d workers:\n", c.opts.workers)
+	for _, w := range c.workerInstUUIDs {
+		fmt.Printf(" - %s\n", w)
+	}
+
+	if c.externalIP != "" {
+		fmt.Println("Created external-ips:")
+		fmt.Printf("- %s\n", c.externalIP)
+		fmt.Println("Created pools:")
+		fmt.Printf("- %s\n", c.pool)
+	}
+
+	if c.adminPath != "" {
+		fmt.Println("To access k8s cluster:")
+		fmt.Printf("- export KUBECONFIG=%s\n", c.adminPath)
+		fmt.Println("- If you use proxies, set")
+		fmt.Printf("  - export no_proxy=$no_proxy,%s\n", c.mc.ExternalIP)
+	}
+}
+
+func deleteInstance(ctx context.Context, i string) error {
+	var err error
+	for tries := 0; tries < 10; tries++ {
+		tctx, cancel := context.WithTimeout(ctx, time.Second*15)
+		err = bat.DeleteInstanceAndWait(tctx, "", i)
+		cancel()
+		if err == nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			break
+		case <-time.After(time.Second):
+		}
+	}
+
+	return err
+}
+
+func (c *creator) cleanup() {
+	fmt.Fprintln(os.Stderr, "Error Detected")
+
+	if c.listener != nil {
+		_ = c.listener.Close()
+	}
+
+	if c.externalIP != "" {
+		fmt.Fprintf(os.Stderr, "Unmapping external-ip: %s\n", c.externalIP)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		_ = bat.UnmapExternalIP(ctx, "", c.externalIP)
+		cancel()
+	}
+
+	if c.pool != "" {
+		fmt.Fprintf(os.Stderr, "Deleting external-ip pool: %s\n", c.pool)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		_ = bat.DeleteExternalIPPool(ctx, "", c.pool)
+		cancel()
+	}
+
+	// TODO: This is slow
+	for _, i := range c.workerInstUUIDs {
+		fmt.Fprintf(os.Stderr, "Deleting worker instance: %s\n", i)
+		_ = deleteInstance(context.Background(), i)
+	}
+
+	if c.workerWkldUUID != "" {
+		fmt.Fprintf(os.Stderr, "Deleting worker workload: %s\n", c.workerWkldUUID)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		_ = bat.DeleteWorkload(ctx, "", c.workerWkldUUID)
+		cancel()
+	}
+
+	if c.masterInstUUID != "" {
+		fmt.Fprintf(os.Stderr, "Deleting master instance: %s\n", c.masterInstUUID)
+		_ = deleteInstance(context.Background(), c.masterInstUUID)
+	}
+
+	if c.masterWkldUUID != "" {
+		fmt.Fprintf(os.Stderr, "Deleting master workload: %s\n", c.masterWkldUUID)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		_ = bat.DeleteWorkload(ctx, "", c.masterWkldUUID)
+		cancel()
+	}
+}
+
+func startHTTPServer(adminPath string, listener net.Listener, errCh chan error) {
+	finished := false
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		d, err := ioutil.ReadAll(r.Body)
+		defer func() {
+			_ = listener.Close()
+		}()
+
+		if err != nil {
+			return
+		}
+		err = ioutil.WriteFile(adminPath, d, 0600)
+		if err != nil {
+			return
+		}
+
+		finished = true
+	})
+
+	server := &http.Server{}
+	go func() {
+		_ = server.Serve(listener)
+		if finished {
+			errCh <- nil
+		} else {
+			errCh <- fmt.Errorf("HTTP server exited prematurely")
+		}
+	}()
+}
+
+func (c *creator) startServer() {
+	if c.mc.PhoneHomeIP == "" {
+		return
+	}
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", c.mc.PhoneHomeIP, 9000))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Unable to create listener for HTTP server: %v", err)
+		return
+	}
+	c.listener = listener
+	c.errCh = make(chan error)
+	c.adminPath = filepath.Join(c.cwd, "admin.conf")
+	startHTTPServer(c.adminPath, listener, c.errCh)
+}
+
+func (c *creator) waitForAdminConf(ctx context.Context) error {
+	var err error
+	if c.listener == nil {
+		return err
+	}
+
+	fmt.Println("Instances launched.  Waiting for k8s cluster to start")
+	select {
+	case <-ctx.Done():
+		_ = c.listener.Close()
+		<-c.errCh
+		err = ctx.Err()
+	case err = <-c.errCh:
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
+		}
+	}
+
+	return err
+}
+
+func newCreator() (*creator, error) {
+	c := &creator{}
+
+	var err error
+	c.opts, err = createFlags()
+	if err != nil {
+		return nil, err
+	}
+
+	pk, err := ioutil.ReadFile(c.opts.publicKeyPath)
+	if err != nil {
+		return nil, err
+	}
+	c.pk = string(pk)
+
+	c.token, err = genToken()
+	if err != nil {
+		return nil, err
+	}
+
+	c.pc, err = getProxyConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	c.cwd, err = os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func createCluster(ctx context.Context) (err error) {
+	var c *creator
+	c, err = newCreator()
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err != nil {
+			c.cleanup()
+		}
+	}()
+
+	fmt.Println("Creating master")
+	err = c.createMaster(ctx)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Creating workers")
+	err = c.createWorkers(ctx)
+	if err != nil {
+		return err
+	}
+
+	if c.mc.ExternalIP != "" {
+		fmt.Println("Mapping external-ip")
+		err = c.createExternalIP(ctx)
+		if err != nil {
+			return
+		}
+	}
+
+	err = c.waitForAdminConf(ctx)
+	if err != nil {
+		return err
+	}
+
+	c.status()
+
+	return nil
+}
+
+func create(ctx context.Context, errCh chan error) {
+	errCh <- createCluster(ctx)
+}

--- a/k8s/kubicle/delete.go
+++ b/k8s/kubicle/delete.go
@@ -1,0 +1,205 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/01org/ciao/bat"
+)
+
+type destroyer struct {
+	instances   map[string]*bat.Instance
+	wDeleted    []string
+	iDeleted    []string
+	ipsDeleted  []string
+	poolDeleted string
+	ipsMapped   bool
+}
+
+func getWorkloadUUID(ctx context.Context, name string) (string, error) {
+	wls, err := bat.GetAllWorkloads(ctx, "")
+	if err != nil {
+		return "", fmt.Errorf("Failed to retrieve workload list")
+	}
+	var id string
+	matches := 0
+
+	for _, w := range wls {
+		if w.Name == name {
+			id = w.ID
+			matches++
+		}
+	}
+
+	if matches == 0 {
+		return "", fmt.Errorf("workload %s not found", name)
+	}
+
+	if matches > 1 {
+		return "", fmt.Errorf("Multiple workloads with the same name (%s) found", name)
+	}
+
+	return id, nil
+}
+
+func (d *destroyer) deleteExternalIPs(ctx context.Context) error {
+	externalIPs, err := bat.ListExternalIPs(ctx, "")
+	if err != nil {
+		return ctx.Err()
+	}
+
+	for _, ip := range externalIPs {
+		if _, ok := d.instances[ip.InstanceID]; ok {
+			d.ipsMapped = true
+			err := bat.UnmapExternalIP(ctx, "", ip.ExternalIP)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: Failed to unmap %s\n", ip.ExternalIP)
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				continue
+			}
+			d.ipsDeleted = append(d.ipsDeleted, ip.ExternalIP)
+		}
+	}
+
+	for i := 0; i < 5; i++ {
+		err := bat.DeleteExternalIPPool(ctx, "", externalIPPool)
+		if err == nil {
+			d.poolDeleted = externalIPPool
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+
+	return nil
+}
+
+func (d *destroyer) deleteWorkloadAndInstances(ctx context.Context, workload string) error {
+	for instanceID, instance := range d.instances {
+		if workload == instance.FlavorID {
+			err := deleteInstance(ctx, instanceID)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: Failed to delete instance %s\n", instanceID)
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+			} else {
+				d.iDeleted = append(d.iDeleted, instanceID)
+			}
+		}
+	}
+
+	err := bat.DeleteWorkload(ctx, "", workload)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: Unable to delete workload %s: %v\n", workload, err)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+	}
+
+	d.wDeleted = append(d.wDeleted, workload)
+
+	return nil
+}
+
+func (d *destroyer) status() {
+	if len(d.ipsDeleted) > 0 {
+		fmt.Println("External-ips deleted:")
+		for _, ips := range d.ipsDeleted {
+			fmt.Println(ips)
+		}
+		fmt.Println("")
+	}
+
+	if d.poolDeleted != "" {
+		fmt.Println("Pools Deleted:")
+		fmt.Println(d.poolDeleted)
+		fmt.Println("")
+	}
+
+	fmt.Println("Workloads deleted:")
+	for _, w := range d.wDeleted {
+		fmt.Println(w)
+	}
+
+	fmt.Println("\nInstances deleted:")
+	for _, i := range d.iDeleted {
+		fmt.Println(i)
+	}
+}
+
+func (d *destroyer) destroyCluster(ctx context.Context) error {
+	var err error
+	d.instances, err = bat.GetAllInstances(ctx, "")
+	if err != nil {
+		return fmt.Errorf("Failed to retrieve instance list")
+	}
+
+	defer d.status()
+
+	err = d.deleteExternalIPs(ctx)
+	if err != nil {
+		return err
+	}
+
+	workerWkldUUID, err := getWorkloadUUID(ctx, workerWorkloadName)
+	if err == nil {
+		err := d.deleteWorkloadAndInstances(ctx, workerWkldUUID)
+		if err != nil {
+			return err
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "Warning: Failed determine worker workload: %v\n", err)
+		if ctx.Err() != nil {
+			return err
+		}
+	}
+
+	masterWkldUUID, err := getWorkloadUUID(ctx, masterWorkloadName)
+	if err == nil {
+		err := d.deleteWorkloadAndInstances(ctx, masterWkldUUID)
+		if err != nil {
+			return err
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "Warning: Failed determine master workload: %v\n", err)
+		if ctx.Err() != nil {
+			return err
+		}
+	}
+
+	if len(d.wDeleted) == 0 || len(d.iDeleted) == 0 ||
+		(d.ipsMapped && (len(d.ipsDeleted) == 0 || d.poolDeleted == "")) {
+		return fmt.Errorf("Not all parts of the cluster were deleted")
+	}
+
+	return nil
+}
+
+func destroy(ctx context.Context, errCh chan error) {
+	d := &destroyer{}
+	errCh <- d.destroyCluster(ctx)
+}

--- a/k8s/kubicle/delete.go
+++ b/k8s/kubicle/delete.go
@@ -34,32 +34,6 @@ type destroyer struct {
 	ipsMapped   bool
 }
 
-func getWorkloadUUID(ctx context.Context, name string) (string, error) {
-	wls, err := bat.GetAllWorkloads(ctx, "")
-	if err != nil {
-		return "", fmt.Errorf("Failed to retrieve workload list")
-	}
-	var id string
-	matches := 0
-
-	for _, w := range wls {
-		if w.Name == name {
-			id = w.ID
-			matches++
-		}
-	}
-
-	if matches == 0 {
-		return "", fmt.Errorf("workload %s not found", name)
-	}
-
-	if matches > 1 {
-		return "", fmt.Errorf("Multiple workloads with the same name (%s) found", name)
-	}
-
-	return id, nil
-}
-
 func (d *destroyer) deleteExternalIPs(ctx context.Context) error {
 	externalIPs, err := bat.ListExternalIPs(ctx, "")
 	if err != nil {

--- a/k8s/kubicle/kubicle.go
+++ b/k8s/kubicle/kubicle.go
@@ -38,9 +38,9 @@ func (e usageError) Error() string {
 }
 
 type vmOptions struct {
-	vCPUs int
-	mem   int
-	disk  int
+	vCPUs   int
+	memMiB  int
+	diskGiB int
 }
 
 type options struct {
@@ -56,8 +56,8 @@ type options struct {
 
 type baseConfig struct {
 	VCPUs        int
-	RAM          int
-	Disk         int
+	RAMMiB       int
+	DiskGiB      int
 	User         string
 	ImageUUID    string
 	HTTPSProxy   string
@@ -88,14 +88,14 @@ func init() {
 func createFlags() (*options, error) {
 	opts := options{
 		masterVM: vmOptions{
-			vCPUs: 1,
-			mem:   1024,
-			disk:  10,
+			vCPUs:   1,
+			memMiB:  1024,
+			diskGiB: 10,
 		},
 		workerVM: vmOptions{
-			vCPUs: 1,
-			mem:   2048,
-			disk:  10,
+			vCPUs:   1,
+			memMiB:  2048,
+			diskGiB: 10,
 		},
 		workers: 1,
 	}
@@ -108,17 +108,17 @@ func createFlags() (*options, error) {
 
 	fs := flag.NewFlagSet("create", flag.ExitOnError)
 
-	fs.IntVar(&opts.masterVM.mem, "mmem", opts.masterVM.mem,
-		"Megabytes of RAM allocated to master VM")
+	fs.IntVar(&opts.masterVM.memMiB, "mmem", opts.masterVM.memMiB,
+		"Mebibytes of RAM allocated to master VM")
 	fs.IntVar(&opts.masterVM.vCPUs, "mcpus", opts.masterVM.vCPUs, "VCPUs assignged to master VM")
-	fs.IntVar(&opts.masterVM.disk, "mdisk", opts.masterVM.disk,
-		"Gigabytes of disk allocated to master VM")
+	fs.IntVar(&opts.masterVM.diskGiB, "mdisk", opts.masterVM.diskGiB,
+		"Gibibytes of disk allocated to master VM")
 
-	fs.IntVar(&opts.workerVM.mem, "wmem", opts.workerVM.mem,
-		"Megabytes of RAM allocated to worker VMs")
+	fs.IntVar(&opts.workerVM.memMiB, "wmem", opts.workerVM.memMiB,
+		"Mebibytes of RAM allocated to worker VMs")
 	fs.IntVar(&opts.workerVM.vCPUs, "wcpus", opts.workerVM.vCPUs, "VCPUs assignged to worker VM")
-	fs.IntVar(&opts.workerVM.disk, "wdisk", opts.workerVM.disk,
-		"Gigabytes of disk allocated to worker VM")
+	fs.IntVar(&opts.workerVM.diskGiB, "wdisk", opts.workerVM.diskGiB,
+		"Gibibytes of disk allocated to worker VMs")
 
 	fs.IntVar(&opts.workers, "workers", opts.workers, "Number of worker nodes to create")
 

--- a/k8s/kubicle/kubicle.go
+++ b/k8s/kubicle/kubicle.go
@@ -1,0 +1,182 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"path"
+	"syscall"
+)
+
+const (
+	masterWorkloadName = "k8s master"
+	workerWorkloadName = "k8s worker"
+)
+
+type usageError string
+
+func (e usageError) Error() string {
+	return string(e)
+}
+
+type vmOptions struct {
+	vCPUs int
+	mem   int
+	disk  int
+}
+
+type options struct {
+	masterVM      vmOptions
+	workerVM      vmOptions
+	user          string
+	publicKeyPath string
+	workers       int
+	imageUUID     string
+	externalIP    string
+	keep          bool
+}
+
+type baseConfig struct {
+	VCPUs        int
+	RAM          int
+	Disk         int
+	User         string
+	ImageUUID    string
+	HTTPSProxy   string
+	HTTPProxy    string
+	NoProxy      string
+	Token        string
+	PublicKey    string
+	UserDataFile string
+	Description  string
+}
+
+type proxyConfig struct {
+	httpProxy  string
+	httpsProxy string
+	noProxy    string
+}
+
+func init() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s:\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "%s create image-uuid [options]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "%s delete\n\n", os.Args[0])
+		fmt.Fprintln(os.Stderr, "- create : creates a k8s cluster")
+		fmt.Fprintln(os.Stderr, "- delete : removes kubicle created instances and workloads")
+	}
+}
+
+func createFlags() (*options, error) {
+	opts := options{
+		masterVM: vmOptions{
+			vCPUs: 1,
+			mem:   1024,
+			disk:  10,
+		},
+		workerVM: vmOptions{
+			vCPUs: 1,
+			mem:   2048,
+			disk:  10,
+		},
+		workers: 1,
+	}
+
+	opts.user = os.Getenv("USER")
+	home := os.Getenv("HOME")
+	if home != "" {
+		opts.publicKeyPath = path.Join(home, "local", "testkey.pub")
+	}
+
+	fs := flag.NewFlagSet("create", flag.ExitOnError)
+
+	fs.IntVar(&opts.masterVM.mem, "mmem", opts.masterVM.mem,
+		"Megabytes of RAM allocated to master VM")
+	fs.IntVar(&opts.masterVM.vCPUs, "mcpus", opts.masterVM.vCPUs, "VCPUs assignged to master VM")
+	fs.IntVar(&opts.masterVM.disk, "mdisk", opts.masterVM.disk,
+		"Gigabytes of disk allocated to master VM")
+
+	fs.IntVar(&opts.workerVM.mem, "wmem", opts.workerVM.mem,
+		"Megabytes of RAM allocated to worker VMs")
+	fs.IntVar(&opts.workerVM.vCPUs, "wcpus", opts.workerVM.vCPUs, "VCPUs assignged to worker VM")
+	fs.IntVar(&opts.workerVM.disk, "wdisk", opts.workerVM.disk,
+		"Gigabytes of disk allocated to worker VM")
+
+	fs.IntVar(&opts.workers, "workers", opts.workers, "Number of worker nodes to create")
+
+	fs.StringVar(&opts.publicKeyPath, "key", opts.publicKeyPath, "Path to public key used to ssh into nodes")
+	fs.StringVar(&opts.user, "user", opts.user, "Name of user account to create on the nodes")
+	fs.StringVar(&opts.externalIP, "external-ip", opts.externalIP,
+		"External-ip to associate with the master node")
+	fs.BoolVar(&opts.keep, "keep", false, "Retains workload definition files if set to true")
+
+	if err := fs.Parse(flag.Args()[1:]); err != nil {
+		return nil, err
+	}
+
+	if len(fs.Args()) < 1 {
+		return nil, usageError("No image-uuid specified!")
+	}
+	opts.imageUUID = fs.Args()[0]
+
+	return &opts, nil
+}
+func runCommand(signalCh <-chan os.Signal) error {
+	var err error
+
+	errCh := make(chan error)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	switch os.Args[1] {
+	case "create":
+		go create(ctx, errCh)
+	case "delete":
+		go destroy(ctx, errCh)
+	}
+	select {
+	case <-signalCh:
+		cancelFunc()
+		err = <-errCh
+	case err = <-errCh:
+		cancelFunc()
+	}
+
+	return err
+}
+
+func main() {
+	flag.Parse()
+	if len(flag.Args()) < 1 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+
+	if err := runCommand(signalCh); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		if _, ok := err.(usageError); ok {
+			fmt.Fprintln(os.Stderr)
+			flag.Usage()
+		}
+		os.Exit(1)
+	}
+}

--- a/k8s/kubicle/kubicle.go
+++ b/k8s/kubicle/kubicle.go
@@ -163,7 +163,8 @@ func runCommand(signalCh <-chan os.Signal) error {
 
 func main() {
 	flag.Parse()
-	if len(flag.Args()) < 1 {
+	if len(flag.Args()) < 1 ||
+		!(os.Args[1] == "create" || os.Args[1] == "delete") {
 		flag.Usage()
 		os.Exit(1)
 	}

--- a/k8s/kubicle/workloads.go
+++ b/k8s/kubicle/workloads.go
@@ -1,0 +1,56 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/01org/ciao/bat"
+)
+
+func getWorkloadUUIDs(ctx context.Context, name string) ([]string, error) {
+	wls, err := bat.GetAllWorkloads(ctx, "")
+	var ids []string
+	if err != nil {
+		return ids, fmt.Errorf("Failed to retrieve workload list")
+	}
+
+	for _, w := range wls {
+		if w.Name == name {
+			ids = append(ids, w.ID)
+		}
+	}
+
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("workload %s not found", name)
+	}
+
+	return ids, nil
+}
+
+func getWorkloadUUID(ctx context.Context, name string) (string, error) {
+	ids, err := getWorkloadUUIDs(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	if len(ids) > 1 {
+		return "", fmt.Errorf("Multiple workloads with the same name (%s) found", name)
+	}
+
+	return ids[0], nil
+}

--- a/testutil/ciao-down/cloudinit.go
+++ b/testutil/ciao-down/cloudinit.go
@@ -196,6 +196,9 @@ runcmd:
  - {{download . "https://download.fedoraproject.org/pub/fedora/linux/releases/24/CloudImages/x86_64/images/Fedora-Cloud-Base-24-1.2.x86_64.qcow2" (printf "/home/%%s/local/Fedora-Cloud-Base-24-1.2.x86_64.qcow2" .User)}}
  - {{template "CHECK" .}}
 
+ - curl -X PUT -d "Downloading xenial-server-cloudimg-amd64-disk1.img" 10.0.2.2:{{.HTTPServerPort}}
+ - {{download . "https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img" (printf "/home/%%s/local/xenial-server-cloudimg-amd64-disk1.img" .User)}}
+
  - curl -X PUT -d "Downloading CNCI image" 10.0.2.2:{{.HTTPServerPort}}
  - {{download . "https://download.clearlinux.org/demos/ciao/clear-8260-ciao-networking.img.xz" (printf "/home/%%s/local/clear-8260-ciao-networking.img.xz" .User)}}
  - {{template "CHECK" .}}

--- a/testutil/singlevm/verify.sh
+++ b/testutil/singlevm/verify.sh
@@ -207,8 +207,21 @@ function deleteExternalIPPool() {
 # Read cluster env variables
 . $ciao_bin/demo.sh
 
-vm_wlid=$("$ciao_gobin"/ciao-cli workload list -f='{{if gt (len .) 0}}{{(index . 0).ID}}{{end}}')
-exitOnError $?  "Unable to list workloads"
+for item in `ciao-cli workload list -f '{{select . "ID"}} '`
+do
+    type=`ciao-cli workload show --workload $item -f '{{.VMType}}'`;
+    if [ $type == "qemu" ]
+    then
+	vm_wlid=$item
+	break
+    fi
+done
+
+if [ -z $vm_wlid ]
+then
+    echo "FATAL ERROR exiting: No VM workloads defined"
+    exit 1
+fi
 
 "$ciao_gobin"/ciao-cli instance add --workload=$vm_wlid --instances=2
 exitOnError $?  "Unable to launch VMs"


### PR DESCRIPTION
kubicle is a small command line tool that makes it easy to set up k8s clusters in ciao.  You need simply to provide a base image, which must be some version of Ubuntu server, and kubicle will do the rest.  In short it creates workloads for k8s master and worker nodes, creates instances from these workloads and joins these instances together to form a k8s cluster.  The tool accepts a number of options, such as the number of worker nodes to create, configuration information for those nodes and the user accounts to create on those nodes.
