### PR TITLE
ciao-controller: Don't start a CNCI for "public" tenant

### DIFF
--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -112,6 +112,12 @@ func (c *controller) confirmTenantRaw(tenantID string) error {
 		}
 	}
 
+	// "public" can exit in the database as a valid tenant and is only used for
+	// labelling workloads as public. But we musn't start a CNCI for it.
+	if tenantID == "public" {
+		return nil
+	}
+
 	if tenant.CNCIIP == "" && !*noNetwork {
 		err := c.launchCNCI(tenantID)
 		if err != nil {


### PR DESCRIPTION
The tenant with ID "public" exists in the database to satisfy the
requirement that workloads are associated with a tenant. This
pseudo tenant is thus used to signify that this workload is public.

However as no instances are going to be created with this tenant it is
not necessary to launch a CNCI for the tenant.

Fixes: #1324

Signed-off-by: Rob Bradford <robert.bradford@intel.com>