### PR TITLE
Delete CNCI when it is no longer in use.

### DIFF
--- a/ciao-controller/api.go
+++ b/ciao-controller/api.go
@@ -361,7 +361,7 @@ func serversAction(c *controller, w http.ResponseWriter, r *http.Request) (APIRe
 	if len(servers.ServerIDs) > 0 {
 		for _, instanceID := range servers.ServerIDs {
 			// make sure the instance belongs to the tenant
-			instance, err := c.ds.GetInstance(instanceID)
+			instance, err := c.ds.GetTenantInstance(instanceID)
 
 			if err != nil {
 				return errorResponse(err), err

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -106,10 +106,23 @@ func (c *controller) confirmTenantRaw(tenantID string) error {
 	}
 
 	if tenant == nil {
-		tenant, err = c.ds.AddTenant(tenantID)
+		_, err = c.ds.AddTenant(tenantID)
 		if err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (c *controller) confirmCNCI(tenantID string) error {
+	tenant, err := c.ds.GetTenant(tenantID)
+	if err != nil {
+		return err
+	}
+
+	if tenant == nil {
+		return errors.New("No tenant when there should be")
 	}
 
 	if tenant.CNCIIP == "" && !*noNetwork {
@@ -181,6 +194,11 @@ func (c *controller) startWorkload(w types.WorkloadRequest) ([]*types.Instance, 
 
 	if !isCNCIWorkload(&wl) {
 		err := c.confirmTenant(w.TenantID)
+		if err != nil {
+			return nil, err
+		}
+
+		err = c.confirmCNCI(w.TenantID)
 		if err != nil {
 			return nil, err
 		}

--- a/ciao-controller/external_ip.go
+++ b/ciao-controller/external_ip.go
@@ -212,7 +212,7 @@ func (c *controller) ListMappedAddresses(tenant *string) []types.MappedIP {
 func (c *controller) MapAddress(poolName *string, instanceID string) (err error) {
 	var m types.MappedIP
 
-	i, err := c.ds.GetInstance(instanceID)
+	i, err := c.ds.GetTenantInstance(instanceID)
 	if err != nil {
 		return err
 	}

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -107,14 +107,19 @@ func newInstance(ctl *controller, tenantID string, workload *types.Workload,
 func (i *instance) Add() error {
 	ds := i.ctl.ds
 	var err error
-	if i.CNCI == false {
-		err = ds.AddInstance(&i.Instance)
-	} else {
-		err = ds.AddTenantCNCI(i.TenantID, i.ID, i.MACAddress)
-	}
+
+	err = ds.AddInstance(&i.Instance)
 	if err != nil {
 		return errors.Wrapf(err, "Error creating instance in datastore")
 	}
+
+	if i.CNCI == true {
+		err = ds.AddTenantCNCI(i.TenantID, i.ID, i.MACAddress)
+		if err != nil {
+			return errors.Wrapf(err, "Error creating instance in datastore")
+		}
+	}
+
 	for _, volume := range i.newConfig.sc.Start.Storage {
 		if volume.ID == "" && volume.Local {
 			// these are launcher auto-created ephemeral

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -681,7 +681,18 @@ func (ds *Datastore) ReleaseTenantIP(tenantID string, ip string) error {
 	ds.tenantsLock.Lock()
 
 	if ds.tenants[tenantID] != nil {
-		ds.tenants[tenantID].network[int(subnetInt)][int(ipBytes[3])] = false
+		delete(ds.tenants[tenantID].network[int(subnetInt)], int(ipBytes[3]))
+		subnets := ds.tenants[tenantID].subnets
+		network := ds.tenants[tenantID].network
+		i := int(subnetInt)
+
+		if len(network[i]) == 0 {
+			if len(subnets) > 1 {
+				ds.tenants[tenantID].subnets = append(subnets[:i], subnets[i+1:]...)
+			} else {
+				ds.tenants[tenantID].subnets = nil
+			}
+		}
 	}
 
 	ds.tenantsLock.Unlock()

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -1036,6 +1036,11 @@ func TestReleaseTenantIP(t *testing.T) {
 		t.Fatal("IP Address not marked Used")
 	}
 
+	// confirm that subnets has been incremented
+	if len(newTenant.subnets) != 1 {
+		t.Fatal("subnet not allocated in cache")
+	}
+
 	err = ds.ReleaseTenantIP(tenant.ID, ip.String())
 	if err != nil {
 		t.Fatal(err)
@@ -1050,6 +1055,10 @@ func TestReleaseTenantIP(t *testing.T) {
 	// confirm that tenant map shows it not used.
 	if newTenant.network[int(subnetInt)][int(ipBytes[3])] != false {
 		t.Fatal("IP Address not released from cache")
+	}
+
+	if len(newTenant.subnets) != 0 {
+		t.Fatal("subnet not released from cache")
 	}
 
 	// clear tenant from cache

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -887,7 +887,7 @@ func TestRemoveTenantCNCI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ds.removeTenantCNCI(tenant.ID)
+	err = ds.RemoveTenantCNCI(tenant.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -126,6 +126,7 @@ func (d instanceData) Init() error {
 		ip string,
 		create_time DATETIME,
 		name string,
+		cnci int,
 		foreign key(tenant_id) references tenants(id),
 		foreign key(workload_id) references workload_template(id),
 		unique(tenant_id, ip, mac_address),
@@ -1286,7 +1287,8 @@ func (ds *sqliteDB) getInstances() ([]*types.Instance, error) {
 		vnic_uuid,
 		subnet,
 		ip,
-		name
+		name,
+		cnci
 	FROM instances
 	LEFT JOIN latest
 	ON instances.id = latest.instance_id
@@ -1305,7 +1307,7 @@ func (ds *sqliteDB) getInstances() ([]*types.Instance, error) {
 
 		var sshPort sql.NullInt64
 
-		err = rows.Scan(&i.ID, &i.TenantID, &i.State, &i.WorkloadID, &i.SSHIP, &sshPort, &i.NodeID, &i.MACAddress, &i.VnicUUID, &i.Subnet, &i.IPAddress, &i.Name)
+		err = rows.Scan(&i.ID, &i.TenantID, &i.State, &i.WorkloadID, &i.SSHIP, &sshPort, &i.NodeID, &i.MACAddress, &i.VnicUUID, &i.Subnet, &i.IPAddress, &i.Name, &i.CNCI)
 		if err != nil {
 			tx.Rollback()
 			ds.tdbLock.RUnlock()
@@ -1366,7 +1368,8 @@ func (ds *sqliteDB) getTenantInstances(tenantID string) (map[string]*types.Insta
 		vnic_uuid,
 		subnet,
 		ip,
-		name
+		name,
+		cnci
 	FROM instances
 	LEFT JOIN latest
 	ON instances.id = latest.instance_id
@@ -1389,7 +1392,7 @@ func (ds *sqliteDB) getTenantInstances(tenantID string) (map[string]*types.Insta
 
 		i := &types.Instance{}
 
-		err = rows.Scan(&i.ID, &i.TenantID, &i.State, &sshIP, &sshPort, &i.WorkloadID, &nodeID, &i.MACAddress, &i.VnicUUID, &i.Subnet, &i.IPAddress, &i.Name)
+		err = rows.Scan(&i.ID, &i.TenantID, &i.State, &sshIP, &sshPort, &i.WorkloadID, &nodeID, &i.MACAddress, &i.VnicUUID, &i.Subnet, &i.IPAddress, &i.Name, &i.CNCI)
 		if err != nil {
 			tx.Rollback()
 			ds.tdbLock.RUnlock()
@@ -1425,12 +1428,24 @@ func (ds *sqliteDB) getTenantInstances(tenantID string) (map[string]*types.Insta
 }
 
 func (ds *sqliteDB) addInstance(instance *types.Instance) error {
+	datastore := ds.getTableDB("instances")
 	ds.dbLock.Lock()
+	defer ds.dbLock.Unlock()
 
-	err := ds.create("instances", instance.ID, instance.TenantID, instance.WorkloadID, instance.MACAddress, instance.VnicUUID, instance.Subnet, instance.IPAddress, instance.CreateTime.Format(time.RFC3339Nano), instance.Name)
+	tx, err := datastore.Begin()
+	if err != nil {
+		return err
+	}
 
-	ds.dbLock.Unlock()
-	return err
+	_, err = tx.Exec("INSERT INTO instances VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", instance.ID, instance.TenantID, instance.WorkloadID, instance.MACAddress, instance.VnicUUID, instance.Subnet, instance.IPAddress, instance.CreateTime.Format(time.RFC3339Nano), instance.Name, instance.CNCI)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	tx.Commit()
+
+	return nil
 }
 
 func (ds *sqliteDB) deleteInstance(instanceID string) error {

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -602,7 +602,7 @@ func TestCreateMappedIP(t *testing.T) {
 
 	err = db.addInstance(&i)
 	if err != nil {
-		t.Fatal("unable to store instance")
+		t.Fatalf("unable to store instance: %v\n", err)
 	}
 
 	instances, err := db.getInstances()
@@ -660,7 +660,7 @@ func TestDeleteMappedIP(t *testing.T) {
 
 	err = db.addInstance(&i)
 	if err != nil {
-		t.Fatal("unable to store instance")
+		t.Fatalf("unable to store instance: %v\n", err)
 	}
 
 	instances, err := db.getInstances()
@@ -1145,7 +1145,7 @@ func TestInstanceNameConstraint(t *testing.T) {
 
 	err = db.addInstance(&i)
 	if err != nil {
-		t.Fatal("unable to store instance")
+		t.Fatalf("unable to store instance %v\n", err)
 	}
 
 	i2 := types.Instance{
@@ -1161,4 +1161,37 @@ func TestInstanceNameConstraint(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected instance add to fail (duplicate name)")
 	}
+}
+
+func TestAddCNCIInstance(t *testing.T) {
+	db, err := getPersistentStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tenantID := uuid.Generate().String()
+	i := types.Instance{
+		ID:         uuid.Generate().String(),
+		TenantID:   tenantID,
+		WorkloadID: uuid.Generate().String(),
+		IPAddress:  "172.16.0.2",
+		Name:       "test",
+		CNCI:       true,
+	}
+
+	err = db.addInstance(&i)
+	if err != nil {
+		t.Fatalf("unable to store instance %v\n", err)
+	}
+
+	instances, err := db.getInstances()
+	if err != nil || len(instances) != 1 {
+		t.Fatal(err)
+	}
+
+	if instances[0].CNCI != true {
+		t.Fatal("CNCI Instance not properly stored")
+	}
+
+	db.disconnect()
 }

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -465,7 +465,7 @@ func (c *controller) ListServersDetail(tenant string) ([]compute.ServerDetails, 
 func (c *controller) ShowServerDetails(tenant string, server string) (compute.Server, error) {
 	var s compute.Server
 
-	instance, err := c.ds.GetInstance(server)
+	instance, err := c.ds.GetTenantInstance(server)
 	if err != nil {
 		return s, err
 	}
@@ -484,7 +484,7 @@ func (c *controller) ShowServerDetails(tenant string, server string) (compute.Se
 
 func (c *controller) DeleteServer(tenant string, server string) error {
 	/* First check that the instance belongs to this tenant */
-	i, err := c.ds.GetInstance(server)
+	i, err := c.ds.GetTenantInstance(server)
 	if err != nil {
 		return compute.ErrServerNotFound
 	}
@@ -502,7 +502,7 @@ func (c *controller) DeleteServer(tenant string, server string) error {
 }
 
 func (c *controller) StartServer(tenant string, ID string) error {
-	i, err := c.ds.GetInstance(ID)
+	i, err := c.ds.GetTenantInstance(ID)
 	if err != nil {
 		return err
 	}
@@ -520,7 +520,7 @@ func (c *controller) StartServer(tenant string, ID string) error {
 }
 
 func (c *controller) StopServer(tenant string, ID string) error {
-	i, err := c.ds.GetInstance(ID)
+	i, err := c.ds.GetTenantInstance(ID)
 	if err != nil {
 		return err
 	}

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -187,7 +187,7 @@ func (c *controller) AttachVolume(tenant string, volume string, instance string,
 	}
 
 	// check that the instance is owned by the tenant.
-	i, err := c.ds.GetInstance(instance)
+	i, err := c.ds.GetTenantInstance(instance)
 	if err != nil {
 		return block.ErrInstanceNotFound
 	}
@@ -293,7 +293,7 @@ func (c *controller) DetachVolume(tenant string, volume string, attachment strin
 	// detach everything for this volume
 	for _, a := range attachments {
 		// get instance info
-		i, err := c.ds.GetInstance(a.InstanceID)
+		i, err := c.ds.GetTenantInstance(a.InstanceID)
 		if err != nil {
 			glog.Error(block.ErrInstanceNotFound)
 			// keep going


### PR DESCRIPTION
If we do not need the CNCI because the tenant has deleted all of their instances, delete the CNCI as well in order to keep it from hanging around forever.

Fixes: #1307 