### PR TITLE
configuration: Remove unused image service section from configuration

### DIFF
--- a/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/templates/configuration.yaml.j2
+++ b/_DeploymentAndDistroPackaging/ansible/roles/ciao-controller/templates/configuration.yaml.j2
@@ -9,8 +9,6 @@ configure:
     identity_user: {{ ciao_service_user }}
     identity_password: {{ ciao_service_password }}
     compute_fqdn: {{ ciao_controller_fqdn }}
-  image_service:
-    url: https://{{ ciao_controller_fqdn }}:9292
   storage:
     ceph_id: {{ ceph_id }}
   launcher:

--- a/ciao-launcher/tests/ciao-launcher-server/server.go
+++ b/ciao-launcher/tests/ciao-launcher-server/server.go
@@ -484,7 +484,6 @@ func createConfigFile(confPath string) error {
 	conf.Configure.Controller.HTTPSKey = "n/a"
 	conf.Configure.Controller.IdentityUser = "n/a"
 	conf.Configure.Controller.IdentityPassword = "n/a"
-	conf.Configure.ImageService.URL = "http://127.0.0.1"
 	conf.Configure.IdentityService.URL = "http://127.0.0.1"
 
 	conf.Configure.Launcher.DiskLimit = diskLimit

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -59,9 +59,6 @@ configure:
     mgmt_net: list [The launcher management network(s)]
     disk_limit: bool
     mem_limit: bool
-  image_service:
-    type: string [The image service type, e.g. glance]
-    url: string [The image service URL]
   identity_service:
     type: string [The identity service type, e.g. keystone]
     url: string [The identity service URL]
@@ -86,8 +83,6 @@ configure:
     - 192.168.0.0/16
     mgmt_net:
     - 192.168.0.0/16
-  image_service:
-    url: http://glance.example.com:9292
   identity_service:
     url: http://keystone.example.com:35357
 ```
@@ -114,9 +109,6 @@ configure:
     - 192.168.0.0/16
     disk_limit: true
     mem_limit: true
-  image_service:
-    type: glance
-    url: http://glance.example.com:9292
   identity_service:
     type: keystone
     url: http://keystone.example.com:35357

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -29,7 +29,6 @@ import (
 //    scheduler { storage_uri }
 //    controller { compute_ca, compute_cert, identity_user, identity_password }
 //    launcher { compute_net, mgmt_net }
-//    image_service { url }
 //    identity_service { url }
 //
 // so we need to have at least those values set in our config

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -84,9 +84,6 @@ const fullValidConf = `configure:
     - 192.168.1.0/24
     disk_limit: true
     mem_limit: true
-  image_service:
-    type: glance
-    url: http://glance.example.com
   identity_service:
     type: keystone
     url: http://keystone.example.com
@@ -139,7 +136,6 @@ func fillPayload(conf *payloads.Configure) {
 	conf.Configure.Controller.CNCIDisk = 128
 	conf.Configure.Launcher.ComputeNetwork = []string{computeNet}
 	conf.Configure.Launcher.ManagementNetwork = []string{mgmtNet}
-	conf.Configure.ImageService.URL = glanceURL
 	conf.Configure.IdentityService.URL = keystoneURL
 	conf.Configure.Storage.CephID = cephID
 }
@@ -189,7 +185,6 @@ func saneDefaults(conf *payloads.Configure) bool {
 	return (conf.Configure.Controller.VolumePort == 8776 &&
 		conf.Configure.Controller.ComputePort == 8774 &&
 		conf.Configure.Controller.CiaoPort == 8889 &&
-		conf.Configure.ImageService.Type == payloads.Glance &&
 		conf.Configure.IdentityService.Type == payloads.Keystone &&
 		conf.Configure.Launcher.DiskLimit == true &&
 		conf.Configure.Launcher.MemoryLimit == true)

--- a/configuration/file_test.go
+++ b/configuration/file_test.go
@@ -37,8 +37,6 @@ controller:
 launcher:
     compute_net: 192.168.1.110
     mgmt_net: 192.168.1.111
-image_service:
-    url: http://glance.example.com
 identity_service:
     url: http://keystone.example.com
 `

--- a/payloads/configure.go
+++ b/payloads/configure.go
@@ -111,7 +111,6 @@ type ConfigurePayload struct {
 	Storage         ConfigureStorage    `yaml:"storage"`
 	Controller      ConfigureController `yaml:"controller"`
 	Launcher        ConfigureLauncher   `yaml:"launcher"`
-	ImageService    ConfigureService    `yaml:"image_service"`
 	IdentityService ConfigureService    `yaml:"identity_service"`
 }
 
@@ -125,7 +124,6 @@ func (conf *Configure) InitDefaults() {
 	conf.Configure.Controller.VolumePort = 8776
 	conf.Configure.Controller.ComputePort = 8774
 	conf.Configure.Controller.CiaoPort = 8889
-	conf.Configure.ImageService.Type = Glance
 	conf.Configure.IdentityService.Type = Keystone
 	conf.Configure.Launcher.DiskLimit = true
 	conf.Configure.Launcher.MemoryLimit = true

--- a/payloads/configure_test.go
+++ b/payloads/configure_test.go
@@ -34,10 +34,6 @@ func TestConfigureUnmarshal(t *testing.T) {
 		t.Error(err)
 	}
 
-	if cfg.Configure.ImageService.Type != Glance {
-		t.Errorf("Wrong image service type [%s]", cfg.Configure.ImageService.Type)
-	}
-
 	if cfg.Configure.IdentityService.Type != Keystone {
 		t.Errorf("Wrong identity service type [%s]", cfg.Configure.IdentityService.Type)
 	}
@@ -66,9 +62,6 @@ func TestConfigureUnmarshal(t *testing.T) {
 
 func TestConfigureMarshal(t *testing.T) {
 	var cfg Configure
-
-	cfg.Configure.ImageService.Type = Glance
-	cfg.Configure.ImageService.URL = testutil.GlanceURL
 
 	cfg.Configure.IdentityService.Type = Keystone
 	cfg.Configure.IdentityService.URL = testutil.KeystoneURL

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -406,9 +406,6 @@ const ConfigureYaml = `configure:
     - ` + MgmtNet + `
     disk_limit: false
     mem_limit: false
-  image_service:
-    type: glance
-    url: ` + GlanceURL + `
   identity_service:
     type: keystone
     url: ` + KeystoneURL + `

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -332,9 +332,6 @@ configure:
     cnci_disk: 128
     admin_ssh_key: ${test_sshkey}
     admin_password: ${test_passwd}
-  image_service:
-    type: glance
-    url: https://${ciao_host}
   launcher:
     compute_net: [${ciao_vlan_subnet}]
     mgmt_net: [${ciao_vlan_subnet}]


### PR DESCRIPTION
The ImageService struct, part of the Configuration payload, is never read
from. The client obtains the image service details via the openstack
endpoints.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>