### PR TITLE
Remove swagger instrumentation from Ciao

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,12 +67,6 @@ script:
    - test-cases -v -timeout 9 -coverprofile /tmp/cover.out -append-profile -short github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/payloads github.com/01org/ciao/configuration github.com/01org/ciao/testutil github.com/01org/ciao/ssntp/uuid github.com/01org/ciao/qemu github.com/01org/ciao/openstack/... github.com/01org/ciao/bat  github.com/01org/ciao/ciao-image/... github.com/01org/ciao/database/... github.com/01org/ciao/ciao-storage/... github.com/01org/ciao/deviceinfo github.com/01org/ciao/osprepare github.com/01org/ciao/templateutils
    - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/ssntp
    - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -short -tags travis -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/networking/libsnnet
-   # API Documentation is automated by swagger, every PR will verify the documentation can be generated
-   # verify ciao-controller api documentation can be generated with swagger
-   - go get golang.org/x/sys/unix
-   - go get github.com/gorilla/context
-   - go get github.com/yvasiyarov/swagger
-   - $GOPATH/bin/swagger  -apiPackage=github.com/01org/ciao/ciao-controller -mainApiFile=github.com/01org/ciao/ciao-controller/main.go -format=markdown -contentsTable=false -models=false -vendoringPath $HOME/gopath/src/github.com/01org/ciao/vendor
    # Test ansible playbooks
    - ansible-playbook -i _DeploymentAndDistroPackaging/ansible/tests/hosts _DeploymentAndDistroPackaging/ansible/ciao.yml --syntax-check
 

--- a/ciao-controller/api.go
+++ b/ciao-controller/api.go
@@ -392,29 +392,6 @@ func serversAction(c *controller, w http.ResponseWriter, r *http.Request) (APIRe
 	return APIResponse{http.StatusAccepted, nil}, nil
 }
 
