### PR TITLE
ciao-controller: Avoid raciness when adding tenant for workload creation

### DIFF
--- a/ciao-controller/workload.go
+++ b/ciao-controller/workload.go
@@ -17,6 +17,7 @@ package main
 import (
 	"github.com/golang/glog"
 
+	"github.com/01org/ciao/ciao-controller/internal/datastore"
 	"github.com/01org/ciao/ciao-controller/types"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp/uuid"
@@ -160,16 +161,9 @@ func (c *controller) CreateWorkload(req types.Workload) (types.Workload, error) 
 	// workload. Instead, we'll add the new tenant directly to the
 	// datastore. On first launch request, if the tenant doesn't yet
 	// have a cnci, it will get launched for them then.
-	tenant, err := c.ds.GetTenant(req.TenantID)
-	if err != nil {
+	_, err = c.ds.AddTenant(req.TenantID)
+	if err != nil && err != datastore.ErrTenantExists {
 		return req, err
-	}
-
-	if tenant == nil {
-		_, err := c.ds.AddTenant(req.TenantID)
-		if err != nil {
-			return req, err
-		}
 	}
 
 	// create a workload storage resource for this new workload.


### PR DESCRIPTION
This change modifies datastore's AddTenant() to return a newly defined
error if the tenant ID is already in use. This allows the code in
controller to avoid a race between using GetTenant to find out if there
is a tenant AddTenant to add a new one.

This change also ensures that the lock is taken early enough and that
the lock is released on error paths (previously the lock was not
releases on error paths.)

Signed-off-by: Rob Bradford <robert.bradford@intel.com>