### PR TITLE
singlevm: Drop unused network lookup from run_launcher.sh

### DIFF
--- a/testutil/singlevm/run_launcher.sh
+++ b/testutil/singlevm/run_launcher.sh
@@ -2,10 +2,6 @@
 
 ciao_host=$(hostname)
 
-#Obtain the subnet of the primary interface
-default_if=$(ip route list | awk '/^default/ {print $5}')
-default_subnet=$(ip -o -f inet addr show $default_if | awk '{print $4}')
-
 #Cleanup artifacts
 sudo "$GOPATH"/bin/ciao-launcher --alsologtostderr -v 3 --hard-reset
 


### PR DESCRIPTION
In the past it was necessary to tell launcher network configuration
details. However this is no longer necessary so this change removes the
unused variables.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>