### PR TITLE
singlevm: Split up and clean up legacy parts

### DIFF
--- a/testutil/singlevm/run_controller.sh
+++ b/testutil/singlevm/run_controller.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 ciao_host=$(hostname)
+ciao_dir=/var/lib/ciao
+ciao_data_dir=${ciao_dir}/data
+ciao_ctl_dir=${ciao_data_dir}/controller
+
+#Create controller dirs
+echo "Making ciao workloads dir: ${ciao_ctl_dir}/workloads"
+sudo mkdir -p ${ciao_ctl_dir}/workloads
+if [ ! -d ${ciao_ctl_dir}/workloads ]
+then
+	echo "FATAL ERROR: Unable to create ${ciao_ctl_dir}/workloads}"
+	exit 1
+fi
 
 sudo rm ciao-controller.db-shm ciao-controller.db-wal ciao-controller.db /tmp/ciao-controller-stats.db
 

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -64,7 +64,6 @@ export CIAO_USERNAME="$ciao_demo_username"
 export CIAO_PASSWORD="$ciao_demo_password"
 export CIAO_ADMIN_USERNAME="$ciao_admin_username"
 export CIAO_ADMIN_PASSWORD="$ciao_admin_password"
-export CIAO_CA_CERT_FILE="$ciao_bin"/"CAcert-""$ciao_host"".pem"
 export CIAO_IDENTITY="$ciao_identity_url"
 export CIAO_SSH_KEY="$workload_sshkey"
 
@@ -326,7 +325,6 @@ cacert_prog_fedora=$(type -p update-ca-trust)
 if [ x"$cacert_prog_ubuntu" != x ] && [ -x "$cacert_prog_ubuntu" ]; then
     cacert_dir=/usr/local/share/ca-certificates
     sudo install -m 0644 -T "$keystone_cert" "$cacert_dir"/keystone.crt
-    sudo install -m 0644 -T "$CIAO_CA_CERT_FILE" "$cacert_dir"/ciao.crt
     sudo "$cacert_prog_ubuntu"
 
     # Do it a second time with nothing new to make it clean out the old
@@ -344,7 +342,6 @@ elif [ x"$cacert_prog_fedora" != x ] && [ -x "$cacert_prog_fedora" ]; then
     
     if [ -d "$cacert_dir" ]; then
         sudo install -m 0644 -t "$cacert_dir" "$keystone_cert"
-        sudo install -m 0644 -t "$cacert_dir" "$CIAO_CA_CERT_FILE"
         sudo "$cacert_prog_fedora" extract
     else
 	echo "Unable to add keystone's CA certificate to your system's trusted \

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -295,23 +295,6 @@ cd "$ciao_bin"
 "$ciao_bin"/run_launcher.sh   &> /dev/null
 "$ciao_bin"/run_controller.sh &> /dev/null
 
-echo -n "Waiting up to $ciao_image_wait_time seconds for the ciao image" \
-    "service to become available "
-try_until=$(($(date +%s) + $ciao_image_wait_time))
-while : ; do
-    while [ $(date +%s) -le $try_until ]; do
-        if ciao-cli image list > /dev/null 2>&1; then
-            echo " READY"
-            break 2
-        else
-            echo -n .
-            sleep 1
-        fi
-    done
-    echo FAILED
-    break
-done
-
 # become admin in order to upload images and setup workloads
 export CIAO_USERNAME=$CIAO_ADMIN_USERNAME
 export CIAO_PASSWORD=$CIAO_ADMIN_PASSWORD

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -241,47 +241,6 @@ fi
     -email="$ciao_email" -organization="$ciao_org" -host="$ciao_host" \
     -ip="$ciao_vlan_ip" -verify
 
-openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-    -keyout "$keystone_key" -out "$keystone_cert" -subj "/C=US/ST=CA/L=Santa Clara/O=ciao/CN=$ciao_host"
-
-#Copy the certs
-sudo install -m 0644 -t "$ciao_pki_path" "$keystone_cert"
-
-#Update system's trusted certificates
-cacert_prog_ubuntu=$(type -p update-ca-certificates)
-cacert_prog_fedora=$(type -p update-ca-trust)
-if [ x"$cacert_prog_ubuntu" != x ] && [ -x "$cacert_prog_ubuntu" ]; then
-    cacert_dir=/usr/local/share/ca-certificates
-    sudo install -m 0644 -T "$keystone_cert" "$cacert_dir"/keystone.crt
-    sudo "$cacert_prog_ubuntu"
-
-    # Do it a second time with nothing new to make it clean out the old
-    sudo "$cacert_prog_ubuntu" --fresh
-elif [ x"$cacert_prog_fedora" != x ] && [ -x "$cacert_prog_fedora" ]; then
-    cacert_dir_fedora=/etc/pki/ca-trust/source/anchors/
-    cacert_dir_archlinux=/etc/ca-certificates/trust-source/anchors
-    cacert_dir=""
-
-    if [ -d "$cacert_dir_fedora" ]; then
-	cacert_dir=$cacert_dir_fedora
-    elif [ -d "$cacert_dir_archlinux" ]; then
-	cacert_dir=$cacert_dir_archlinux
-    fi
-    
-    if [ -d "$cacert_dir" ]; then
-        sudo install -m 0644 -t "$cacert_dir" "$keystone_cert"
-        sudo "$cacert_prog_fedora" extract
-    else
-	echo "Unable to add keystone's CA certificate to your system's trusted \
-             store!"
-	exit 1
-    fi
-else
-    echo "Unable to add keystone's CA certificate to your system's trusted \
-        store!"
-    exit 1
-fi
-
 #Copy the launch scripts
 cp "$ciao_scripts"/run_scheduler.sh "$ciao_bin"
 cp "$ciao_scripts"/run_controller.sh "$ciao_bin"

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -246,15 +246,6 @@ cat <<-EOF
 EOF
 ) > $webui_conf_file
 
-
-sudo mkdir -p ${ciao_dir}/images
-if [ ! -d ${ciao_dir}/images ]
-then
-	echo "FATAL ERROR: Unable to create $ciao_dir/images"
-	exit 1
-
-fi
-
 sudo mkdir -p ${ciao_pki_path}
 if [ ! -d ${ciao_pki_path} ]
 then

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -241,12 +241,6 @@ fi
     -email="$ciao_email" -organization="$ciao_org" -host="$ciao_host" \
     -ip="$ciao_vlan_ip" -verify
 
-#Copy the launch scripts
-cp "$ciao_scripts"/run_scheduler.sh "$ciao_bin"
-cp "$ciao_scripts"/run_controller.sh "$ciao_bin"
-cp "$ciao_scripts"/run_launcher.sh "$ciao_bin"
-cp "$ciao_scripts"/verify.sh "$ciao_bin"
-
 # Set macvlan interface
 if [ -x "$(command -v ip)" ]; then
     sudo ip link del "$ciao_bridge"
@@ -288,6 +282,12 @@ source $ciao_scripts/setup_keystone.sh
 # This runs *after* keystone so keystone will get port 5000 first
 sudo docker run --name ceph-demo -d --net=host -v /etc/ceph:/etc/ceph -e MON_IP=$ciao_vlan_ip -e CEPH_PUBLIC_NETWORK=$ciao_vlan_subnet ceph/demo
 sudo ceph auth get-or-create client.ciao -o /etc/ceph/ceph.client.ciao.keyring mon 'allow *' osd 'allow *' mds 'allow'
+
+#Copy the launch scripts
+cp "$ciao_scripts"/run_scheduler.sh "$ciao_bin"
+cp "$ciao_scripts"/run_controller.sh "$ciao_bin"
+cp "$ciao_scripts"/run_launcher.sh "$ciao_bin"
+cp "$ciao_scripts"/verify.sh "$ciao_bin"
 
 #Kick off the agents
 cd "$ciao_bin"

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -295,8 +295,6 @@ cd "$ciao_bin"
 "$ciao_bin"/run_launcher.sh   &> /dev/null
 "$ciao_bin"/run_controller.sh &> /dev/null
 
-. $ciao_env
-
 echo -n "Waiting up to $ciao_image_wait_time seconds for the ciao image" \
     "service to become available "
 try_until=$(($(date +%s) + $ciao_image_wait_time))

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -22,8 +22,6 @@ ciao_gobin="$GOPATH"/bin
 ciao_scripts="$GOPATH"/src/github.com/01org/ciao/testutil/singlevm
 ciao_env="$ciao_bin/demo.sh"
 ciao_dir=/var/lib/ciao
