### PR TITLE
ciao-controller: differentiate compute / network nodes

### DIFF
--- a/ciao-controller/api.go
+++ b/ciao-controller/api.go
@@ -107,11 +107,11 @@ func pagerQueryParse(r *http.Request) (int, int, string) {
 
 type nodePager struct {
 	ctl   *controller
-	nodes []types.CiaoComputeNode
+	nodes []types.CiaoNode
 }
 
-func (pager *nodePager) getNodes(filterType pagerFilterType, filter string, nodes []types.CiaoComputeNode, limit int, offset int) (types.CiaoComputeNodes, error) {
-	computeNodes := types.NewCiaoComputeNodes()
+func (pager *nodePager) getNodes(filterType pagerFilterType, filter string, nodes []types.CiaoNode, limit int, offset int) (types.CiaoNodes, error) {
+	computeNodes := types.NewCiaoNodes()
 
 	pageLength := 0
 
@@ -133,11 +133,11 @@ func (pager *nodePager) getNodes(filterType pagerFilterType, filter string, node
 	return computeNodes, nil
 }
 
-func (pager *nodePager) filter(filterType pagerFilterType, filter string, node types.CiaoComputeNode) bool {
+func (pager *nodePager) filter(filterType pagerFilterType, filter string, node types.CiaoNode) bool {
 	return false
 }
 
-func (pager *nodePager) nextPage(filterType pagerFilterType, filter string, r *http.Request) (types.CiaoComputeNodes, error) {
+func (pager *nodePager) nextPage(filterType pagerFilterType, filter string, r *http.Request) (types.CiaoNodes, error) {
 	limit, offset, lastSeen := pagerQueryParse(r)
 
 	if lastSeen == "" {
@@ -162,7 +162,7 @@ func (pager *nodePager) nextPage(filterType pagerFilterType, filter string, r *h
 		}
 	}
 
-	return types.CiaoComputeNodes{}, fmt.Errorf("Item %s not found", lastSeen)
+	return types.CiaoNodes{}, fmt.Errorf("Item %s not found", lastSeen)
 }
 
 type nodeServerPager struct {
@@ -440,7 +440,7 @@ func listNodes(c *controller, w http.ResponseWriter, r *http.Request) (APIRespon
 		}
 	}
 
-	sort.Sort(types.SortedComputeNodesByID(computeNodes.Nodes))
+	sort.Sort(types.SortedNodesByID(computeNodes.Nodes))
 
 	pager := nodePager{
 		ctl:   c,

--- a/ciao-controller/client.go
+++ b/ciao-controller/client.go
@@ -185,6 +185,8 @@ func (client *ssntpClient) nodeConnected(payload []byte) {
 		return
 	}
 	glog.Infof("Node %s connected", nodeConnected.Connected.NodeUUID)
+
+	client.ctl.ds.AddNode(nodeConnected.Connected.NodeUUID, nodeConnected.Connected.NodeType)
 }
 
 func (client *ssntpClient) nodeDisconnected(payload []byte) {

--- a/ciao-controller/compute_test.go
+++ b/ciao-controller/compute_test.go
@@ -950,7 +950,7 @@ func testListNodes(t *testing.T, httpExpectedStatus int, validToken bool) {
 		}
 	}
 
-	sort.Sort(types.SortedComputeNodesByID(expected.Nodes))
+	sort.Sort(types.SortedNodesByID(expected.Nodes))
 
 	url := testutil.ComputeURL + "/v2.1/nodes"
 
@@ -960,7 +960,7 @@ func testListNodes(t *testing.T, httpExpectedStatus int, validToken bool) {
 		return
 	}
 
-	var result types.CiaoComputeNodes
+	var result types.CiaoNodes
 
 	err = json.Unmarshal(body, &result)
 	if err != nil {

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -1205,6 +1205,20 @@ func (ds *Datastore) AddNode(nodeID string, nodeType payloads.Resource) {
 	ds.nodes[nodeID] = n
 }
 
+// GetNode retrieves a node in the node cache.
+func (ds *Datastore) GetNode(nodeID string) (types.Node, error) {
+	var node types.Node
+
+	ds.nodesLock.RLock()
+	defer ds.nodesLock.RUnlock()
+
+	if ds.nodes[nodeID] == nil {
+		return node, fmt.Errorf("node %s not found", nodeID)
+	}
+
+	return ds.nodes[nodeID].Node, nil
+}
+
 // HandleStats makes sure that the data from the stat payload is stored.
 func (ds *Datastore) HandleStats(stat payloads.Stat) error {
 	if stat.Load != -1 {

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -143,7 +143,7 @@ type Datastore struct {
 	cnciAddedChans map[string]chan bool
 	cnciAddedLock  *sync.Mutex
 
-	nodeLastStat     map[string]types.CiaoComputeNode
+	nodeLastStat     map[string]types.CiaoNode
 	nodeLastStatLock *sync.RWMutex
 
 	instanceLastStat     map[string]types.CiaoServerStats
@@ -220,7 +220,7 @@ func (ds *Datastore) Init(config Config) error {
 	ds.cnciAddedChans = make(map[string]chan bool)
 	ds.cnciAddedLock = &sync.Mutex{}
 
-	ds.nodeLastStat = make(map[string]types.CiaoComputeNode)
+	ds.nodeLastStat = make(map[string]types.CiaoNode)
 	ds.nodeLastStatLock = &sync.RWMutex{}
 
 	ds.instanceLastStat = make(map[string]types.CiaoServerStats)
@@ -1216,18 +1216,18 @@ func (ds *Datastore) GetInstanceLastStats(nodeID string) types.CiaoServersStats 
 	return serversStats
 }
 
-// GetNodeLastStats retrieves the last nodes stats received for this node.
+// GetNodeLastStats retrieves the last nodes' stats received.
 // It returns it in a format suitable for the compute API.
-func (ds *Datastore) GetNodeLastStats() types.CiaoComputeNodes {
-	var computeNodes types.CiaoComputeNodes
+func (ds *Datastore) GetNodeLastStats() types.CiaoNodes {
+	var nodes types.CiaoNodes
 
 	ds.nodeLastStatLock.RLock()
 	for _, node := range ds.nodeLastStat {
-		computeNodes.Nodes = append(computeNodes.Nodes, node)
+		nodes.Nodes = append(nodes.Nodes, node)
 	}
 	ds.nodeLastStatLock.RUnlock()
 
-	return computeNodes
+	return nodes
 }
 
 func (ds *Datastore) addNodeStat(stat payloads.Stat) error {
@@ -1245,7 +1245,7 @@ func (ds *Datastore) addNodeStat(stat payloads.Stat) error {
 
 	ds.nodesLock.Unlock()
 
-	cnStat := types.CiaoComputeNode{
+	cnStat := types.CiaoNode{
 		ID:            stat.NodeUUID,
 		Status:        stat.Status,
 		Load:          stat.Load,

--- a/ciao-controller/legacy_api.go
+++ b/ciao-controller/legacy_api.go
@@ -146,6 +146,30 @@ func legacyListNodes(c *controller, w http.ResponseWriter, r *http.Request) (API
 	return listNodes(c, w, r)
 }
 
+// @Title legacyListComputeNodes
+// @Description Returns a list of all compute nodes.
+// @Accept  json
+// @Success 200 {array} interface "Returns ciao-controller.nodePager with TotalInstances, TotalRunningInstances, TotalPendingInstances, TotalPausedInstances."
+// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
+// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
+// @Router /v2.1/nodes/compute [get]
+// @Resource /v2.1/node/computes
+func legacyListComputeNodes(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
+	return listComputeNodes(c, w, r)
+}
+
+// @Title legacyListNetworkNodes
+// @Description Returns a list of all network nodes.
+// @Accept  json
+// @Success 200 {array} interface "Returns ciao-controller.nodePager with TotalInstances, TotalRunningInstances, TotalPendingInstances, TotalPausedInstances."
+// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
+// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
+// @Router /v2.1/nodes/network [get]
+// @Resource /v2.1/nodes/network
+func legacyListNetworkNodes(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
+	return listNetworkNodes(c, w, r)
+}
+
 // @Title legacyNodesSummary
 // @Description A summary of all node stats.
 // @Accept  json
@@ -301,6 +325,10 @@ func legacyComputeRoutes(ctl *controller, r *mux.Router) *mux.Router {
 		legacyAPIHandler{ctl, legacyNodesSummary, true}).Methods("GET")
 	r.Handle("/v2.1/nodes/{node}/servers/detail",
 		legacyAPIHandler{ctl, legacyListNodeServers, true}).Methods("GET")
+	r.Handle("/v2.1/nodes/compute",
+		legacyAPIHandler{ctl, legacyListComputeNodes, true}).Methods("GET")
+	r.Handle("/v2.1/nodes/network",
+		legacyAPIHandler{ctl, legacyListNetworkNodes, true}).Methods("GET")
 
 	r.Handle("/v2.1/cncis",
 		legacyAPIHandler{ctl, legacyListCNCIs, true}).Methods("GET")

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -131,12 +131,12 @@ func (s SortedInstancesByID) Len() int           { return len(s) }
 func (s SortedInstancesByID) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s SortedInstancesByID) Less(i, j int) bool { return s[i].ID < s[j].ID }
 
-// SortedComputeNodesByID implements sort.Interface for Node by ID string
-type SortedComputeNodesByID []CiaoComputeNode
+// SortedNodesByID implements sort.Interface for Node by ID string
+type SortedNodesByID []CiaoNode
 
-func (s SortedComputeNodesByID) Len() int           { return len(s) }
-func (s SortedComputeNodesByID) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s SortedComputeNodesByID) Less(i, j int) bool { return s[i].ID < s[j].ID }
+func (s SortedNodesByID) Len() int           { return len(s) }
+func (s SortedNodesByID) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s SortedNodesByID) Less(i, j int) bool { return s[i].ID < s[j].ID }
 
 // Tenant contains information about a tenant or project.
 type Tenant struct {
@@ -286,9 +286,9 @@ func NewCiaoComputeTenants() (tenants CiaoComputeTenants) {
 	return
 }
 
-// CiaoComputeNode contains status and statistic information for an individual
+// CiaoNode contains status and statistic information for an individual
 // node.
-type CiaoComputeNode struct {
+type CiaoNode struct {
 	ID                    string    `json:"id"`
 	Timestamp             time.Time `json:"updated"`
 	Status                string    `json:"status"`
@@ -304,19 +304,19 @@ type CiaoComputeNode struct {
 	TotalPausedInstances  int       `json:"total_paused_instances"`
 }
 
-// CiaoComputeNodes represents the unmarshalled version of the contents of a
+// CiaoNodes represents the unmarshalled version of the contents of a
 // /v2.1/nodes response.  It contains status and statistics information
 // for a set of nodes.
-type CiaoComputeNodes struct {
-	Nodes []CiaoComputeNode `json:"nodes"`
+type CiaoNodes struct {
+	Nodes []CiaoNode `json:"nodes"`
 }
 
-// NewCiaoComputeNodes allocates a CiaoComputeNodes structure.
+// NewCiaoNodes allocates a CiaoNodes structure.
 // It allocates the Nodes slice as well so that the marshalled
 // JSON is an empty array and not a nil pointer, as specified by the
 // OpenStack APIs.
-func NewCiaoComputeNodes() (nodes CiaoComputeNodes) {
-	nodes.Nodes = []CiaoComputeNode{}
+func NewCiaoNodes() (nodes CiaoNodes) {
+	nodes.Nodes = []CiaoNode{}
 	return
 }
 

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -26,6 +26,7 @@ import (
 	"github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/openstack/block"
 	"github.com/01org/ciao/payloads"
+	"github.com/01org/ciao/ssntp"
 )
 
 // SourceType contains the valid values of the storage source.
@@ -216,9 +217,10 @@ type BatchFrameSummary struct {
 
 // Node contains information about a physical node in the cluster.
 type Node struct {
-	ID       string `json:"node_id"`
-	IPAddr   string `json:"ip_address"`
-	Hostname string `json:"hostname"`
+	ID       string     `json:"node_id"`
+	IPAddr   string     `json:"ip_address"`
+	Hostname string     `json:"hostname"`
+	NodeRole ssntp.Role `json:"role"`
 }
 
 // BlockState represents the state of the block device in the controller

--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -32,6 +32,7 @@ import (
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp"
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
 
@@ -123,55 +124,75 @@ type controllerStat struct {
 	uuid   string
 }
 
-func (sched *ssntpSchedulerServer) sendNodeConnectionEvent(nodeUUID, controllerUUID string, nodeType payloads.Resource, connected bool) (int, error) {
-	/* connect */
+func prepareNodeConnectionEvent(nodeUUID string, nodeType payloads.Resource, connected bool) (b []byte, err error) {
+	event := payloads.NodeConnectedEvent{
+		NodeUUID: nodeUUID,
+		NodeType: nodeType,
+	}
+
 	if connected == true {
 		payload := payloads.NodeConnected{
-			Connected: payloads.NodeConnectedEvent{
-				NodeUUID: nodeUUID,
-				NodeType: nodeType,
-			},
+			Connected: event,
 		}
 
-		b, err := yaml.Marshal(&payload)
+		b, err = yaml.Marshal(&payload)
+	} else {
+		payload := payloads.NodeDisconnected{
+			Disconnected: event,
+		}
+
+		b, err = yaml.Marshal(&payload)
+	}
+
+	return
+}
+
+// The ssntp server implementation is expected to generate ssntp client
+// connect/disconnect events. This function sends to one controller a
+// connect event for each currently connected nodes.
+func (sched *ssntpSchedulerServer) sendDirectedNodeConnectionEvents(ctlUUID string) {
+	sched.cnMutex.RLock()
+	defer sched.cnMutex.RUnlock()
+	for _, node := range sched.cnList {
+		nodeUUID := node.uuid
+
+		b, err := prepareNodeConnectionEvent(nodeUUID, payloads.ComputeNode, true)
 		if err != nil {
-			return 0, err
+			errors.Wrap(err, "Node connection event lost")
+			continue
 		}
 
-		return sched.ssntp.SendEvent(controllerUUID, ssntp.NodeConnected, b)
+		sched.ssntp.SendEvent(ctlUUID, ssntp.NodeConnected, b)
 	}
 
-	/* disconnect */
-	payload := payloads.NodeDisconnected{
-		Disconnected: payloads.NodeConnectedEvent{
-			NodeUUID: nodeUUID,
-			NodeType: nodeType,
-		},
-	}
+	sched.nnMutex.RLock()
+	defer sched.nnMutex.RUnlock()
+	for _, node := range sched.nnList {
+		nodeUUID := node.uuid
 
-	b, err := yaml.Marshal(&payload)
+		b, err := prepareNodeConnectionEvent(nodeUUID, payloads.NetworkNode, true)
+		if err != nil {
+			errors.Wrap(err, "Node connection event lost")
+			continue
+		}
+
+		sched.ssntp.SendEvent(ctlUUID, ssntp.NodeConnected, b)
+	}
+}
+
+// The ssntp server implementation is expected to generate ssntp client
+// connect/disconnect events. This function sends them to all controllers.
+func (sched *ssntpSchedulerServer) sendNodeConnectionEvents(nodeUUID string, nodeType payloads.Resource, connected bool) {
+	b, err := prepareNodeConnectionEvent(nodeUUID, nodeType, connected)
 	if err != nil {
-		return 0, err
+		errors.Wrap(err, "Node connection event lost")
 	}
 
-	return sched.ssntp.SendEvent(controllerUUID, ssntp.NodeDisconnected, b)
-}
-
-func (sched *ssntpSchedulerServer) sendNodeConnectedEvents(nodeUUID string, nodeType payloads.Resource) {
 	sched.controllerMutex.RLock()
 	defer sched.controllerMutex.RUnlock()
 
-	for _, c := range sched.controllerMap {
-		sched.sendNodeConnectionEvent(nodeUUID, c.uuid, nodeType, true)
-	}
-}
-
-func (sched *ssntpSchedulerServer) sendNodeDisconnectedEvents(nodeUUID string, nodeType payloads.Resource) {
-	sched.controllerMutex.RLock()
-	defer sched.controllerMutex.RUnlock()
-
-	for _, c := range sched.controllerMap {
-		sched.sendNodeConnectionEvent(nodeUUID, c.uuid, nodeType, false)
+	for _, ctl := range sched.controllerMap {
+		sched.ssntp.SendEvent(ctl.uuid, ssntp.NodeConnected, b)
 	}
 }
 
@@ -200,7 +221,11 @@ func connectController(sched *ssntpSchedulerServer, uuid string) {
 		sched.controllerList = append(sched.controllerList, &controller)
 	}
 
-	sched.controllerMap[controller.uuid] = &controller
+	sched.controllerMap[uuid] = &controller
+
+	// In case launcher clients are already connected, generate a node
+	// connection event for all nodes.
+	sched.sendDirectedNodeConnectionEvents(uuid)
 }
 
 // Undo previous state additions for departed Controller
@@ -265,7 +290,7 @@ func connectComputeNode(sched *ssntpSchedulerServer, uuid string) {
 	sched.cnList = append(sched.cnList, &node)
 	sched.cnMap[uuid] = &node
 
-	sched.sendNodeConnectedEvents(uuid, payloads.ComputeNode)
+	go sched.sendNodeConnectionEvents(uuid, payloads.ComputeNode, true)
 }
 
 // Undo previous state additions for departed Compute Node
@@ -296,7 +321,7 @@ func disconnectComputeNode(sched *ssntpSchedulerServer, uuid string) {
 		sched.cnMRUIndex = -1
 	}
 
-	sched.sendNodeDisconnectedEvents(uuid, payloads.ComputeNode)
+	go sched.sendNodeConnectionEvents(uuid, payloads.ComputeNode, false)
 }
 
 // Add state for newly connected Network Node
@@ -317,7 +342,7 @@ func connectNetworkNode(sched *ssntpSchedulerServer, uuid string) {
 	sched.nnList = append(sched.nnList, &node)
 	sched.nnMap[uuid] = &node
 
-	sched.sendNodeConnectedEvents(uuid, payloads.NetworkNode)
+	go sched.sendNodeConnectionEvents(uuid, payloads.NetworkNode, true)
 }
 
 // Undo previous state additions for departed Network Node
@@ -348,8 +373,9 @@ func disconnectNetworkNode(sched *ssntpSchedulerServer, uuid string) {
 		sched.nnMRUIndex = -1
 	}
 
-	sched.sendNodeDisconnectedEvents(uuid, payloads.NetworkNode)
+	go sched.sendNodeConnectionEvents(uuid, payloads.NetworkNode, false)
 }
+
 func (sched *ssntpSchedulerServer) ConnectNotify(uuid string, role ssntp.Role) {
 	if role.IsController() {
 		connectController(sched, uuid)


### PR DESCRIPTION
Currently controller doesn't track connected nodes' node type (ie: compute
or network) and then in response to a "nodes" listing query via api (eg:
"ciao-cli node list --compute") the controller will report all nodes
with a running launcher sending stats frames. To support listing just
compute nodes, I add a NodeType into the datastore's node type which is
used for the in-memory ephemeral info cache. Upon node connection
this information is stored. Node listing can then disregard any nodes
which aren't compute nodes.

Fixes #1187

Signed-off-by: Tim Pepper timothy.c.pepper@linux.intel.com

( replaces Pull #1193 )