### PR TITLE
Fix tenant CNCI/workload raciness

### DIFF
--- a/ciao-controller/workload.go
+++ b/ciao-controller/workload.go
@@ -154,22 +154,9 @@ func (c *controller) CreateWorkload(req types.Workload) (types.Workload, error) 
 		return req, err
 	}
 
-	// check to see if this is a new tenant. If so, we need to add
-	// them to the datastore. We do not however want to launch a
-	// CNCI yet since this might be a request to upload a CNCI
-	// workload. Instead, we'll add the new tenant directly to the
-	// datastore. On first launch request, if the tenant doesn't yet
-	// have a cnci, it will get launched for them then.
-	tenant, err := c.ds.GetTenant(req.TenantID)
+	err = c.confirmTenant(req.TenantID)
 	if err != nil {
 		return req, err
-	}
-
-	if tenant == nil {
-		_, err := c.ds.AddTenant(req.TenantID)
-		if err != nil {
-			return req, err
-		}
 	}
 
 	// create a workload storage resource for this new workload.


### PR DESCRIPTION
This PR addresses a bug found when creating non-public workloads before the CNCI has been activated. This is caused by:

- CreateWorkload() creates a tenant without starting a CNCI
- confirmTenant() checked if the tenant was there or didn't have an IP address. In either case it would call addTenant() which would try and call AddTenant() on the database which after 06085307c8e7b3670c88d712177daca0f6f021b4 will return an error on the duplicate tenant being added.

The solution in this PR is to avoid calling AddTenant() twice.