-ciao_data_dir=${ciao_dir}/data
-ciao_ctl_dir=${ciao_data_dir}/controller
 ciao_cnci_image="clear-8260-ciao-networking.img"
 ciao_cnci_url="https://download.clearlinux.org/demos/ciao"
 fedora_cloud_image="Fedora-Cloud-Base-24-1.2.x86_64.qcow2"
@@ -314,10 +312,6 @@ openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
 
 #Copy the certs
 sudo install -m 0644 -t "$ciao_pki_path" "$keystone_cert"
-sudo install -m 0644 -t "$ciao_pki_path" \
-    "$ciao_bin"/"cert-Controller-""$ciao_host"".pem"
-sudo install -m 0644 -t "$ciao_pki_path" \
-    "$ciao_bin"/"CAcert-""$ciao_host"".pem"
 
 if [ ! -f ${ciao_pki_path}/${ui_cert} ] || [ ! -f ${ciao_pki_path}/${ui_key} ]; then
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
@@ -361,16 +355,6 @@ else
     echo "Unable to add keystone's CA certificate to your system's trusted \
         store!"
     exit 1
-fi
-
-
-#Create controller dirs
-echo "Making ciao workloads dir: ${ciao_ctl_dir}/workloads"
-sudo mkdir -p ${ciao_ctl_dir}/workloads
-if [ ! -d ${ciao_ctl_dir}/workloads ]
-then
-	echo "FATAL ERROR: Unable to create ${ciao_ctl_dir}/workloads}"
-	exit 1
 fi
 
 #Copy the launch scripts

