### PR TITLE
travis: Add 1.9 (beta) builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
 go:
     - 1.7
     - 1.8
+    - go1.9beta2
     - tip
 
 env:
@@ -14,6 +15,7 @@ env:
 matrix:
   allow_failures:
   - go: tip
+  - go: go1.9beta2
 
 go_import_path: github.com/01org/ciao
 


### PR DESCRIPTION
This change enables support for building with go 1.9beta2. For now this
is marked as an allowable failure and will not prevent a PR from being
merged.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>