### PR TITLE
ciao-controller: Use memory backend for transient database

### DIFF
--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -78,7 +78,6 @@ var workloadsPath = flag.String("workloads_path", "/var/lib/ciao/data/controller
 var noNetwork = flag.Bool("nonetwork", false, "Debug with no networking")
 var persistentDatastoreLocation = flag.String("database_path", "/var/lib/ciao/data/controller/ciao-controller.db", "path to persistent database")
 var imageDatastoreLocation = flag.String("image_database_path", "/var/lib/ciao/data/image/ciao-image.db", "path to image persistent database")
-var transientDatastoreLocation = flag.String("stats_path", "/tmp/ciao-controller-stats.db", "path to stats database")
 var logDir = "/var/lib/ciao/logs/controller"
 
 var imagesPath = flag.String("images_path", "/var/lib/ciao/images", "path to ciao images")
@@ -120,7 +119,7 @@ func main() {
 
 	dsConfig := datastore.Config{
 		PersistentURI:     "file:" + *persistentDatastoreLocation,
-		TransientURI:      "file:" + *transientDatastoreLocation,
+		TransientURI:      "file:transient?mode=memory&cache=shared",
 		InitWorkloadsPath: *workloadsPath,
 	}
 


### PR DESCRIPTION
For performance controller has separate databases for frequently updated
statistics that are not critical for operation and for state that needs
to be persisted long term. The former being stored in /tmp to avoid
filesystem performance issues. However /tmp is not guaranteed to be
tmpfs (and on Ubuntu 16.04 is not) instead this change switches
controller to use the memory backend to sqlite.

Fixes: #1330

Signed-off-by: Rob Bradford <robert.bradford@intel.com>