-func listTenants(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
-	var computeTenants types.CiaoComputeTenants
-
-	tenants, err := c.ds.GetAllTenants()
-	if err != nil {
-		return errorResponse(err), err
-	}
-
-	for _, tenant := range tenants {
-		computeTenants.Tenants = append(computeTenants.Tenants,
-			struct {
-				ID   string `json:"id"`
-				Name string `json:"name"`
-			}{
-				ID:   tenant.ID,
-				Name: tenant.Name,
-			},
-		)
-	}
-
-	return APIResponse{http.StatusOK, computeTenants}, nil
-}
-
 func trimComputeNodes(c *controller, nodeList types.CiaoNodes, targetRole ssntp.Role) (types.CiaoNodes, error) {
 	var trimmedNodes types.CiaoNodes
 

--- a/ciao-controller/compute_test.go
+++ b/ciao-controller/compute_test.go
@@ -879,54 +879,6 @@ func TestListNodeServersInvalidToken(t *testing.T) {
 	testListNodeServers(t, http.StatusUnauthorized, false)
 }
 
-func testListTenants(t *testing.T, httpExpectedStatus int, validToken bool) {
-	tenants, err := ctl.ds.GetAllTenants()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expected := types.NewCiaoComputeTenants()
-
-	for _, tenant := range tenants {
-		expected.Tenants = append(expected.Tenants,
-			struct {
-				ID   string `json:"id"`
-				Name string `json:"name"`
-			}{
-				ID:   tenant.ID,
-				Name: tenant.Name,
-			},
-		)
-	}
-
-	url := testutil.ComputeURL + "/v2.1/tenants"
-
-	body := testHTTPRequest(t, "GET", url, httpExpectedStatus, nil, validToken)
-	// stop evaluating in case the scenario is InvalidToken
-	if httpExpectedStatus == 401 {
-		return
-	}
-
-	var result types.CiaoComputeTenants
-
-	err = json.Unmarshal(body, &result)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if reflect.DeepEqual(expected, result) == false {
-		t.Fatal("Tenant list not correct")
-	}
-}
-
-func TestListTenants(t *testing.T) {
-	testListTenants(t, http.StatusOK, true)
-}
-
-func TestListTenantsInvalidToken(t *testing.T) {
-	testListTenants(t, http.StatusUnauthorized, false)
-}
-
 func testListNodes(t *testing.T, httpExpectedStatus int, validToken bool) {
 	expected := ctl.ds.GetNodeLastStats()
 

--- a/ciao-controller/legacy_api.go
+++ b/ciao-controller/legacy_api.go
@@ -90,10 +90,6 @@ func tenantServersAction(c *controller, w http.ResponseWriter, r *http.Request) 
 	return serversAction(c, w, r)
 }
 
-func legacyListTenants(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
-	return listTenants(c, w, r)
-}
-
 func legacyListNodes(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return listNodes(c, w, r)
 }
@@ -169,9 +165,6 @@ func legacyComputeRoutes(ctl *controller, r *mux.Router) *mux.Router {
 
 	r.Handle("/v2.1/{tenant}/quotas",
 		legacyAPIHandler{ctl, listTenantQuotas, false}).Methods("GET")
-
-	r.Handle("/v2.1/tenants",
-		legacyAPIHandler{ctl, legacyListTenants, true}).Methods("GET")
 
 	r.Handle("/v2.1/nodes",
 		legacyAPIHandler{ctl, legacyListNodes, true}).Methods("GET")

--- a/ciao-controller/legacy_api.go
+++ b/ciao-controller/legacy_api.go
@@ -13,14 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 */
-// @SubApi Servers API [/v2.1/{tenant}/servers]
-// @SubApi Resources API [/v2.1/{tenant}/resources]
-// @SubApi Quotas API [/v2.1/{tenant}/quotas]
-// @SubApi Events API [/v2.1/{tenant}/events]
-// @SubApi Nodes API [/v2.1/nodes]
-// @SubApi Tenants API [/v2.1/tenants]
-// @SubApi CNCIs API [/v2.1/cncis]
-// @SubApi Traces API [/v2.1/traces]
 
 package main
 
@@ -83,38 +75,14 @@ func (h legacyAPIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Write(b)
 }
 
-// @Title listTenantQuotas
-// @Description List the use of all resources used of a tenant from a start to end point of time.
-// @Accept  json
-// @Success 200 {object} types.CiaoTenantResources "Returns the limits and usage of resources of a tenant."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/{tenant}/quotas [get]
-// @Resource /v2.1/{tenant}/quotas
 func listTenantQuotas(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return getResources(c, w, r)
 }
 
-// @Title listTenantResources
-// @Description List the use of all resources used of a tenant from a start to end point of time.
-// @Accept  json
-// @Success 200 {object} types.CiaoUsageHistory "Returns the usage of resouces."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/{tenant}/resources [get]
-// @Resource /v2.1/{tenant}/resources
 func listTenantResources(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return getUsage(c, w, r)
 }
 
-// @Title tenantServersAction
-// @Description Runs the indicated action (os-start, os-stop, os-delete) in the servers.
-// @Accept  json
-// @Success 202 {object} string "This operation does not return a response body, returns the 202 StatusAccepted code."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/{tenant}/servers/action [post]
-// @Resource /v2.1/{tenant}/servers
 // tenantServersAction will apply the operation sent in POST (as os-start, os-stop, os-delete)
 // to all servers of a tenant or if ServersID size is greater than zero it will be applied
 // only to the subset provided that also belongs to the tenant
@@ -122,172 +90,58 @@ func tenantServersAction(c *controller, w http.ResponseWriter, r *http.Request) 
 	return serversAction(c, w, r)
 }
 
-// @Title legacyListTenants
-// @Description List all tenants.
-// @Accept  json
-// @Success 200 {array} interface "Marshalled format of types.CiaoComputeTenants representing the list of all tentants."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/tenants [get]
-// @Resource /v2.1/tenants
 func legacyListTenants(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return listTenants(c, w, r)
 }
 
-// @Title legacyListNodes
-// @Description Returns a list of all nodes.
-// @Accept  json
-// @Success 200 {array} interface "Returns ciao-controller.nodePager with TotalInstances, TotalRunningInstances, TotalPendingInstances, TotalPausedInstances."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/nodes [get]
-// @Resource /v2.1/nodes
 func legacyListNodes(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return listNodes(c, w, r)
 }
 
-// @Title legacyListComputeNodes
-// @Description Returns a list of all compute nodes.
-// @Accept  json
-// @Success 200 {array} interface "Returns ciao-controller.nodePager with TotalInstances, TotalRunningInstances, TotalPendingInstances, TotalPausedInstances."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/nodes/compute [get]
-// @Resource /v2.1/node/computes
 func legacyListComputeNodes(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return listComputeNodes(c, w, r)
 }
 
-// @Title legacyListNetworkNodes
-// @Description Returns a list of all network nodes.
-// @Accept  json
-// @Success 200 {array} interface "Returns ciao-controller.nodePager with TotalInstances, TotalRunningInstances, TotalPendingInstances, TotalPausedInstances."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/nodes/network [get]
-// @Resource /v2.1/nodes/network
 func legacyListNetworkNodes(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return listNetworkNodes(c, w, r)
 }
 
-// @Title legacyNodesSummary
-// @Description A summary of all node stats.
-// @Accept  json
-// @Success 200 {object} interface "Returns types.CiaoClusterStatus with TotalNodesReady, TotalNodesFull, TotalNodesOffline and TotalNodesMaintenance."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/nodes/summary [get]
-// @Resource /v2.1/nodes
 func legacyNodesSummary(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return nodesSummary(c, w, r)
 }
 
-// @Title legacyListNodeServers
-// @Description A list of servers by node id.
-// @Accept  json
-// @Success 200 {object} interface "Returns types.CiaoServersStats"
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/nodes/{node}/servers/detail [get]
-// @Resource /v2.1/nodes
 func legacyListNodeServers(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return listNodeServers(c, w, r)
 }
 
-// @Title legacyListCNCIs
-// @Description Lists all CNCI agents.
-// @Accept  json
-// @Success 200 {array} types.CiaoCNCIs "Returns all CNCI agents data as InstanceId, TenantID, IPv4 and subnets."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/cncis [get]
-// @Resource /v2.1/cncis
 func legacyListCNCIs(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return listCNCIs(c, w, r)
 }
 
-// @Title legacyListCNCIDetails
-// @Description List details of a CNCI agent.
-// @Accept  json
-// @Success 200 {array} types.CiaoCNCIs "Returns details of a CNCI agent as InstanceId, TenantID, IPv4 and subnets."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/cncis/{cnci}/detail [get]
-// @Resource /v2.1/cncis
 func legacyListCNCIDetails(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return listCNCIDetails(c, w, r)
 }
 
-// @Title legacyListTraces
-// @Description List all Traces.
-// @Accept  json
-// @Success 200 {array} types.CiaoTracesSummary "Returns a summary of each trace in the system."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/traces [get]
-// @Resource /v2.1/traces
 func legacyListTraces(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return listTraces(c, w, r)
 }
 
-// @Title legacyListEvents
-// @Description List all Events.
-// @Accept  json
-// @Success 200 {array} types.CiaoEvent "Returns all events from the log system."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/events [get]
-// @Resource /v2.1/events
 func legacyListEvents(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return listEvents(c, w, r)
 }
 
-// @Title legacyListTenantEvents
-// @Description List Events.
-// @Accept  json
-// @Success 200 {array} types.CiaoEvent "Returns the events of a tenant from the log system."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/{tenant}/events [get]
-// @Resource /v2.1/events
-// listTenantEvents is created with the only purpose of API documentation for method
-// /v2.1/{tenant}/events
 func legacyListTenantEvents(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return listEvents(c, w, r)
 }
 
-// @Title legacyClearEvents
-// @Description Clear Events Log.
-// @Accept  json
-// @Success 202 {object} string "This operation does not return a response body, returns the 202 StatusAccepted code."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/events [delete]
-// @Resource /v2.1/events
 func legacyClearEvents(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return clearEvents(c, w, r)
 }
 
-// @Title legacyTraceData
-// @Description Trace data of a indicated trace.
-// @Accept json
-// @Success 200 {array} types.CiaoBatchFrameStat "Returns a summary of a trace in the system."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/traces/{label} [get]
-// @Resource /v2.1/traces
 func legacyTraceData(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	return traceData(c, w, r)
 }
 
-// @Title listServerDetailsFlavors
-// @Description Lists all servers with details for a particular flavor.
-// @Accept  json
-// @Success 200 {array} compute.ServerDetails "Returns a list of all servers."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/flavors/{flavor}/servers/detail [get]
-// @Resource /v2.1/flavors/{flavor}/servers
 func listServerDetailsFlavors(c *controller, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	cxt := &compute.Context{
 		Service: c,

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -13,13 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 */
-// @APIVersion v2.1
-// @APITitle CIAO Controller API
-// @APIDescription Ciao controller is responsible for policy choices around tenant workloads. It provides compute API endpoints for access from ciao-cli and ciao-webui over HTTPS.
-// @Contact https://github.com/01org/ciao/wiki/Package-maintainers
-// @License Apache License, Version 2.0
-// @LicenseUrl http://www.apache.org/licenses/LICENSE-2.0
-// @BasePath http://<ciao-controller-server>:8774/v2.1/
 
 package main
 

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -266,28 +266,6 @@ type StorageAttachment struct {
 	Boot       bool   // whether this is a boot device
 }
 
-// CiaoComputeTenants represents the unmarshalled version of the contents of a
-// /v2.1/tenants response.  It contains information about the tenants in a ciao
-// cluster.
-type CiaoComputeTenants struct {
-	Tenants []struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-	} `json:"tenants"`
-}
-
-// NewCiaoComputeTenants allocates a CiaoComputeTenants structure.
-// It allocates the Tenants slice as well so that the marshalled
-// JSON is an empty array and not a nil pointer, as specified by the
-// OpenStack APIs.
-func NewCiaoComputeTenants() (tenants CiaoComputeTenants) {
-	tenants.Tenants = []struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-	}{}
-	return
-}
-
 // CiaoNode contains status and statistic information for an individual
 // node.
 type CiaoNode struct {

--- a/openstack/compute/api.go
+++ b/openstack/compute/api.go
@@ -515,14 +515,6 @@ func (h APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Write(b)
 }
 
-// @Title createServer
-// @Description Creates a server.
-// @Accept  json
-// @Success 202 {object} Servers "Returns Servers and CreateServerRequest with data of the created server."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/{tenant}/servers [post]
-// @Resource /v2.1/{tenant}/servers
 func createServer(c *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 
 	vars := mux.Vars(r)
@@ -557,14 +549,6 @@ func createServer(c *Context, w http.ResponseWriter, r *http.Request) (APIRespon
 // endpoint using the "flavor" option. It is simpler to just overload
 // this function than to reimplement the legacy code.
 //
-// @Title ListServerDetails
-// @Description Lists all servers with details.
-// @Accept  json
-// @Success 200 {array} ServerDetails "Returns details of all servers."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/{tenant}/servers/detail [get]
-// @Resource /v2.1/{tenant}/servers
 func ListServersDetails(c *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	vars := mux.Vars(r)
 	tenant := vars["tenant"]
@@ -606,14 +590,6 @@ func ListServersDetails(c *Context, w http.ResponseWriter, r *http.Request) (API
 	return APIResponse{http.StatusOK, resp}, nil
 }
 
-// @Title showServerDetails
-// @Description Shows details for a server.
-// @Accept  json
-// @Success 200 {object} Server "Returns details for a server."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/{tenant}/servers/{server} [get]
-// @Resource /v2.1/{tenant}/servers
 func showServerDetails(c *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	vars := mux.Vars(r)
 	tenant := vars["tenant"]
@@ -629,14 +605,6 @@ func showServerDetails(c *Context, w http.ResponseWriter, r *http.Request) (APIR
 	return APIResponse{http.StatusOK, resp}, nil
 }
 
-// @Title deleteServer
-// @Description Deletes a server.
-// @Accept  json
-// @Success 204 {object} string "This operation does not return a response body, returns the 204 StatusNoContent code."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/{tenant}/servers/{server} [delete]
-// @Resource /v2.1/{tenant}/servers
 func deleteServer(c *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	vars := mux.Vars(r)
 	tenant := vars["tenant"]
@@ -652,14 +620,6 @@ func deleteServer(c *Context, w http.ResponseWriter, r *http.Request) (APIRespon
 	return APIResponse{http.StatusNoContent, nil}, nil
 }
 
-// @Title serverAction
-// @Description Runs the indicated action (os-start, os-stop) in the a server.
-// @Accept  json
-// @Success 202 {object} string "This operation does not return a response body, returns the 202 StatusAccepted code."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/{tenant}/servers/{server}/action [post]
-// @Resource /v2.1/{tenant}/servers
 func serverAction(c *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	vars := mux.Vars(r)
 	tenant := vars["tenant"]
@@ -701,14 +661,6 @@ func serverAction(c *Context, w http.ResponseWriter, r *http.Request) (APIRespon
 	return APIResponse{http.StatusAccepted, nil}, nil
 }
 
-// @Title listFlavors
-// @Description Lists flavors.
-// @Accept  json
-// @Success 200 {object} Flavors "Returns Flavors with the corresponding available flavors for the tenant."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/{tenant}/flavors [get]
-// @Resource /v2.1/{tenant}/flavors
 func listFlavors(c *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	vars := mux.Vars(r)
 	tenant := vars["tenant"]
@@ -723,14 +675,6 @@ func listFlavors(c *Context, w http.ResponseWriter, r *http.Request) (APIRespons
 	return APIResponse{http.StatusOK, resp}, nil
 }
 
-// @Title listFlavorsDetails
-// @Description Lists flavors with details.
-// @Accept  json
-// @Success 200 {object} FlavorsDetails "Returns FlavorsDetails with flavor details."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/{tenant}/flavors/detail [get]
-// @Resource /v2.1/{tenant}/flavors
 func listFlavorsDetails(c *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	vars := mux.Vars(r)
 	tenant := vars["tenant"]
@@ -745,14 +689,6 @@ func listFlavorsDetails(c *Context, w http.ResponseWriter, r *http.Request) (API
 	return APIResponse{http.StatusOK, resp}, nil
 }
 
-// @Title showFlavorDetails
-// @Description Shows details for a flavor.
-// @Accept  json
-// @Success 200 {object} Flavor "Returns details for a flavor."
-// @Failure 400 {object} HTTPReturnErrorCode "The response contains the corresponding message and 40x corresponding code."
-// @Failure 500 {object} HTTPReturnErrorCode "The response contains the corresponding message and 50x corresponding code."
-// @Router /v2.1/{tenant}/flavors/{flavor} [get]
-// @Resource /v2.1/{tenant}/flavors
 func showFlavorDetails(c *Context, w http.ResponseWriter, r *http.Request) (APIResponse, error) {
 	vars := mux.Vars(r)
 	tenant := vars["tenant"]


### PR DESCRIPTION
The current swagger instrumentation for the APIs are outdated and unhelpful so we made a decision to remove them from the source tree. This change removes the swagger entries from the source code and disables the documentation generation on travis.

Fixes: #1292