### PR TITLE
storage_bat: Re-enable storage tests

### DIFF
--- a/_release/bat/storage_bat/storage_bat_test.go
+++ b/_release/bat/storage_bat/storage_bat_test.go
@@ -63,7 +63,7 @@ func createSpecificInstance(ctx context.Context, t *testing.T, tenant, workloadI
 }
 
 func createVMInstance(ctx context.Context, t *testing.T, tenant string) string {
-	const testVMWorkload = "Fedora test VM"
+	const testVMWorkload = "Ubuntu test VM"
 
 	w, err := bat.GetWorkloadByName(ctx, tenant, testVMWorkload)
 	if err != nil {


### PR DESCRIPTION
By disabling the Fedora workload by default, I inadvertently disabled
some of the storage BAT tests.  The tests were skipped as the fedora
workload could not be found.  This commit updates the storage tests
to use the Ubuntu workload which is always present on SingleVM builds.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>