### PR TITLE
Allow ciao-down VMs mounts and mapped ports to be controlled

### DIFF
--- a/testutil/ciao-down/README.md
+++ b/testutil/ciao-down/README.md
@@ -140,7 +140,22 @@ ciao-down stop is used to power down the ciao-down VM cleanly.
 ciao-down start boots a previously prepared but not running ciao-down VM.
 The start command also supports the --mem and --cpu options.  So it's
 possible to change the resources assigned to the guest VM by stopping it
-and restarting it, specifying --mem and --cpu.
+and restarting it, specifying --mem and --cpu.  It's also possible to
+specify additional port mappings or mounts via the start command.  See
+the section on port mappings below.
+
+Any parameters you pass to the start command override the parameters
+you originally passed to prepare.  These settings are also persisted.
+For example, if you were to run
+
+./ciao-down prepare --mem=2
+./ciao-down stop
+./ciao-down start --mem=1
+./ciao-down stop
+./ciao-down start
+
+The final ciao-down instance would boot with 1GB of RAM even though no mem
+parameter was provided.
 
 ### quit
 
@@ -157,4 +172,30 @@ the host.  However, it is sometimes useful to be able to create commits from
 inside the guest, for example, if you were to ssh into the guest from a machine
 that is not the host.
 
+## Port mappings and Mounts
+
+By default, ciao-down creates two port mappings for ciao VMs, 10022-22 for SSH
+and 3000-3000 for ciao's webui.  It creates a single port mapping for clear
+container VMs for SSH.  It also creates a single mount for the Go Path.  You
+can specify additional port mappings or mounts or even override the default
+settings.
+
+For example,
+
+./ciao-down prepare --mount docs,passthrough,$HOME/Documents --port 10000-80
+
+shares the host directory, $HOME/Documents, with the ciao-down VM using the 9p
+passthrough security model.  The directory can be mounted inside the VM using
+the docs tag.  The command also adds a new port mapping.  127.0.0.1:10000 on
+the host now maps to port 80 on the guest.
+
+Multiple --mount and --port options can be provided and it's also possible to
+override the default ports.  Default mounts can be overridden by specifying
+an existing tag with new options, and default ports can be overridden by
+mapping a new host port to an existing guest port.  For example,
+
+./ciao-down prepare --mount hostgo,none,$HOME/go -port 10023-22
+
+changes the security model with the default hostgo mount and makes the instance
+available via ssh on 127.0.0.1:10023.
 

--- a/testutil/ciao-down/README.md
+++ b/testutil/ciao-down/README.md
@@ -94,17 +94,20 @@ In addition to downloading and building the ciao source code, ciao-down also
 downloads the code for ciao's ui, ciao-webui.  By default it will place the
 source in a local directory in $HOME/ciao-webui.  However, if you are modifying
 the code of the webui it is convenient to have the code shared between your host
-machine and the ciao-down VM.  This can be achieved using the --ui-path.  This
+machine and the ciao-down VM.  This can be achieved using the --mount option.  This
 option takes a path to the location on your host machine where the UI code is
 stored.  This path gets mounted to the same location inside the VM, allowing you to
 modify the sources on your host and compile inside the VM.  For example,
 
-ciao-down prepare --with-ui $HOME/src/ciao-webui
+ciao-down prepare --mount hostui,mapped,$HOME/src/ciao-webui
 
 will create a new ciao-down VM in which the $HOME/src/ciao-webui folder on
-your host will be mounted at $HOME/src/ciao-webui.
+your host will be mounted at $HOME/src/ciao-webui.  It is important to use
+the 'mapped' 9p security model.  If you use passthrough the mounted folder
+will not be writeable in the guest and you will not be able to build the
+web-ui.
 
-Note that if the directory passed to --with-ui option already contains a
+Note that if the directory passed to --mount option already contains a
 git repo, ciao-down will perform no action other than to mount the directory
 in the guest VM.  It will not try to clone the repo or update it.  It assumes
 that the directory already contains the webui code.

