### PR TITLE
[DONOTMERGE] Support a CNCI per subnet per tenant in ciao-controller

### DIFF
--- a/ciao-controller/cnci.go
+++ b/ciao-controller/cnci.go
@@ -1,0 +1,450 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/01org/ciao/ciao-controller/types"
+	"github.com/01org/ciao/payloads"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+)
+
+// CNCIState represents specific allowed state strings
+type CNCIState string
+
+var (
+	exited CNCIState = payloads.Exited
+	active CNCIState = payloads.Running
+	failed CNCIState = payloads.ExitFailed
+)
+
+type event string
+
+var (
+	added        event = "concentrator added"
+	startFailure event = "cnci start failure"
+	removed      event = "concentrator removed"
+)
+
+var cnciEventTimeout = (5 * time.Minute)
+
+// CNCI represents a cnci instance that manages a single subnet.
+type CNCI struct {
+	instance *types.Instance
+	ctrl     *controller
+	eventCh  chan event
+	subnet   int
+}
+
+// CNCIManager is a structure which defines a manager for CNCI instances
+// TBD: managing multiple CNCI instances.
+type CNCIManager struct {
+	tenant string
+	ctrl   *controller
+
+	// there's no reason to have separate lock for each map.
+	cnciLock *sync.RWMutex
+	cncis    map[string]*CNCI
+	subnets  map[int]*CNCI
+}
+
+func (c *CNCI) stop() error {
+	err := transitionInstanceState(c.instance, payloads.Stopping)
+	if err != nil {
+		return err
+	}
+
+	err = c.ctrl.deleteInstance(c.instance.ID)
+	if err != nil {
+		return errors.Wrapf(err, "error deleting CNCI instance")
+	}
+
+	return nil
+}
+
+func (c *CNCI) waitForEventTimeout(e event, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	select {
+	case recv := <-c.eventCh:
+		if recv != e {
+			return fmt.Errorf("expecting %v got %v", e, recv)
+		}
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("timeout waiting for event %v", e)
+	}
+}
+
+func (c *CNCI) transitionState(to CNCIState) {
+	transitionInstanceState(c.instance, (string(to)))
+
+	// some state changes cause events
+	switch to {
+	case exited:
+		c.eventCh <- removed
+	case active:
+		c.eventCh <- added
+	case failed:
+		c.eventCh <- startFailure
+	}
+}
+
+// Active will return true if the CNCI has been launched successfully
+func (c *CNCIManager) Active(ID string) bool {
+	c.cnciLock.RLock()
+	defer c.cnciLock.RUnlock()
+
+	cnci, ok := c.cncis[ID]
+	if !ok {
+		return false
+	}
+
+	return instanceActive(cnci.instance)
+}
+
+func (c *CNCIManager) launch(subnet string) (*types.Instance, error) {
+	glog.V(2).Infof("launching cnci for subnet %s", subnet)
+
+	workloadID, err := c.ctrl.ds.GetCNCIWorkloadID()
+	if err != nil {
+		return nil, err
+	}
+
+	w := types.WorkloadRequest{
+		WorkloadID: workloadID,
+		TenantID:   c.tenant,
+		Instances:  1,
+		Subnet:     subnet,
+		Name:       fmt.Sprintf("CNCI for subnet %s", subnet),
+	}
+
+	instances, err := c.ctrl.startWorkload(w)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to Launch CNCI")
+	}
+
+	return instances[0], nil
+}
+
+// WaitForActive will launch a cnci if needed and wait for it to be active,
+// or wait for an existing cnci to become active.
+func (c *CNCIManager) WaitForActive(subnet int) error {
+	c.cnciLock.Lock()
+
+	cnci, ok := c.subnets[subnet]
+	if ok {
+		// subnet already exists
+		c.cnciLock.Unlock()
+
+		// block until subnet is active
+		return c.waitForActive(subnet)
+	}
+
+	cnci = &CNCI{
+		ctrl:    c.ctrl,
+		eventCh: make(chan event),
+		subnet:  subnet,
+	}
+
+	c.subnets[subnet] = cnci
+
+	subnetBytes := make([]byte, 2)
+	binary.BigEndian.PutUint16(subnetBytes, uint16(subnet))
+	ip := net.IPv4(172, subnetBytes[0], subnetBytes[1], 0)
+	ipNet := net.IPNet{
+		IP:   ip,
+		Mask: net.IPv4Mask(255, 255, 255, 0),
+	}
+	subnetStr := ipNet.String()
+
+	// send a launch command
+	instance, err := c.launch(subnetStr)
+	if err != nil {
+		c.cnciLock.Unlock()
+		return err
+	}
+
+	glog.V(2).Infof("AddSubnet CNCI instance is %s", instance.ID)
+
+	cnci.instance = instance
+	cnci.subnet = subnet
+
+	c.cncis[instance.ID] = cnci
+
+	c.cnciLock.Unlock()
+
+	// we release the lock before waiting because
+	// we need to be able to read the event channel.
+	return cnci.waitForEventTimeout(added, cnciEventTimeout)
+}
+
+// RemoveSubnet is called when a subnet no longer is needed.
+// a cnci can be stopped.
+func (c *CNCIManager) RemoveSubnet(subnet int) error {
+	c.cnciLock.Lock()
+
+	cnci, ok := c.subnets[subnet]
+	if !ok {
+		// there is no cnci for this subnet
+		c.cnciLock.Unlock()
+		return errors.New("Subnet doesn't exist")
+	}
+
+	delete(c.subnets, subnet)
+
+	err := cnci.stop()
+	if err != nil {
+		c.cnciLock.Unlock()
+		return err
+	}
+
+	c.cnciLock.Unlock()
+
+	err = cnci.waitForEventTimeout(removed, cnciEventTimeout)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ConcentratorInstanceRemoved will move the CNCI back to the initial state
+// and send an event through the event channel.
+func (c *CNCIManager) ConcentratorInstanceRemoved(id string) error {
+	c.cnciLock.Lock()
+	defer c.cnciLock.Unlock()
+
+	cnci, ok := c.cncis[id]
+	if !ok {
+		return errors.New("No CNCI found")
+	}
+
+	cnci.transitionState(exited)
+
+	delete(c.cncis, cnci.instance.ID)
+
+	return nil
+}
+
+// ConcentratorInstanceAdded will move the CNCI into the active state
+// and send an event through the event channel.
+func (c *CNCIManager) ConcentratorInstanceAdded(id string) error {
+	c.cnciLock.Lock()
+	defer c.cnciLock.Unlock()
+
+	cnci, ok := c.cncis[id]
+	if !ok {
+		return errors.New("No CNCI found")
+	}
+
+	cnci.transitionState(active)
+
+	return nil
+}
+
+// StartFailure will move the CNCI to the error state and
+// send an event through the event channel.
+func (c *CNCIManager) StartFailure(id string) error {
+	c.cnciLock.Lock()
+	defer c.cnciLock.Unlock()
+
+	cnci, ok := c.cncis[id]
+	if !ok {
+		return errors.New("No CNCI found")
+	}
+
+	cnci.transitionState(failed)
+
+	// we should probably not do this, and instead we should
+	// delete from the map?
+	cnci.instance = nil
+
+	return nil
+}
+
+func (c *CNCIManager) waitForActive(subnet int) error {
+	c.cnciLock.RLock()
+
+	cnci, ok := c.subnets[subnet]
+
+	c.cnciLock.RUnlock()
+
+	if !ok {
+		return errors.New("No CNCI found")
+	}
+
+	if instanceActive(cnci.instance) {
+		return nil
+	}
+
+	ch := make(chan bool)
+
+	// poll with timeout
+
+	ticker := time.NewTicker(time.Millisecond * 500)
+
+	go func() {
+		for range ticker.C {
+			if instanceActive(cnci.instance) {
+				ch <- true
+				close(ch)
+				return
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), cnciEventTimeout)
+	defer cancel()
+
+	select {
+	case <-ch:
+		ticker.Stop()
+		return nil
+	case <-ctx.Done():
+		ticker.Stop()
+		return errors.New("timeout waiting for CNCI active")
+	}
+}
+
+// GetInstanceCNCI will return the CNCI Instance for a specific tenant Instance
+func (c *CNCIManager) GetInstanceCNCI(ID string) (*types.Instance, error) {
+	// figure out what subnet we are looking for.
+	instance, err := c.ctrl.ds.GetInstance(ID)
+	if err != nil {
+		return nil, err
+	}
+
+	// convert subnet string to int
+	ipAddr := net.ParseIP(instance.IPAddress)
+	if ipAddr == nil {
+		return nil, errors.New("Invalid instance IP address")
+	}
+
+	ipBytes := ipAddr.To4()
+	if ipBytes == nil {
+		return nil, errors.New("Unable to convert ip to bytes")
+	}
+
+	subnetInt := binary.BigEndian.Uint16(ipBytes[1:3])
+
+	c.cnciLock.Lock()
+	defer c.cnciLock.Unlock()
+
+	cnci, ok := c.subnets[int(subnetInt)]
+	if !ok {
+		// there is no cnci for this subnet
+		return nil, errors.New("Subnet doesn't exist")
+	}
+
+	return cnci.instance, nil
+}
+
+func subnetStringToInt(cidr string) (int, error) {
+	ipAddr, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return 0, err
+	}
+
+	ipBytes := ipAddr.To4()
+	if ipBytes == nil {
+		return 0, errors.New("Unable to convert ip to bytes")
+	}
+
+	return int(binary.BigEndian.Uint16(ipBytes[1:3])), nil
+}
+
+// GetSubnetCNCI will return the CNCI Instance for a specific subnet string
+func (c *CNCIManager) GetSubnetCNCI(subnet string) (*types.Instance, error) {
+	subnetInt, err := subnetStringToInt(subnet)
+	if err != nil {
+		return nil, err
+	}
+
+	c.cnciLock.Lock()
+	defer c.cnciLock.Unlock()
+
+	cnci, ok := c.subnets[subnetInt]
+	if !ok {
+		// there is no cnci for this subnet
+		return nil, errors.New("Subnet doesn't exist")
+	}
+
+	return cnci.instance, nil
+}
+
+func newCNCIManager(ctrl *controller, tenant string) (*CNCIManager, error) {
+	mgr := CNCIManager{
+		tenant: tenant,
+		ctrl:   ctrl,
+
+		cnciLock: &sync.RWMutex{},
+		cncis:    make(map[string]*CNCI),
+		subnets:  make(map[int]*CNCI),
+	}
+
+	instances, err := ctrl.ds.GetTenantCNCIs(tenant)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, i := range instances {
+		cnci := CNCI{
+			ctrl:    ctrl,
+			eventCh: make(chan event),
+		}
+
+		cnci.instance = i
+
+		// convert cnci instance string to int for map
+		subnetInt, err := subnetStringToInt(i.Subnet)
+		if err != nil {
+			return nil, err
+		}
+
+		cnci.subnet = subnetInt
+
+		mgr.cncis[i.ID] = &cnci
+
+		mgr.subnets[subnetInt] = &cnci
+	}
+
+	return &mgr, nil
+}
+
+func initializeCNCICtrls(c *controller) error {
+	// get all the current tenants
+	ts, err := c.ds.GetAllTenants()
+	if err != nil {
+		return errors.Wrap(err, "error getting tenants")
+	}
+
+	for _, t := range ts {
+		t.CNCIctrl, err = newCNCIManager(c, t.ID)
+		if err != nil {
+			return errors.Wrap(err, "error allocating CNCI manager")
+		}
+	}
+
+	return nil
+}

--- a/ciao-controller/cnci_test.go
+++ b/ciao-controller/cnci_test.go
@@ -16,7 +16,27 @@ package main
 
 import (
 	"testing"
+
+	"github.com/01org/ciao/ssntp"
 )
+
+func TestCNCIInitializeCtrls(t *testing.T) {
+	err := initializeCNCICtrls(ctl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts, err := ctl.ds.GetAllTenants()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tenant := range ts {
+		if tenant.CNCIctrl == nil {
+			t.Fatal("CNCIctrl not initialized properly")
+		}
+	}
+}
 
 func TestCNCILaunch(t *testing.T) {
 	testClient, client, instances := testStartWorkloadLaunchCNCI(t, 1)
@@ -26,21 +46,121 @@ func TestCNCILaunch(t *testing.T) {
 	id := instances[0].TenantID
 
 	// get CNCI info for this tenant
-	cncis, err := ctl.ds.GetTenantCNCISummary("")
+	instances, err := ctl.ds.GetTenantCNCIs(id)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	for _, c := range cncis {
-		if c.TenantID != id {
-			continue
-		}
-
-		if c.IPAddress == "" {
-			t.Fatal("CNCI Info not updated")
-		}
-		return
+	if len(instances) != 1 {
+		t.Fatal("Incorrect number of CNCIs")
 	}
 
-	t.Fatal("CNCI not found")
+	if instances[0].IPAddress == "" {
+		t.Fatal("CNCI Info not updated")
+	}
+
+	tenant, err := ctl.ds.GetTenant(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !tenant.CNCIctrl.Active(instances[0].ID) {
+		t.Fatal(err)
+	}
+}
+
+func TestCNCIRemoved(t *testing.T) {
+	netClient, client, instances := testStartWorkloadLaunchCNCI(t, 1)
+	defer client.Shutdown()
+	defer netClient.Shutdown()
+
+	sendStatsCmd(client, t)
+	sendStatsCmd(netClient, t)
+
+	instanceID := instances[0].ID
+	tenantID := instances[0].TenantID
+
+	// get the tenant
+	tenant, err := ctl.ds.GetTenant(tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get CNCI for this instance.
+	cnci, err := tenant.CNCIctrl.GetInstanceCNCI(instanceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// confirm that instance is added.
+	_, err = ctl.ds.GetInstance(instanceID)
+	if err != nil {
+		t.Fatal("Instance not actually created")
+	}
+
+	serverCh := server.AddCmdChan(ssntp.DELETE)
+	clientCh := client.AddCmdChan(ssntp.DELETE)
+	netClientCh := netClient.AddCmdChan(ssntp.DELETE)
+
+	err = ctl.deleteInstance(instanceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = server.GetCmdChanResult(serverCh, ssntp.DELETE)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = server.GetCmdChanResult(clientCh, ssntp.DELETE)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	controllerCh := wrappedClient.addEventChan(ssntp.InstanceDeleted)
+	go client.SendDeleteEvent(instances[0].ID)
+
+	err = wrappedClient.getEventChan(controllerCh, ssntp.InstanceDeleted)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sendStatsCmd(client, t)
+
+	_, err = ctl.ds.GetInstance(instanceID)
+	if err == nil {
+		t.Fatal("instance was not deleted")
+	}
+
+	tenant, err = ctl.ds.GetTenant(tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	CNCIID := cnci.ID
+
+	// call remove subnet directly to remove the cnci.
+	go func() {
+		err = tenant.CNCIctrl.RemoveSubnet(4096)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	_, err = server.GetCmdChanResult(serverCh, ssntp.DELETE)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = server.GetCmdChanResult(netClientCh, ssntp.DELETE)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go netClient.SendDeleteEvent(CNCIID)
+
+	err = wrappedClient.getEventChan(controllerCh, ssntp.InstanceDeleted)
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -110,39 +110,10 @@ func (c *controller) confirmTenantRaw(tenantID string) error {
 		if err != nil {
 			return err
 		}
-	}
 
-	// "public" can exit in the database as a valid tenant and is only used for
-	// labelling workloads as public. But we musn't start a CNCI for it.
-	if tenantID == "public" {
-		return nil
-	}
-
-	i, err := c.ds.GetInstance(tenant.CNCIID)
-	if err != nil {
-		if tenant.CNCIID != "" {
-			return err
-		}
-	}
-
-	if i == nil || i.IPAddress == "" {
-		err := c.launchCNCI(tenantID)
+		tenant.CNCIctrl, err = newCNCIManager(c, tenantID)
 		if err != nil {
 			return err
-		}
-
-		tenant, err = c.ds.GetTenant(tenantID)
-		if err != nil {
-			return err
-		}
-
-		i, err := c.ds.GetInstance(tenant.CNCIID)
-		if err != nil {
-			return err
-		}
-
-		if i.IPAddress == "" {
-			return errors.New("Unable to Launch Tenant CNCI")
 		}
 	}
 
@@ -197,11 +168,9 @@ func (c *controller) startWorkload(w types.WorkloadRequest) ([]*types.Instance, 
 		return nil, err
 	}
 
-	if !isCNCIWorkload(&wl) {
-		err := c.confirmTenant(w.TenantID)
-		if err != nil {
-			return nil, err
-		}
+	err = c.confirmTenant(w.TenantID)
+	if err != nil {
+		return nil, err
 	}
 
 	var newInstances []*types.Instance
@@ -216,7 +185,7 @@ func (c *controller) startWorkload(w types.WorkloadRequest) ([]*types.Instance, 
 			}
 		}
 
-		instance, err := newInstance(c, w.TenantID, &wl, w.Volumes, name)
+		instance, err := newInstance(c, w.TenantID, &wl, w.Volumes, name, w.Subnet)
 		if err != nil {
 			e = errors.Wrap(err, "Error creating instance")
 			continue
@@ -253,36 +222,6 @@ func (c *controller) startWorkload(w types.WorkloadRequest) ([]*types.Instance, 
 	}
 
 	return newInstances, e
-}
-
-func (c *controller) launchCNCI(tenantID string) error {
-	workloadID, err := c.ds.GetCNCIWorkloadID()
-	if err != nil {
-		return err
-	}
-
-	ch := make(chan bool)
-
-	c.ds.AddTenantChan(ch, tenantID)
-
-	w := types.WorkloadRequest{
-		WorkloadID: workloadID,
-		TenantID:   tenantID,
-		Instances:  1,
-		Name:       "cnci-" + tenantID,
-	}
-	_, err = c.startWorkload(w)
-	if err != nil {
-		return err
-	}
-
-	success := <-ch
-
-	if success {
-		return nil
-	}
-	msg := fmt.Sprintf("Failed to Launch CNCI for %s", tenantID)
-	return errors.New(msg)
 }
 
 func (c *controller) deleteEphemeralStorage(instanceID string) error {

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -118,7 +118,14 @@ func (c *controller) confirmTenantRaw(tenantID string) error {
 		return nil
 	}
 
-	if tenant.CNCIIP == "" {
+	i, err := c.ds.GetInstance(tenant.CNCIID)
+	if err != nil {
+		if tenant.CNCIID != "" {
+			return err
+		}
+	}
+
+	if i == nil || i.IPAddress == "" {
 		err := c.launchCNCI(tenantID)
 		if err != nil {
 			return err
@@ -129,7 +136,12 @@ func (c *controller) confirmTenantRaw(tenantID string) error {
 			return err
 		}
 
-		if tenant.CNCIIP == "" {
+		i, err := c.ds.GetInstance(tenant.CNCIID)
+		if err != nil {
+			return err
+		}
+
+		if i.IPAddress == "" {
 			return errors.New("Unable to Launch Tenant CNCI")
 		}
 	}

--- a/ciao-controller/compute_test.go
+++ b/ciao-controller/compute_test.go
@@ -862,7 +862,8 @@ func testListNodeServers(t *testing.T, httpExpectedStatus int, validToken bool) 
 		}
 
 		if result.TotalServers != len(instances) {
-			t.Fatal("Incorrect number of servers")
+			fmt.Printf("result: %v\n", result)
+			t.Fatalf("Incorrect number of servers: expected %d, got %d", len(instances), result.TotalServers)
 		}
 
 		// TBD: make sure result exactly matches expected results.

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -80,14 +80,27 @@ users:
 }
 
 func addFakeCNCI(tenant *types.Tenant) error {
-	err := ctl.ds.AddTenantCNCI(tenant.ID, uuid.Generate().String(), tenant.CNCIMAC)
+	mac, err := newHardwareAddr()
 	if err != nil {
 		return err
 	}
-	err = ctl.ds.AddCNCIIP(tenant.CNCIMAC, "192.168.0.1")
+
+	// Add fake CNCI
+	CNCI := types.Instance{
+		TenantID:   tenant.ID,
+		State:      payloads.Running,
+		ID:         uuid.Generate().String(),
+		CNCI:       true,
+		IPAddress:  "192.168.0.1",
+		MACAddress: mac.String(),
+	}
+
+	err = ctl.ds.AddInstance(&CNCI)
 	if err != nil {
 		return err
 	}
+
+	tenant.CNCIID = CNCI.ID
 
 	return nil
 }

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -95,13 +95,7 @@ func addFakeCNCI(tenant *types.Tenant) (*types.Instance, error) {
 		IPAddress:  "192.168.0.1",
 		MACAddress: mac.String(),
 		Subnet:     "172.16.0.0/24",
-		MACAddress: mac.String(),
 		StateLock:  &sync.RWMutex{},
-	}
-
-	err = ctl.ds.AddInstance(&CNCI)
-	if err != nil {
-		return err
 	}
 
 	return &CNCI, ctl.ds.AddInstance(&CNCI)

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -107,14 +108,20 @@ func newInstance(ctl *controller, tenantID string, workload *types.Workload,
 func (i *instance) Add() error {
 	ds := i.ctl.ds
 	var err error
-	if i.CNCI == false {
-		err = ds.AddInstance(&i.Instance)
-	} else {
-		err = ds.AddTenantCNCI(i.TenantID, i.ID, i.MACAddress)
-	}
+	err = ds.AddInstance(&i.Instance)
 	if err != nil {
 		return errors.Wrapf(err, "Error creating instance in datastore")
 	}
+
+	if i.CNCI == true {
+		t, err := ds.GetTenant(i.TenantID)
+		if err != nil {
+			return errors.Wrap(err, "Error creating instance")
+		}
+
+		t.CNCIID = i.ID
+	}
+
 	for _, volume := range i.newConfig.sc.Start.Storage {
 		if volume.ID == "" && volume.Local {
 			// these are launcher auto-created ephemeral
@@ -289,7 +296,12 @@ func networkConfig(ctl *controller, tenant *types.Tenant, networking *payloads.N
 	networking.VnicUUID = uuid.Generate().String()
 
 	if cnci {
-		networking.VnicMAC = tenant.CNCIMAC
+		hwaddr, err := newHardwareAddr()
+		if err != nil {
+			return err
+		}
+
+		networking.VnicMAC = hwaddr.String()
 		return nil
 	}
 
@@ -311,9 +323,14 @@ func networkConfig(ctl *controller, tenant *types.Tenant, networking *payloads.N
 	networking.Subnet = ipnet.String()
 	networking.ConcentratorUUID = tenant.CNCIID
 
+	i, err := ctl.ds.GetInstance(tenant.CNCIID)
+	if err != nil {
+		return err
+	}
+
 	// in theory we should refuse to go on if ip is null
 	// for now let's keep going
-	networking.ConcentratorIP = tenant.CNCIIP
+	networking.ConcentratorIP = i.IPAddress
 
 	return nil
 }
@@ -450,4 +467,26 @@ func newTenantHardwareAddr(ip net.IP) net.HardwareAddr {
 	buf[1] = 0
 	copy(buf[2:6], ipBytes)
 	return net.HardwareAddr(buf)
+}
+
+func newHardwareAddr() (net.HardwareAddr, error) {
+	buf := make([]byte, 6)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return nil, errors.Wrap(err, "error reading random data")
+	}
+
+	// vnic creation seems to require not just the
+	// bit 1 to be set, but the entire byte to be
+	// set to 2.  Also, ensure that we get no
+	// overlap with tenant mac addresses by not allowing
+	// byte 1 to ever be zero.
+	buf[0] = 2
+	if buf[1] == 0 {
+		buf[1] = 3
+	}
+
+	hw := net.HardwareAddr(buf)
+
+	return hw, nil
 }

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/01org/ciao/ciao-controller/types"
@@ -63,7 +64,7 @@ func isCNCIWorkload(workload *types.Workload) bool {
 }
 
 func newInstance(ctl *controller, tenantID string, workload *types.Workload,
-	volumes []storage.BlockDevice, name string) (*instance, error) {
+	volumes []storage.BlockDevice, name string, subnet string) (*instance, error) {
 	id := uuid.Generate()
 
 	if name != "" {
@@ -94,6 +95,11 @@ func newInstance(ctl *controller, tenantID string, workload *types.Workload,
 		MACAddress: config.mac,
 		CreateTime: time.Now(),
 		Name:       name,
+		StateLock:  &sync.RWMutex{},
+	}
+
+	if subnet != "" {
+		newInstance.Subnet = subnet
 	}
 
 	i := &instance{
@@ -108,18 +114,10 @@ func newInstance(ctl *controller, tenantID string, workload *types.Workload,
 func (i *instance) Add() error {
 	ds := i.ctl.ds
 	var err error
+
 	err = ds.AddInstance(&i.Instance)
 	if err != nil {
 		return errors.Wrapf(err, "Error creating instance in datastore")
-	}
-
-	if i.CNCI == true {
-		t, err := ds.GetTenant(i.TenantID)
-		if err != nil {
-			return errors.Wrap(err, "Error creating instance")
-		}
-
-		t.CNCIID = i.ID
 	}
 
 	for _, volume := range i.newConfig.sc.Start.Storage {
@@ -179,6 +177,37 @@ func (i *instance) Allowed() (bool, error) {
 
 	// Cleanup on disallowed happens in Clean()
 	return res.Allowed(), nil
+}
+
+func transitionInstanceState(i *types.Instance, to string) error {
+	i.StateLock.Lock()
+	defer i.StateLock.Unlock()
+
+	switch to {
+	case payloads.Stopping:
+		if i.State != payloads.Running {
+			return errors.New("Stop operation not allowed")
+		}
+	case payloads.Running:
+		if i.State != payloads.Pending {
+			return errors.New("Set active without pending")
+		}
+	}
+
+	i.State = to
+
+	return nil
+}
+
+func instanceActive(i *types.Instance) bool {
+	i.StateLock.RLock()
+	defer i.StateLock.RUnlock()
+
+	if i.State == payloads.Running {
+		return true
+	}
+
+	return false
 }
 
 func addBlockDevice(c *controller, tenant string, instanceID string, device storage.BlockDevice, s types.StorageResource) (payloads.StorageResource, error) {
@@ -321,17 +350,17 @@ func networkConfig(ctl *controller, tenant *types.Tenant, networking *payloads.N
 		Mask: mask,
 	}
 	networking.Subnet = ipnet.String()
-	networking.ConcentratorUUID = tenant.CNCIID
 
-	i, err := ctl.ds.GetInstance(tenant.CNCIID)
+	cnciInstance, err := tenant.CNCIctrl.GetSubnetCNCI(networking.Subnet)
 	if err != nil {
 		return err
 	}
 
+	networking.ConcentratorUUID = cnciInstance.ID
+
 	// in theory we should refuse to go on if ip is null
 	// for now let's keep going
-	networking.ConcentratorIP = i.IPAddress
-
+	networking.ConcentratorIP = cnciInstance.IPAddress
 	return nil
 }
 

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -139,9 +139,6 @@ type persistentStore interface {
 type Datastore struct {
 	db persistentStore
 
-	cnciAddedChans map[string]chan bool
-	cnciAddedLock  *sync.Mutex
-
 	nodeLastStat     map[string]types.CiaoNode
 	nodeLastStatLock *sync.RWMutex
 
@@ -216,9 +213,6 @@ func (ds *Datastore) Init(config Config) error {
 
 	ds.db = ps
 
-	ds.cnciAddedChans = make(map[string]chan bool)
-	ds.cnciAddedLock = &sync.Mutex{}
-
 	ds.nodeLastStat = make(map[string]types.CiaoNode)
 	ds.nodeLastStatLock = &sync.RWMutex{}
 
@@ -278,9 +272,6 @@ func (ds *Datastore) Init(config Config) error {
 		tenant := ds.tenants[i.TenantID]
 		if tenant != nil {
 			tenant.instances[i.ID] = i
-			if i.CNCI {
-				tenant.CNCIID = i.ID
-			}
 		}
 	}
 
@@ -325,16 +316,6 @@ func (ds *Datastore) Init(config Config) error {
 // Exit will disconnect the backing database.
 func (ds *Datastore) Exit() {
 	ds.db.disconnect()
-}
-
-// AddTenantChan allows a caller to pass in a channel for CNCI Launch status.
-// When a CNCI has been added to the datastore and a channel exists,
-// success will be indicated on the channel.  If a CNCI failure occurred
-// and a channel exists, failure will be indicated on the channel.
-func (ds *Datastore) AddTenantChan(c chan bool, tenantID string) {
-	ds.cnciAddedLock.Lock()
-	ds.cnciAddedChans[tenantID] = c
-	ds.cnciAddedLock.Unlock()
 }
 
 // AddTenant stores information about a tenant into the datastore.
@@ -510,42 +491,6 @@ func (ds *Datastore) GetWorkloads(tenantID string) ([]types.Workload, error) {
 	return workloads, nil
 }
 
-// CNCIAdded will write to any associated tenant chans to indicate a
-// CNCI has been successfully launched.
-func (ds *Datastore) CNCIAdded(tenantID string) error {
-	ds.cnciAddedLock.Lock()
-
-	c, ok := ds.cnciAddedChans[tenantID]
-	if ok {
-		delete(ds.cnciAddedChans, tenantID)
-	}
-
-	ds.cnciAddedLock.Unlock()
-
-	if c != nil {
-		c <- true
-	}
-
-	return nil
-}
-
-func (ds *Datastore) removeTenantCNCI(tenantID string) error {
-	// update tenants cache
-	ds.tenantsLock.Lock()
-
-	tenant, ok := ds.tenants[tenantID]
-	if !ok {
-		ds.tenantsLock.Unlock()
-		return ErrNoTenant
-	}
-
-	tenant.CNCIID = ""
-
-	ds.tenantsLock.Unlock()
-
-	return nil
-}
-
 // UpdateInstance will update certain fields of an instance
 func (ds *Datastore) UpdateInstance(instance *types.Instance) error {
 	return ds.db.updateInstance(instance)
@@ -566,6 +511,9 @@ func (ds *Datastore) GetAllTenants() ([]*types.Tenant, error) {
 // Once a tenant IP address is released, it can be reassigned to another
 // instance.
 func (ds *Datastore) ReleaseTenantIP(tenantID string, ip string) error {
+	removeSubnet := false
+	var i int
+
 	ipAddr := net.ParseIP(ip)
 	if ipAddr == nil {
 		return errors.New("Invalid IPv4 Address")
@@ -582,10 +530,51 @@ func (ds *Datastore) ReleaseTenantIP(tenantID string, ip string) error {
 	ds.tenantsLock.Lock()
 
 	if ds.tenants[tenantID] != nil {
-		ds.tenants[tenantID].network[int(subnetInt)][int(ipBytes[3])] = false
+		delete(ds.tenants[tenantID].network[int(subnetInt)], int(ipBytes[3]))
+		subnets := ds.tenants[tenantID].subnets
+		network := ds.tenants[tenantID].network
+		i = int(subnetInt)
+
+		if len(network[i]) == 0 {
+			// delete the network map and the subnet
+			delete(ds.tenants[tenantID].network, i)
+
+			if len(subnets) > 1 {
+				ds.tenants[tenantID].subnets = append(subnets[:i], subnets[i+1:]...)
+			} else {
+				ds.tenants[tenantID].subnets = nil
+			}
+
+			removeSubnet = true
+		}
 	}
 
 	ds.tenantsLock.Unlock()
+
+	// must be called with tenants lock unlocked?
+	// should we wait 5 minutes here?
+	if removeSubnet && ds.tenants[tenantID].CNCIctrl != nil {
+		go func() {
+			time.Sleep(5 * time.Minute)
+			ds.tenantsLock.RLock()
+			subnets := ds.tenants[tenantID].subnets
+			for _, s := range subnets {
+				if s == i {
+					removeSubnet = false
+					break
+				}
+			}
+			ds.tenantsLock.RUnlock()
+
+			if removeSubnet {
+				// handle error?
+				err := ds.tenants[tenantID].CNCIctrl.RemoveSubnet(i)
+				if err != nil {
+					glog.Warningf("Error removing subnet: (%v)\n", err)
+				}
+			}
+		}()
+	}
 
 	return ds.db.releaseTenantIP(tenantID, int(subnetInt), int(ipBytes[3]))
 }
@@ -678,6 +667,19 @@ func (ds *Datastore) AllocateTenantIP(tenantID string) (net.IP, error) {
 		return nil, errors.Wrap(err, "Error claiming tenant IP in database")
 	}
 
+	// must be done with lock unlocked?.
+	mgr := ds.tenants[tenantID].CNCIctrl
+
+	if mgr != nil {
+		// if the subnet has already been added, this function
+		// will just confirm the subnet is active. If a new one
+		// is needed, it will wait for the new cnci to become active.
+		err := mgr.WaitForActive(int(subnetInt))
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// convert to IP type.
 	next := net.IPv4(172, subnetBytes[0], subnetBytes[1], byte(rest))
 
@@ -703,12 +705,18 @@ func (ds *Datastore) getInstances(cncis bool) ([]*types.Instance, error) {
 	return instances, nil
 }
 
-// GetAllInstances retrieves all instances out of the datastore.
+// GetAllInstances retrieves all tenant instances out of the datastore.
 func (ds *Datastore) GetAllInstances() ([]*types.Instance, error) {
 	return ds.getInstances(false)
 }
 
+// GetAllCNCIInstances retrieves all CNCI instances out of the datastore.
+func (ds *Datastore) GetAllCNCIInstances() ([]*types.Instance, error) {
+	return ds.getInstances(true)
+}
+
 // GetInstance retrieves an instance out of the datastore.
+// The CNCI could be retrieved this way.
 func (ds *Datastore) GetInstance(id string) (*types.Instance, error) {
 	// always get from cache
 	ds.instancesLock.RLock()
@@ -866,37 +874,13 @@ func (ds *Datastore) StopFailure(instanceID string, reason payloads.StopFailureR
 // exited instance and we want to make sure that a failure to restart such
 // an instance does not result in it being deleted.
 func (ds *Datastore) StartFailure(instanceID string, reason payloads.StartFailureReason, migration bool) error {
-	var tenantID string
-
 	i, err := ds.GetInstance(instanceID)
 	if err != nil {
 		return errors.Wrapf(err, "error getting instance (%v)", instanceID)
 	}
-	tenantID = i.TenantID
 
 	if i.CNCI == true {
 		glog.Warning("CNCI ", instanceID, " Failed to start")
-
-		err := ds.removeTenantCNCI(tenantID)
-		if err != nil {
-			return errors.Wrap(err, "error removing CNCI for tenant")
-		}
-
-		msg := fmt.Sprintf("CNCI Start Failure %s: %s", instanceID, reason.String())
-		_ = ds.db.logEvent(tenantID, string(userError), msg)
-
-		ds.cnciAddedLock.Lock()
-
-		c, ok := ds.cnciAddedChans[tenantID]
-		if ok {
-			delete(ds.cnciAddedChans, tenantID)
-		}
-
-		ds.cnciAddedLock.Unlock()
-
-		if c != nil {
-			c <- false
-		}
 	}
 
 	if reason.IsFatal() && !migration {
@@ -1000,11 +984,16 @@ func (ds *Datastore) deleteInstance(instanceID string) (string, error) {
 	}
 
 	var err error
+	if tmpErr := ds.db.deleteInstance(i.ID); tmpErr != nil {
+		glog.Warningf("error deleting instance (%v): %v", i.ID, err)
+		err = errors.Wrapf(tmpErr, "error deleting instance from database (%v)", i.ID)
+	}
+
 	if i.CNCI == false {
 		if tmpErr := ds.ReleaseTenantIP(i.TenantID, i.IPAddress); tmpErr != nil {
-			glog.Warningf("error releasing IP for instance (%v): %v", i.ID, err)
+			glog.Warningf("error releasing IP for instance (%v): %v", i.ID, tmpErr)
 			if err == nil {
-				err = errors.Wrapf(tmpErr, "error releasing IP for instance (%v)", i.ID)
+				err = errors.Wrapf(err, "error releasing IP for instance (%v)", i.ID)
 			}
 		}
 	}
@@ -1411,49 +1400,34 @@ func (c ByTenantID) Less(i int, j int) bool {
 // cnci.
 func (ds *Datastore) GetTenantCNCISummary(cnci string) ([]types.TenantCNCI, error) {
 	var cncis []types.TenantCNCI
-	subnetBytes := []byte{0, 0}
 
-	ds.tenantsLock.RLock()
+	instances, err := ds.GetAllCNCIInstances()
+	if err != nil {
+		return cncis, err
+	}
 
-	for _, t := range ds.tenants {
-		if cnci != "" && cnci != t.CNCIID {
+	for _, i := range instances {
+		if cnci != "" && cnci != i.ID {
 			continue
 		}
 
-		var IPAddress string
-		var MACAddress string
-
-		if t.CNCIID != "" {
-			i, err := ds.GetInstance(t.CNCIID)
-			if err != nil {
-				return nil, err
-			}
-
-			IPAddress = i.IPAddress
-			MACAddress = i.MACAddress
-		}
-
 		cn := types.TenantCNCI{
-			TenantID:   t.ID,
-			IPAddress:  IPAddress,
-			MACAddress: MACAddress,
-			InstanceID: t.CNCIID,
+			TenantID:   i.TenantID,
+			IPAddress:  i.IPAddress,
+			MACAddress: i.MACAddress,
+			InstanceID: i.ID,
 		}
 
-		for _, subnet := range t.subnets {
-			binary.BigEndian.PutUint16(subnetBytes, (uint16)(subnet))
-			cn.Subnets = append(cn.Subnets, fmt.Sprintf("Subnet 172.%d.%d.0/8", subnetBytes[0], subnetBytes[1]))
-		}
+		cn.Subnets = append(cn.Subnets, i.Subnet)
 
 		cncis = append(cncis, cn)
 
-		if cnci != "" && cnci == t.CNCIID {
+		if cnci != "" {
 			break
 		}
 	}
 
-	ds.tenantsLock.RUnlock()
-
+	// sort by TenantID.
 	sort.Sort(ByTenantID(cncis))
 
 	return cncis, nil
@@ -1495,8 +1469,6 @@ func (ds *Datastore) GetNodeSummary() ([]*types.NodeSummary, error) {
 				summary.TotalPausedInstances++
 			}
 		}
-
-		summary.NodeID = n.ID
 
 		nodes = append(nodes, &summary)
 	}

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -1390,6 +1390,21 @@ func (ds *Datastore) addInstanceStats(stats []payloads.InstanceStat, nodeID stri
 	return errors.Wrapf(ds.db.addInstanceStats(stats, nodeID), "error adding instance stats to database")
 }
 
+// ByTenantID is used to sort CNCI instances by Tenant ID.
+type ByTenantID []types.TenantCNCI
+
+func (c ByTenantID) Len() int {
+	return len(c)
+}
+
+func (c ByTenantID) Swap(i int, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
+func (c ByTenantID) Less(i int, j int) bool {
+	return c[i].TenantID < c[j].TenantID
+}
+
 // GetTenantCNCISummary retrieves information about a given CNCI id, or all CNCIs
 // If the cnci string is the null string, then this function will retrieve all
 // tenants.  If cnci is not null, it will only provide information about a specific
@@ -1438,6 +1453,8 @@ func (ds *Datastore) GetTenantCNCISummary(cnci string) ([]types.TenantCNCI, erro
 	}
 
 	ds.tenantsLock.RUnlock()
+
+	sort.Sort(ByTenantID(cncis))
 
 	return cncis, nil
 }

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"os"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -187,14 +188,13 @@ func addTestTenant() (tenant *types.Tenant, err error) {
 		CNCI:       true,
 		IPAddress:  "192.168.0.1",
 		MACAddress: mac.String(),
+		StateLock:  &sync.RWMutex{},
 	}
 
 	err = ds.AddInstance(&CNCI)
 	if err != nil {
 		return
 	}
-
-	tenant.CNCIID = CNCI.ID
 
 	err = addTestWorkload(tuuid.String())
 
@@ -956,39 +956,6 @@ func TestGetAllTenants(t *testing.T) {
 	// errors.
 }
 
-func TestCNCIAdded(t *testing.T) {
-	tenant, err := addTestTenant()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// make sure that AddCNCIIP signals the channel it's supposed to
-	c := make(chan bool)
-	ds.cnciAddedLock.Lock()
-	ds.cnciAddedChans[tenant.ID] = c
-	ds.cnciAddedLock.Unlock()
-
-	go func() {
-		err := ds.CNCIAdded(tenant.ID)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	success := <-c
-	if !success {
-		t.Fatal(err)
-	}
-
-	// confirm that the channel was cleared
-	ds.cnciAddedLock.Lock()
-	c = ds.cnciAddedChans[tenant.ID]
-	ds.cnciAddedLock.Unlock()
-	if c != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestHandleTraceReport(t *testing.T) {
 	trace := payloads.Trace{
 		Frames: createTestFrameTraces("test"),
@@ -1006,10 +973,17 @@ func TestGetCNCISummary(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// test without null cnciid
-	_, err = ds.GetTenantCNCISummary(tenant.CNCIID)
+	instances, err := ds.GetTenantCNCIs(tenant.ID)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// test without null cnciid
+	for _, i := range instances {
+		_, err = ds.GetTenantCNCISummary(i.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// test with null cnciid
@@ -1048,6 +1022,11 @@ func TestReleaseTenantIP(t *testing.T) {
 		t.Fatal("IP Address not marked Used")
 	}
 
+	// confirm that subnets has been incremented
+	if len(newTenant.subnets) != 1 {
+		t.Fatal("subnet not allocated in cache")
+	}
+
 	err = ds.ReleaseTenantIP(tenant.ID, ip.String())
 	if err != nil {
 		t.Fatal(err)
@@ -1064,6 +1043,10 @@ func TestReleaseTenantIP(t *testing.T) {
 		t.Fatal("IP Address not released from cache")
 	}
 
+	if len(newTenant.subnets) != 0 {
+		t.Fatal("subnet not released from cache")
+	}
+
 	// clear tenant from cache
 	ds.tenantsLock.Lock()
 	delete(ds.tenants, tenant.ID)
@@ -1078,27 +1061,6 @@ func TestReleaseTenantIP(t *testing.T) {
 	// confirm that tenant map shows it not used.
 	if newTenant.network[int(subnetInt)][int(ipBytes[3])] != false {
 		t.Fatal("IP Address not released from database")
-	}
-}
-
-func TestAddTenantChan(t *testing.T) {
-	c := make(chan bool)
-
-	tenant, err := addTestTenant()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ds.AddTenantChan(c, tenant.ID)
-
-	// check cncisAddedChans
-	ds.cnciAddedLock.Lock()
-	c1 := ds.cnciAddedChans[tenant.ID]
-	delete(ds.cnciAddedChans, tenant.ID)
-	ds.cnciAddedLock.Unlock()
-
-	if c1 != c {
-		t.Fatal("Did not update Added Chans properly")
 	}
 }
 

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -17,6 +17,7 @@
 package datastore
 
 import (
+	"crypto/rand"
 	"database/sql"
 	"encoding/binary"
 	"flag"
@@ -31,6 +32,7 @@ import (
 	"github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp/uuid"
+	"github.com/pkg/errors"
 )
 
 func newTenantHardwareAddr(ip net.IP) (hw net.HardwareAddr) {
@@ -41,6 +43,28 @@ func newTenantHardwareAddr(ip net.IP) (hw net.HardwareAddr) {
 	copy(buf[2:6], ipBytes)
 	hw = net.HardwareAddr(buf)
 	return
+}
+
+func newHardwareAddr() (net.HardwareAddr, error) {
+	buf := make([]byte, 6)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return nil, errors.Wrap(err, "error reading random data")
+	}
+
+	// vnic creation seems to require not just the
+	// bit 1 to be set, but the entire byte to be
+	// set to 2.  Also, ensure that we get no
+	// overlap with tenant mac addresses by not allowing
+	// byte 1 to ever be zero.
+	buf[0] = 2
+	if buf[1] == 0 {
+		buf[1] = 3
+	}
+
+	hw := net.HardwareAddr(buf)
+
+	return hw, nil
 }
 
 func addInstance(tenant *types.Tenant, workload types.Workload, name string) (instance *types.Instance, err error) {
@@ -150,15 +174,27 @@ func addTestTenant() (tenant *types.Tenant, err error) {
 		return
 	}
 
+	mac, err := newHardwareAddr()
+	if err != nil {
+		return
+	}
+
 	// Add fake CNCI
-	err = ds.AddTenantCNCI(tuuid.String(), uuid.Generate().String(), tenant.CNCIMAC)
+	CNCI := types.Instance{
+		TenantID:   tenant.ID,
+		State:      payloads.Running,
+		ID:         uuid.Generate().String(),
+		CNCI:       true,
+		IPAddress:  "192.168.0.1",
+		MACAddress: mac.String(),
+	}
+
+	err = ds.AddInstance(&CNCI)
 	if err != nil {
 		return
 	}
-	err = ds.AddCNCIIP(tenant.CNCIMAC, "192.168.0.1")
-	if err != nil {
-		return
-	}
+
+	tenant.CNCIID = CNCI.ID
 
 	err = addTestWorkload(tuuid.String())
 
@@ -896,37 +932,6 @@ func TestGetCNCIWorkloadID(t *testing.T) {
 	}
 }
 
-func TestRemoveTenantCNCI(t *testing.T) {
-	tenant, err := addTestTenant()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = ds.removeTenantCNCI(tenant.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// make sure cache was updated
-	ds.tenantsLock.Lock()
-	t2 := ds.tenants[tenant.ID]
-	delete(ds.tenants, tenant.ID)
-	ds.tenantsLock.Unlock()
-
-	if t2.CNCIID != "" || t2.CNCIIP != "" {
-		t.Fatal("Cache Not Updated")
-	}
-
-	// check database was updated
-	testTenant, err := ds.GetTenant(tenant.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if testTenant.CNCIID != "" || testTenant.CNCIIP != "" {
-		t.Fatal("Database not updated")
-	}
-}
-
 func TestGetTenant(t *testing.T) {
 	tenant, err := addTestTenant()
 	if err != nil {
@@ -951,16 +956,8 @@ func TestGetAllTenants(t *testing.T) {
 	// errors.
 }
 
-func TestAddCNCIIP(t *testing.T) {
-	/* add a new tenant */
-	tuuid := uuid.Generate()
-	tenant, err := ds.AddTenant(tuuid.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Add fake CNCI
-	err = ds.AddTenantCNCI(tenant.ID, uuid.Generate().String(), tenant.CNCIMAC)
+func TestCNCIAdded(t *testing.T) {
+	tenant, err := addTestTenant()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -972,7 +969,7 @@ func TestAddCNCIIP(t *testing.T) {
 	ds.cnciAddedLock.Unlock()
 
 	go func() {
-		err := ds.AddCNCIIP(tenant.CNCIMAC, "192.168.0.1")
+		err := ds.CNCIAdded(tenant.ID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -79,11 +79,11 @@ func (db *MemoryDB) getEventLog() ([]*types.LogEntry, error) {
 	return db.logEntries, nil
 }
 
-func (db *MemoryDB) addTenant(id string, MAC string) error {
+func (db *MemoryDB) addTenant(id string, name string) error {
 	t := &tenant{
 		Tenant: types.Tenant{
-			ID:      id,
-			CNCIMAC: MAC,
+			ID:   id,
+			Name: name,
 		},
 		network:   make(map[int]map[int]bool),
 		instances: make(map[string]*types.Instance),
@@ -107,15 +107,6 @@ func (db *MemoryDB) getTenants() ([]*tenant, error) {
 		tenants = append(tenants, t)
 	}
 	return tenants, nil
-}
-
-func (db *MemoryDB) updateTenant(t *tenant) error {
-	_, ok := db.tenants[t.ID]
-	if !ok {
-		return fmt.Errorf("Tenant %s not found", t.ID)
-	}
-	db.tenants[t.ID] = t
-	return nil
 }
 
 func (db *MemoryDB) releaseTenantIP(tenantID string, subnetInt int, rest int) error {
@@ -240,4 +231,8 @@ func (db *MemoryDB) updateQuotas(tenantID string, qds []types.QuotaDetails) erro
 
 func (db *MemoryDB) getQuotas(tenantID string) ([]types.QuotaDetails, error) {
 	return []types.QuotaDetails{}, nil
+}
+
+func (db *MemoryDB) updateInstance(instance *types.Instance) error {
+	return nil
 }

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -199,6 +199,12 @@ func main() {
 		return
 	}
 
+	err = initializeCNCICtrls(ctl)
+	if err != nil {
+		glog.Fatal("Unable to initialize CNCI controllers: ", err)
+		return
+	}
+
 	server, err := ctl.createComputeServer()
 	if err != nil {
 		glog.Fatalf("Error creating compute server: %v", err)

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -140,11 +140,9 @@ func (s SortedNodesByID) Less(i, j int) bool { return s[i].ID < s[j].ID }
 
 // Tenant contains information about a tenant or project.
 type Tenant struct {
-	ID      string
-	Name    string
-	CNCIID  string
-	CNCIMAC string
-	CNCIIP  string
+	ID     string
+	Name   string
+	CNCIID string
 }
 
 // LogEntry stores information about events.

--- a/payloads/stats.go
+++ b/payloads/stats.go
@@ -129,13 +129,20 @@ const (
 	// Running indicates an instance is running
 	Running = ComputeStatusRunning
 
+	// Stopping is used to indicate that a request to pause an instance
+	// has been issued by controller and is in progress.
+	Stopping = "stopping"
+
 	// Exited indicates that an instance has been successfully created but
 	// is not currently running, either because it failed to start or was
 	// explicitly stopped by a STOP command or perhaps by a CN reboot.
 	Exited = ComputeStatusStopped
-	// ExitFailed is not currently used
+
+	// ExitFailed is used by controller to indicate that a workload failed
+	// to launch.
 	ExitFailed = "exit_failed"
-	// ExitPaused is not currently used
+
+	// ExitPaused is not currently used.
 	ExitPaused = "exit_paused"
 )
 


### PR DESCRIPTION
This PR implements multiple CNCIs per tenant in the controller, one for each subnet. When a subnet is no longer in use, the CNCI for that subnet will be deleted after a 5 minute settle period. It creates a CNCI controller interface per tenant. This controller is responsible for managing the CNCI lifecycle.  With this code, we will now store CNCI instance information in the datastore with the tenant instances so that we can delete CNCI instances when we no longer need them.