### PR TITLE
configuration: Move default CNCI configuration values

### DIFF
--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -85,9 +85,6 @@ var imagesPath = flag.String("images_path", "/var/lib/ciao/images", "path to cia
 
 var cephID = flag.String("ceph_id", "", "ceph client id")
 
-var cnciVCPUs = 4
-var cnciMem = 2048
-var cnciDisk = 2048
 var adminSSHKey = ""
 
 // default password set to "ciao"
@@ -169,17 +166,9 @@ func main() {
 		*cephID = clusterConfig.Configure.Storage.CephID
 	}
 
-	if clusterConfig.Configure.Controller.CNCIVcpus != 0 {
-		cnciVCPUs = clusterConfig.Configure.Controller.CNCIVcpus
-	}
-
-	if clusterConfig.Configure.Controller.CNCIMem != 0 {
-		cnciMem = clusterConfig.Configure.Controller.CNCIMem
-	}
-
-	if clusterConfig.Configure.Controller.CNCIDisk != 0 {
-		cnciDisk = clusterConfig.Configure.Controller.CNCIDisk
-	}
+	cnciVCPUs := clusterConfig.Configure.Controller.CNCIVcpus
+	cnciMem := clusterConfig.Configure.Controller.CNCIMem
+	cnciDisk := clusterConfig.Configure.Controller.CNCIDisk
 
 	adminSSHKey = clusterConfig.Configure.Controller.AdminSSHKey
 

--- a/payloads/configure.go
+++ b/payloads/configure.go
@@ -127,4 +127,7 @@ func (conf *Configure) InitDefaults() {
 	conf.Configure.IdentityService.Type = Keystone
 	conf.Configure.Launcher.DiskLimit = true
 	conf.Configure.Launcher.MemoryLimit = true
+	conf.Configure.Controller.CNCIDisk = 2048
+	conf.Configure.Controller.CNCIMem = 2048
+	conf.Configure.Controller.CNCIVcpus = 4
 }


### PR DESCRIPTION
Move the default values for CNCI resources from controller to the
configuration defaults. This allows code that uses InitDefaults() to get
sane defaults for these values.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>