--- a/testutil/ciao-down/cloudinit.go
+++ b/testutil/ciao-down/cloudinit.go
@@ -71,6 +71,9 @@ package_upgrade: true
 runcmd:
  - echo "127.0.0.1 singlevm" >> /etc/hosts
  - chown {{.User}}:{{.User}} /home/{{.User}}
+{{- with .MountPath "hostui"}}
+ - chown {{$.User}}:{{$.User}} {{.}}
+{{- end}}
  - rm /etc/update-motd.d/10-help-text /etc/update-motd.d/51-cloudguest
  - rm /etc/update-motd.d/90-updates-available
  - rm /etc/legal

--- a/testutil/ciao-down/vm.go
+++ b/testutil/ciao-down/vm.go
@@ -128,7 +128,7 @@ func newInstanceFromFile(ws *workspace) (*instance, error) {
 	if uiPath != "" {
 		in.Mounts = append(in.Mounts, mount{
 			Tag:           "hostui",
-			SecurityModel: "passthrough",
+			SecurityModel: "mapped",
 			Path:          filepath.Clean(uiPath),
 		})
 	}

--- a/testutil/ciao-down/vm.go
+++ b/testutil/ciao-down/vm.go
@@ -22,12 +22,16 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"text/tabwriter"
 	"time"
+
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/01org/ciao/qemu"
 )
@@ -39,7 +43,171 @@ const (
 	urlParam          = "url"
 )
 