--- a/testutil/singlevm/setup_images.sh
+++ b/testutil/singlevm/setup_images.sh
@@ -1,0 +1,130 @@
+#Download the firmware
+cd "$ciao_bin"
+if [ $download -eq 1 ] || [ ! -f OVMF.fd ]
+then
+	rm -f OVMF.fd
+	curl -O https://download.clearlinux.org/image/OVMF.fd
+fi
+
+if [ ! -f OVMF.fd ]
+then
+	echo "FATAL ERROR: unable to download firmware"
+	exit 1
+fi
+
+sudo cp -f OVMF.fd  /usr/share/qemu/OVMF.fd
+
+#Generate the CNCI VM and seed the image and populate the image cache
+cd "$ciao_bin"
+rm -f "$ciao_cnci_image".qcow
+
+if [ $download -eq 1 ] || [ ! -f "$ciao_cnci_image" ] 
+then
+	rm -f "$ciao_cnci_image"
+	"$GOPATH"/src/github.com/01org/ciao/networking/ciao-cnci-agent/scripts/generate_cnci_cloud_image.sh -c "$ciao_bin" -i "$ciao_cnci_image" -d -u "$ciao_cnci_url"
+else
+	"$GOPATH"/src/github.com/01org/ciao/networking/ciao-cnci-agent/scripts/generate_cnci_cloud_image.sh -c "$ciao_bin" -i "$ciao_cnci_image"
+fi
+
+if [ $? -ne 0 ]
+then
+	echo "FATAL ERROR: Unable to mount CNCI Image"
+	exit 1
+fi
+
+if [ ! -f "$ciao_cnci_image" ]
+then
+	echo "FATAL ERROR: unable to download CNCI Image"
+	exit 1
+fi
+
+qemu-img convert -f raw -O qcow2 "$ciao_cnci_image" "$ciao_cnci_image".qcow
+
+if [ $all_images -eq 1 ]
+then
+    cd "$ciao_bin"
+    if [ $download -eq 1 ]
+    then
+	LATEST=$(curl https://download.clearlinux.org/latest)
+    else
+	# replace this will a function that looks in ~local cache
+	# for the last version of clear to use.
+	LATEST="12620"
+    fi
+
+    if [ $download -eq 1 ] || [ ! -f clear-"${LATEST}"-cloud.img ]
+    then
+	rm -f clear-"${LATEST}"-cloud.img.xz
+	rm -f clear-"${LATEST}"-cloud.img
+	curl -O https://download.clearlinux.org/releases/"$LATEST"/clear/clear-"$LATEST"-cloud.img.xz
+	xz -T0 --decompress clear-"${LATEST}"-cloud.img.xz
+    fi
+
+
+    if [ ! -f clear-"${LATEST}"-cloud.img ]
+    then
+	echo "FATAL ERROR: unable to download clear cloud Image"
+	exit 1
+    fi
+
+    cd "$ciao_bin"
+    if [ $download -eq 1 ] || [ ! -f $fedora_cloud_image ]
+    then
+	rm -f $fedora_cloud_image
+	curl -L -O $fedora_cloud_url
+    fi
+
+    if [ ! -f $fedora_cloud_image ]
+    then
+	echo "FATAL ERROR: unable to download fedora cloud Image"
+	exit 1
+    fi
+fi
+
+#Ubuntu, needed for kubicle and BAT tests
+cd "$ciao_bin"
+if [ $download -eq 1 ] || [ ! -f $ubuntu_cloud_image ]
+then
+    rm -f $ubuntu_cloud_image
+    curl -L -O $ubuntu_cloud_url
+fi
+
+if [ ! -f $ubuntu_cloud_image ]
+then
+	echo "FATAL ERROR: unable to download Ubuntu cloud Image"
+	exit 1
+fi
+
+echo ""
+echo "Uploading test images to image service"
+echo "---------------------------------------------------------------------------------------"
+if [ -f "$ciao_cnci_image".qcow ]; then
+    "$ciao_gobin"/ciao-cli \
+        image add --file "$ciao_cnci_image".qcow \
+        --name "ciao CNCI image" --id 4e16e743-265a-4bf2-9fd1-57ada0b28904 \
+	--visibility internal
+fi
+
+if [ $all_images -eq 1 ]
+then
+    if [ -f clear-"${LATEST}"-cloud.img ]; then
+	"$ciao_gobin"/ciao-cli \
+		     image add --file clear-"${LATEST}"-cloud.img \
+		     --name "Clear Linux ${LATEST}" --id df3768da-31f5-4ba6-82f0-127a1a705169 \
+		     --visibility public
+    fi
+
+    if [ -f $fedora_cloud_image ]; then
+	"$ciao_gobin"/ciao-cli \
+		     image add --file $fedora_cloud_image \
+		     --name "Fedora Cloud Base 24-1.2" --id 73a86d7e-93c0-480e-9c41-ab42f69b7799 \
+		     --visibility public
+    fi
+fi
+
+if [ -f $ubuntu_cloud_image ]; then
+    "$ciao_gobin"/ciao-cli \
+        image add --file $ubuntu_cloud_image \
+        --name "Ubuntu Server 16.04" \
+	--visibility public
+fi

--- a/testutil/singlevm/setup_images.sh
+++ b/testutil/singlevm/setup_images.sh
@@ -95,6 +95,23 @@ then
 	exit 1
 fi
 
+echo -n "Waiting up to $ciao_image_wait_time seconds for the ciao image" \
+    "service to become available "
+try_until=$(($(date +%s) + $ciao_image_wait_time))
+while : ; do
+    while [ $(date +%s) -le $try_until ]; do
+        if ciao-cli image list > /dev/null 2>&1; then
+            echo " READY"
+            break 2
+        else
+            echo -n .
+            sleep 1
+        fi
+    done
+    echo FAILED
+    break
+done
+
 echo ""
 echo "Uploading test images to image service"
 echo "---------------------------------------------------------------------------------------"

--- a/testutil/singlevm/setup_keystone.sh
+++ b/testutil/singlevm/setup_keystone.sh
@@ -1,3 +1,44 @@
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+    -keyout "$keystone_key" -out "$keystone_cert" -subj "/C=US/ST=CA/L=Santa Clara/O=ciao/CN=$ciao_host"
+
+#Copy the certs
+sudo install -m 0644 -t "$ciao_pki_path" "$keystone_cert"
+
+#Update system's trusted certificates
+cacert_prog_ubuntu=$(type -p update-ca-certificates)
+cacert_prog_fedora=$(type -p update-ca-trust)
+if [ x"$cacert_prog_ubuntu" != x ] && [ -x "$cacert_prog_ubuntu" ]; then
+    cacert_dir=/usr/local/share/ca-certificates
+    sudo install -m 0644 -T "$keystone_cert" "$cacert_dir"/keystone.crt
+    sudo "$cacert_prog_ubuntu"
+
+    # Do it a second time with nothing new to make it clean out the old
+    sudo "$cacert_prog_ubuntu" --fresh
+elif [ x"$cacert_prog_fedora" != x ] && [ -x "$cacert_prog_fedora" ]; then
+    cacert_dir_fedora=/etc/pki/ca-trust/source/anchors/
+    cacert_dir_archlinux=/etc/ca-certificates/trust-source/anchors
+    cacert_dir=""
+
+    if [ -d "$cacert_dir_fedora" ]; then
+	cacert_dir=$cacert_dir_fedora
+    elif [ -d "$cacert_dir_archlinux" ]; then
+	cacert_dir=$cacert_dir_archlinux
+    fi
+    
+    if [ -d "$cacert_dir" ]; then
+        sudo install -m 0644 -t "$cacert_dir" "$keystone_cert"
+        sudo "$cacert_prog_fedora" extract
+    else
+	echo "Unable to add keystone's CA certificate to your system's trusted \
+             store!"
+	exit 1
+    fi
+else
+    echo "Unable to add keystone's CA certificate to your system's trusted \
+        store!"
+    exit 1
+fi
+
 # Generate the post-keystone script to issue singlevm-specific openstack
 # commands
 ( cat <<-EOF

--- a/testutil/singlevm/setup_keystone.sh
+++ b/testutil/singlevm/setup_keystone.sh
@@ -1,0 +1,65 @@
+# Generate the post-keystone script to issue singlevm-specific openstack
+# commands
+( cat <<-EOF
+#!/bin/bash
+
+# Create basic services, users, and projects/tenants
+openstack service create --name ciao compute
+openstack user create --password "$ciao_password" "$ciao_username"
+openstack role add --project service --user "$ciao_username" admin
+openstack user create --password "$ciao_demo_password" "$ciao_demo_username"
+openstack project show demo
+if [[ \$? == 1 ]]; then
+    openstack project create --domain default demo
+fi
+openstack role add --project demo --user "$ciao_demo_username" user
+
+# Create image service endpoints
+openstack service create --name glance --description "Image Service" image
+openstack endpoint create --region RegionOne image public   https://$ciao_host:9292
+openstack endpoint create --region RegionOne image internal https://$ciao_host:9292
+openstack endpoint create --region RegionOne image admin    https://$ciao_host:9292
+
+# admin should only be admin of the admin project. This role was created by the
+# keystone container's bootstrap.
+openstack role remove --project service --user admin admin
+
+# Create storage endpoints
+openstack service create --name cinderv2 --description "Volume Service" volumev2
+openstack endpoint create --region RegionOne volumev2 public   'https://$ciao_host:8776/v2/%(tenant_id)s'
+openstack endpoint create --region RegionOne volumev2 internal 'https://$ciao_host:8776/v2/%(tenant_id)s'
+openstack endpoint create --region RegionOne volumev2 admin    'https://$ciao_host:8776/v2/%(tenant_id)s'
+
+EOF
+) > "$ciao_bin"/post-keystone.sh
+chmod 755 "$ciao_bin"/post-keystone.sh
+
+## Install keystone
+sudo docker run -d -it --name keystone \
+    --add-host="$ciao_host":"$ciao_ip" \
+    -p $keystone_public_port:5000 \
+    -p $keystone_admin_port:35357 \
+    -e IDENTITY_HOST="$ciao_host" -e KEYSTONE_ADMIN_PASSWORD="${OS_PASSWORD}" \
+    -v "$ciao_bin"/post-keystone.sh:/usr/bin/post-keystone.sh \
+    -v $mysql_data_dir:/var/lib/mysql \
+    -v "$keystone_cert":/etc/nginx/ssl/keystone_cert.pem \
+    -v "$keystone_key":/etc/nginx/ssl/keystone_key.pem clearlinux/keystone:stable
+
+echo -n "Waiting up to $keystone_wait_time seconds for keystone identity" \
+    "service to become available"
+try_until=$(($(date +%s) + $keystone_wait_time))
+while : ; do
+    while [ $(date +%s) -le $try_until ]; do
+        # The keystone container tails the log at the end of its
+        # initialization script
+        if docker exec keystone pidof tail > /dev/null 2>&1; then
+            echo READY
+            break 2
+        else
+            echo -n .
+            sleep 1
+        fi
+    done
+    echo FAILED
+    break
+done

--- a/testutil/singlevm/setup_webui.sh
+++ b/testutil/singlevm/setup_webui.sh
@@ -1,0 +1,73 @@
+ui_key=ui_key.pem
+ui_cert=ui_cert.pem
+
+webui_conf_file="$ciao_bin"/webui_config.json
+
+if [ ! -f ${ciao_pki_path}/${ui_cert} ] || [ ! -f ${ciao_pki_path}/${ui_key} ]; then
+    openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+	    -keyout ${ciao_bin}/${ui_key} -out ${ciao_bin}/${ui_cert} \
+	    -subj "/C=US/ST=CA/L=Santa Clara/O=ciao/CN=localhost"
+    sudo install -m 0644 -t "$ciao_pki_path" ${ciao_bin}/${ui_cert} ${ciao_bin}/${ui_key}
+fi
+
+echo "Generating webui configuration file $webui_conf_file"
+(
+cat <<-EOF
+{
+    "production": {
+        "controller": {
+            "host": "${ciao_host}",
+            "port": "${compute_api_port}",
+            "protocol": "https"
+        },
+        "storage":{
+            "host": "${ciao_host}",
+            "port": "${storage_api_port}",
+            "protocol": "https"
+        },
+        "keystone": {
+            "host": "${ciao_host}",
+            "port": "${keystone_admin_port}",
+            "protocol": "https",
+            "uri": "/v3/auth/tokens"
+        },
+        "ui": {
+            "protocol": "https",
+            "certificates": {
+                "key": "${ciao_pki_path}/${ui_key}",
+                "cert": "${ciao_pki_path}/${ui_cert}",
+                "passphrase": "",
+                "trusted": []
+            }
+        }
+    },
+    "development": {
+        "controller": {
+            "host": "${ciao_host}",
+            "port": "${compute_api_port}",
+            "protocol": "https"
+        },
+        "storage":{
+            "host": "${ciao_host}",
+            "port": "${storage_api_port}",
+            "protocol": "https"
+        },
+        "keystone": {
+            "host": "${ciao_host}",
+            "port": "${keystone_admin_port}",
+            "protocol": "https",
+            "uri": "/v3/auth/tokens"
+        },
+        "ui": {
+            "protocol": "https",
+            "certificates": {
+                "key": "${ciao_pki_path}/${ui_key}",
+                "cert": "${ciao_pki_path}/${ui_cert}",
+                "passphrase": "",
+                "trusted": []
+            }
+        }
+    }
+}
+EOF
+) > $webui_conf_file

--- a/testutil/singlevm/setup_workloads.sh
+++ b/testutil/singlevm/setup_workloads.sh
@@ -1,0 +1,164 @@
+
+function createWorkloads() {
+	mkdir -p ${ciao_bin}/workload_examples
+	if [ ! -d ${ciao_bin}/workload_examples ]
+	then
+		echo "FATAL ERROR: Unable to create ${ciao_bin}/workload_examples"
+		exit 1
+
+	fi
+
+	sudo chmod 755 "$ciao_bin"/workload_examples
+
+	# create a VM test workload with ssh capability
+	echo "Generating VM cloud-init"
+	(
+	cat <<-EOF
+	---
+	#cloud-config
+	users:
+	  - name: demouser
+	    gecos: CIAO Demo User
+	    lock-passwd: false
+	    passwd: ${test_passwd}
+	    sudo: ALL=(ALL) NOPASSWD:ALL
+	    ssh-authorized-keys:
+	      - ${test_sshkey}
+	...
+	EOF
+	) > "$ciao_bin"/workload_examples/vm-test.yaml
+
+	if [ $all_images -eq 1 ]
+	then
+	    # Get the image ID for the fedora cloud image
+	    id=$(ciao-cli image list -f='{{$x := filter . "Name" "Fedora Cloud Base 24-1.2"}}{{if gt (len $x) 0}}{{(index $x 0).ID}}{{end}}')
+
+	    # add 3 vm test workloads
+	    echo "Generating Fedora VM test workload"
+	    (
+		cat <<-EOF
+		description: "Fedora test VM"
+		vm_type: qemu
+		fw_type: legacy
+		defaults:
+		    vcpus: 2
+		    mem_mb: 128
+		    disk_mb: 80
+		cloud_init: "vm-test.yaml"
+		disks:
+		  - source:
+		       service: image
+		       id: "$id"
+		    ephemeral: true
+		    bootable: true
+		EOF
+	    ) > "$ciao_bin"/workload_examples/fedora_vm.yaml
+
+	    # get the clear image id
+	    clear_id=$(ciao-cli image list -f='{{$x := filter . "Name" "Clear Linux '"${LATEST}"'"}}{{if gt (len $x) 0}}{{(index $x 0).ID}}{{end}}')
+
+	    # create a clear VM workload definition
+	    echo "Creating Clear test workload"
+	    (
+		cat <<-EOF
+		description: "Clear Linux test VM"
+		vm_type: qemu
+		fw_type: efi
+		defaults:
+		    vcpus: 2
+		    mem_mb: 128
+		    disk_mb: 80
+		cloud_init: "vm-test.yaml"
+		disks:
+		  - source:
+		       service: image
+		       id: "$clear_id"
+		    ephemeral: true
+		    bootable: true
+		EOF
+	    ) > "$ciao_bin"/workload_examples/clear_vm.yaml
+
+	fi
+
+	# get the clear image id
+	ubuntu_id=$(ciao-cli image list -f='{{select (head (filter . "Name" "Ubuntu Server 16.04")) "ID"}}')
+
+	echo "Generating Ubuntu VM test workload"
+	(
+	cat <<-EOF
+	description: "Ubuntu test VM"
+	vm_type: qemu
+	fw_type: legacy
+	defaults:
+	    vcpus: 2
+	    mem_mb: 256
+	    disk_mb: 80
+	cloud_init: "vm-test.yaml"
+	disks:
+	  - source:
+	       service: image
+	       id: "$ubuntu_id"
+	    ephemeral: true
+	    bootable: true
+	EOF
+	) > "$ciao_bin"/workload_examples/ubuntu_vm.yaml
+
+	# create a container test cloud init
+	echo "Creating Container cloud init"
+	(
+	cat <<-EOF
+	---
+	#cloud-config
+	runcmd:
+	    - [ /bin/bash, -c, "while true; do sleep 60; done" ]
+	...
+	EOF
+	) > "$ciao_bin"/workload_examples/container-test.yaml
+
+	# create a Debian container workload definition
+	echo "Creating Debian Container test workload"
+	(
+	cat <<-EOF
+	description: "Debian latest test container"
+	vm_type: docker
+	image_name: "debian:latest"
+	defaults:
+	  vcpus: 2
+	  mem_mb: 128
+	  disk_mb: 80
+	cloud_init: "container-test.yaml"
+	EOF
+	) > "$ciao_bin"/workload_examples/debian_latest.yaml
+
+	# create an Ubuntu container workload definition
+	echo "Creating Ubuntu Container test workload"
+	(
+	cat <<-EOF
+	description: "Ubuntu latest test container"
+	vm_type: docker
+	image_name: "ubuntu:latest"
+	defaults:
+	  vcpus: 2
+	  mem_mb: 128
+	  disk_mb: 80
+	cloud_init: "container-test.yaml"
+	EOF
+	) > "$ciao_bin"/workload_examples/ubuntu_latest.yaml
+
+	# store the new workloads into ciao
+	pushd "$ciao_bin"/workload_examples
+	if [ $all_images -eq 1 ]
+	then
+	    "$ciao_gobin"/ciao-cli workload create -yaml fedora_vm.yaml
+	    "$ciao_gobin"/ciao-cli workload create -yaml clear_vm.yaml
+	fi
+	"$ciao_gobin"/ciao-cli workload create -yaml ubuntu_latest.yaml
+	"$ciao_gobin"/ciao-cli workload create -yaml debian_latest.yaml
+	"$ciao_gobin"/ciao-cli workload create -yaml ubuntu_vm.yaml
+	popd
+}
+
+echo ""
+echo "Creating public test workloads"
+echo "---------------------------------------------------------------------------------------"
+createWorkloads


### PR DESCRIPTION
This PR is in preparation for my work on bringing a new deployment tool into ciao. It splits out many of the steps singlevm does into scripts that are then separately sourced moving functionality around to improve legibility but also throughput.

It also addresses some minor bugs around certificate handling and removes some extraneous steps.