### PR TITLE
Expose instance ID to all users of external-ip list

### DIFF
--- a/ciao-cli/external-ips.go
+++ b/ciao-cli/external-ips.go
@@ -200,9 +200,9 @@ func (cmd *externalIPListCommand) run(args []string) error {
 
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 0, 1, 1, ' ', 0)
-	fmt.Fprintf(w, "#\tExternalIP\tInternalIP")
+	fmt.Fprintf(w, "#\tExternalIP\tInternalIP\tInstanceID")
 	if checkPrivilege() {
-		fmt.Fprintf(w, "\tInstanceID\tTenantID\tPoolName\n")
+		fmt.Fprintf(w, "\tTenantID\tPoolName\n")
 	} else {
 		fmt.Fprintf(w, "\n")
 	}

--- a/ciao-controller/api/api.go
+++ b/ciao-controller/api/api.go
@@ -403,6 +403,7 @@ func listMappedIPs(c *Context, w http.ResponseWriter, r *http.Request) (Response
 			ID:         IP.ID,
 			ExternalIP: IP.ExternalIP,
 			InternalIP: IP.InternalIP,
+			InstanceID: IP.InstanceID,
 			Links:      IP.Links,
 		}
 		short = append(short, s)

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -656,6 +656,7 @@ type MappedIPShort struct {
 	ID         string `json:"mapping_id"`
 	ExternalIP string `json:"external_ip"`
 	InternalIP string `json:"internal_ip"`
+	InstanceID string `json:"instance_id"`
 	Links      []Link `json:"links"`
 }
 


### PR DESCRIPTION
Previously this was only exposed to admin users but there is no harm in exposing it to all users (and potential benefits)

Fixes: #1303 