-func bootVM(ctx context.Context, ws *workspace, memGB, CPUs int) error {
+type portMapping struct {
+	Host  int `yaml:"host"`
+	Guest int `yaml:"guest"`
+}
+
+func (p portMapping) String() string {
+	return fmt.Sprintf("%d-%d", p.Host, p.Guest)
+}
+
+type mount struct {
+	Tag           string `yaml:"tag"`
+	SecurityModel string `yaml:"security_model"`
+	Path          string `yaml:"path"`
+}
+
+func (m mount) String() string {
+	return fmt.Sprintf("%s,%s,%s", m.Tag, m.SecurityModel, m.Path)
+}
+
+type instance struct {
+	MemGiB       int           `yaml:"mem_gib"`
+	CPUs         int           `yaml:"cpus"`
+	PortMappings []portMapping `yaml:"ports"`
+	Mounts       []mount       `yaml:"mounts"`
+}
+
+func newDefaultInstance(ws *workspace, vmType string) *instance {
+	var in instance
+
+	in.Mounts = []mount{
+		{
+			Tag:           "hostgo",
+			SecurityModel: "passthrough",
+			Path:          ws.GoPath,
+		},
+	}
+
+	in.PortMappings = []portMapping{
+		{
+			Host:  10022,
+			Guest: 22,
+		},
+	}
+
+	if vmType == CIAO {
+		in.PortMappings = append(in.PortMappings, portMapping{
+			Host:  3000,
+			Guest: 3000,
+		})
+	}
+
+	return &in
+}
+
+func newInstanceFromFile(ws *workspace) (*instance, error) {
+	in := &instance{}
+
+	err := in.load(ws)
+	if err == nil {
+		return in, nil
+	}
+
+	// Check for legacy state files.
+
+	vmType := CIAO
+	data, err := ioutil.ReadFile(path.Join(ws.instanceDir, "vmtype.txt"))
+	if err == nil {
+		vmType = string(data)
+		if vmType != CIAO && vmType != CLEARCONTAINERS {
+			err := fmt.Errorf("Unsupported vmType %s. Should be one of "+CIAO+"|"+CLEARCONTAINERS, vmType)
+			return nil, err
+		}
+	}
+
+	uiPath := ""
+	data, err = ioutil.ReadFile(path.Join(ws.instanceDir, "ui_path.txt"))
+	if err == nil {
+		uiPath = string(data)
+	}
+
+	in = newDefaultInstance(ws, vmType)
+
+	if uiPath != "" {
+		in.Mounts = append(in.Mounts, mount{
+			Tag:           "hostui",
+			SecurityModel: "passthrough",
+			Path:          filepath.Clean(uiPath),
+		})
+	}
+
+	return in, nil
+}
+
+func (in *instance) load(ws *workspace) error {
+	data, err := ioutil.ReadFile(path.Join(ws.instanceDir, "state.yaml"))
+	if err != nil {
+		return fmt.Errorf("Unable to read instance state : %v", err)
+	}
+
+	err = yaml.Unmarshal(data, in)
+	if err != nil {
+		return fmt.Errorf("Unable to unmarshall instance state : %v", err)
+	}
+	return nil
+}
+
+func (in *instance) save(ws *workspace) error {
+	data, err := yaml.Marshal(in)
+	if err != nil {
+		return fmt.Errorf("Unable to marshall instance state : %v", err)
+	}
+	err = ioutil.WriteFile(path.Join(ws.instanceDir, "state.yaml"),
+		data, 0600)
+	if err != nil {
+		return fmt.Errorf("Unable to write instance state : %v", err)
+	}
+	return nil
+}
+
+func (in *instance) mergeMounts(m mounts) {
+	mountCount := len(in.Mounts)
+	for _, mount := range m {
+		var i int
+		for i = 0; i < mountCount; i++ {
+			if mount.Tag == in.Mounts[i].Tag {
+				break
+			}
+		}
+
+		if i == mountCount {
+			in.Mounts = append(in.Mounts, mount)
+		} else {
+			in.Mounts[i] = mount
+		}
+	}
+}
+
+func (in *instance) mergePorts(p ports) {
+	portCount := len(in.PortMappings)
+	for _, port := range p {
+		var i int
+		for i = 0; i < portCount; i++ {
+			if port.Guest == in.PortMappings[i].Guest {
+				break
+			}
+		}
+
+		if i == portCount {
+			in.PortMappings = append(in.PortMappings, port)
+		} else {
+			in.PortMappings[i] = port
+		}
+	}
+}
+
+func (in *instance) sshPort() (int, error) {
+	for _, p := range in.PortMappings {
+		if p.Guest == 22 {
+			return p.Host, nil
+		}
+	}
+	return 0, fmt.Errorf("No SSH port configured")
+}
+
+func bootVM(ctx context.Context, ws *workspace, in *instance) error {
 	disconnectedCh := make(chan struct{})
 	socket := path.Join(ws.instanceDir, "socket")
 	qmp, _, err := qemu.QMPStart(ctx, socket, qemu.QMPConfig{}, disconnectedCh)
@@ -50,10 +218,8 @@ func bootVM(ctx context.Context, ws *workspace, memGB, CPUs int) error {
 
 	vmImage := path.Join(ws.instanceDir, "image.qcow2")
 	isoPath := path.Join(ws.instanceDir, "config.iso")
-	memParam := fmt.Sprintf("%dG", memGB)
-	CPUsParam := fmt.Sprintf("cpus=%d", CPUs)
-	fsdevParam := fmt.Sprintf("local,security_model=passthrough,id=fsdev0,path=%s",
-		ws.GoPath)
+	memParam := fmt.Sprintf("%dG", in.MemGiB)
+	CPUsParam := fmt.Sprintf("cpus=%d", in.CPUs)
 	args := []string{
 		"-qmp", fmt.Sprintf("unix:%s,server,nowait", socket),
 		"-m", memParam, "-smp", CPUsParam,
@@ -61,21 +227,32 @@ func bootVM(ctx context.Context, ws *workspace, memGB, CPUs int) error {
 		"-drive", fmt.Sprintf("file=%s,if=virtio,media=cdrom", isoPath),
 		"-daemonize", "-enable-kvm", "-cpu", "host",
 		"-net", "nic,model=virtio",
-		"-fsdev", fsdevParam,
-		"-device", "virtio-9p-pci,id=fs0,fsdev=fsdev0,mount_tag=hostgo",
-	}
-	if ws.vmType == CIAO {
-		args = append(args, "-net", "user,hostfwd=tcp::10022-:22,hostfwd=tcp::3000-:3000")
-	} else {
-		args = append(args, "-net", "user,hostfwd=tcp::10022-:22")
 	}
 
-	if ws.UIPath != "" {
-		fsdevParam := fmt.Sprintf("local,security_model=passthrough,id=fsdev1,path=%s",
-			ws.UIPath)
-		args = append(args, "-fsdev", fsdevParam)
-		args = append(args, "-device", "virtio-9p-pci,id=fs1,fsdev=fsdev1,mount_tag=hostui")
+	for i, m := range in.Mounts {
+		fsdevParam := fmt.Sprintf("local,security_model=%s,id=fsdev%d,path=%s",
+			m.SecurityModel, i, m.Path)
+		devParam := fmt.Sprintf("virtio-9p-pci,id=fs%[1]d,fsdev=fsdev%[1]d,mount_tag=%s",
+			i, m.Tag)
+		args = append(args, "-fsdev", fsdevParam, "-device", devParam)
 	}
+
+	var b bytes.Buffer
+	if len(in.PortMappings) > 0 {
+		i := 0
+		p := in.PortMappings[i]
+		b.WriteString(fmt.Sprintf("user,hostfwd=tcp::%d-:%d", p.Host, p.Guest))
+		for i = i + 1; i < len(in.PortMappings); i++ {
+			p := in.PortMappings[i]
+			b.WriteString(fmt.Sprintf(",hostfwd=tcp::%d-:%d", p.Host, p.Guest))
+		}
+	}
+
+	netParam := b.String()
+	if len(netParam) > 0 {
+		args = append(args, "-net", netParam)
+	}
+
 	args = append(args, "-display", "none", "-vga", "none")
 
 	output, err := qemu.LaunchCustomQemu(ctx, "", args, nil, nil)
@@ -120,9 +297,10 @@ func quitVM(ctx context.Context, instanceDir string) error {
 	})
 }
 
-func sshReady(ctx context.Context) bool {
+func sshReady(ctx context.Context, sshPort int) bool {
 	dialer := net.Dialer{}
-	conn, err := dialer.DialContext(ctx, "tcp", "127.0.0.1:10022")
+	conn, err := dialer.DialContext(ctx, "tcp",
+		fmt.Sprintf("127.0.0.1:%d", sshPort))
 	if err != nil {
 		return false
 	}
@@ -133,12 +311,12 @@ func sshReady(ctx context.Context) bool {
 	return retval
 }
 
-func statusVM(ctx context.Context, instanceDir, keyPath string) {
+func statusVM(ctx context.Context, instanceDir, keyPath string, sshPort int) {
 	status := "ciao down"
 	ssh := "N/A"
-	if sshReady(ctx) {
+	if sshReady(ctx, sshPort) {
 		status = "ciao up"
-		ssh = fmt.Sprintf("ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i %s 127.0.0.1 -p %d", keyPath, 10022)
+		ssh = fmt.Sprintf("ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i %s 127.0.0.1 -p %d", keyPath, sshPort)
 	}
 
 	w := new(tabwriter.Writer)


### PR DESCRIPTION
The commit makes three main changes to ciao-down.

- The settings, e.g., memory, cpu usage and mounts, specified when VMs are created using prepare or started using start, are now persisted.  These settings are re-used when the VM is started at a later date.
- Users can specify which directories they would like to see mounted in the guest VM and the 9p security model used to mount them.  Multiple mounts can be specified.
- Users can specify which ports can be mapped from the host's localhost to the guest VM.

The two vm types currently supported by ciao include one mounted directory by default, the GOPATH.  It is not possible to remove this mount entirely via the command line, although this can be done by editing the ~/.ciao-down/instance/state.yaml.  However, it is possible to change the security model or the host directory to mount.  This can done as follows

--mount hostgo,none,$HOME/go

The key is to specify the existing hostgo tag.  When ciao-down processes a new mount it checks to see whether the tag, hostgo in this case, already exists.  If it does it updates the mount with the new information.

A similar situation exists with ports.  Each ciao-down VM has one port mapped, port 22, which is mapped to 10022 on the hosts localhost interface.  It is possible to change the host port by specifying a --port option, e.g.,

--port 10023-22

As the guest port 22 has already been defined a new port mapping is not created.  Instead the host port of the existing mapping is updated from 10022 to 10023.
