### PR TITLE
Enable graceful shutdown of controller 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
   - docker
 
 go:
-    - 1.7
     - 1.8
     - go1.9beta2
     - tip

--- a/DeveloperQuickStart.md
+++ b/DeveloperQuickStart.md
@@ -105,9 +105,9 @@ completely self contained.
 On the host install the latest release of go for your distribution
 [Installing Go](https://golang.org/doc/install).
 
-> NOTE: Go version 1.7 or later is required for Ciao. Ciao will not work with 
+> NOTE: Go version 1.8 or later is required for Ciao. Ciao will not work with 
 older version of Go. Hence it is best you download and install the latest 
-version of Go if you distro is not on Go 1.7.
+version of Go if you distro is not on Go 1.8.
 
 You should also ensure that your GOPATH environment variable is set.
 
@@ -117,7 +117,7 @@ ciao-down is a small utility for setting up a VM that contains
 everything you need to run ciao's Single VM. All you need to have
 installed on your machine is:
 
-- Go 1.7 or greater
+- Go 1.8 or greater
 
 Once Go is installed you simply need to type
 

--- a/_DeploymentAndDistroPackaging/ansible/README.md
+++ b/_DeploymentAndDistroPackaging/ansible/README.md
@@ -26,7 +26,7 @@ The deployment machine can be any Linux OS as long as it has the following packa
 * python-keystoneclient
 * python-netaddr
 * gcc
-* go>=1.7
+* go>=1.8
 * git
 
 ---

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -1993,9 +1993,11 @@ func TestMain(m *testing.M) {
 	}
 
 	_, _ = addComputeTestTenant()
-	go ctl.startComputeService()
+	s, _ := ctl.createComputeServer()
+	go s.ListenAndServeTLS(httpsCAcert, httpsKey)
 	time.Sleep(1 * time.Second)
-	go ctl.startVolumeService()
+	s, _ = ctl.createVolumeServer()
+	go s.ListenAndServeTLS(httpsCAcert, httpsKey)
 	time.Sleep(1 * time.Second)
 
 	code := m.Run()

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -606,6 +606,7 @@ func (ds *sqliteDB) Connect(persistentURI string, transientURI string) error {
 // Disconnect is used to close the connection to the sql database
 func (ds *sqliteDB) disconnect() {
 	ds.db.Close()
+	ds.tdb.Close()
 }
 
 func (ds *sqliteDB) logEvent(tenantID string, eventType string, message string) error {

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -49,6 +49,7 @@ type controller struct {
 	storage.BlockDriver
 	client              controllerClient
 	ds                  *datastore.Datastore
+	is                  *ImageService
 	id                  *identity
 	apiURL              string
 	tenantReadiness     map[string]*tenantConfirmMemo
@@ -232,6 +233,7 @@ func main() {
 	wg.Wait()
 	ctl.qs.Shutdown()
 	ctl.ds.Exit()
+	ctl.is.ds.Shutdown()
 	ctl.client.Disconnect()
 }
 

--- a/ciao-controller/openstack_image.go
+++ b/ciao-controller/openstack_image.go
@@ -249,7 +249,6 @@ func (c *controller) startImageService() error {
 	if err != nil {
 		glog.Fatalf("Error on DB Initialization: %v", err)
 	}
-	defer metaDs.DbClose()
 
 	err = metaDs.DbTablesInit(metaDsTables)
 	if err != nil {
@@ -283,15 +282,15 @@ func (c *controller) startImageService() error {
 	glog.Infof("RawDataStore  : %T", config.RawDataStore)
 	glog.Infof("MetaDataStore : %T", config.MetaDataStore)
 
-	is := ImageService{ds: &imageDatastore.ImageStore{}, qs: c.qs}
-	err = is.ds.Init(config.RawDataStore, config.MetaDataStore)
+	c.is = &ImageService{ds: &imageDatastore.ImageStore{}, qs: c.qs}
+	err = c.is.ds.Init(config.RawDataStore, config.MetaDataStore)
 	if err != nil {
 		return err
 	}
 
 	apiConfig := image.APIConfig{
 		Port:         config.Port,
-		ImageService: &is,
+		ImageService: c.is,
 	}
 
 	// get our routes.

--- a/ciao-controller/openstack_image.go
+++ b/ciao-controller/openstack_image.go
@@ -32,6 +32,7 @@ import (
 	"github.com/01org/ciao/ssntp/uuid"
 	"github.com/golang/glog"
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 )
 
 // ImageService is the context for the image service implementation.
@@ -223,11 +224,9 @@ type ImageConfig struct {
 	MetaDataStore imageDatastore.MetaDataStore
 }
 
-// startImageService will get the Image API endpoints from the OpenStack image api,
-// then wrap them in keystone validation. It will then start the https
-// service.
-func (c *controller) startImageService() error {
-
+// createImageServer will get the Image API endpoints from the OpenStack image api,
+// then wrap them in keystone validation.
+func (c *controller) createImageServer() (*http.Server, error) {
 	dbDir := filepath.Dir(*imageDatastoreLocation)
 	dbFile := filepath.Base(*imageDatastoreLocation)
 
@@ -247,12 +246,12 @@ func (c *controller) startImageService() error {
 	err := metaDs.DbInit(metaDs.DbDir, metaDs.DbFile)
 
 	if err != nil {
-		glog.Fatalf("Error on DB Initialization: %v", err)
+		return nil, errors.Wrap(err, "Error on DB Initialization")
 	}
 
 	err = metaDs.DbTablesInit(metaDsTables)
 	if err != nil {
-		glog.Fatalf("Error on DB Tables Initialization: %v ", err)
+		return nil, errors.Wrap(err, "Error on DB Tables Initialization")
 	}
 
 	rawDs := &imageDatastore.Ceph{
@@ -285,7 +284,7 @@ func (c *controller) startImageService() error {
 	c.is = &ImageService{ds: &imageDatastore.ImageStore{}, qs: c.qs}
 	err = c.is.ds.Init(config.RawDataStore, config.MetaDataStore)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	apiConfig := image.APIConfig{
@@ -319,11 +318,15 @@ func (c *controller) startImageService() error {
 		return nil
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// start service.
 	service := fmt.Sprintf(":%d", config.Port)
-	glog.Infof("Starting CIAO Image Service")
-	return http.ListenAndServeTLS(service, config.HTTPSCACert, config.HTTPSKey, r)
+
+	server := &http.Server{
+		Handler: r,
+		Addr:    service,
+	}
+
+	return server, nil
 }

--- a/ciao-image/datastore/ceph.go
+++ b/ciao-image/datastore/ceph.go
@@ -23,7 +23,7 @@ import (
 	"github.com/01org/ciao/ciao-storage"
 )
 
-// Ceph implements the DataStore interface for Ceph RBD based storage
+// Ceph implements the RawDataStore interface for Ceph RBD based storage
 type Ceph struct {
 	ImageTempDir string
 	BlockDriver  storage.CephDriver

--- a/ciao-image/datastore/datastore.go
+++ b/ciao-image/datastore/datastore.go
@@ -90,6 +90,7 @@ type DataStore interface {
 	UpdateImage(Image) error
 	DeleteImage(tenant, id string) error
 	UploadImage(tenant, id string, imageFile io.Reader) error
+	Shutdown() error
 }
 
 // MetaDataStore is the metadata storing interface that's used by
@@ -99,6 +100,7 @@ type MetaDataStore interface {
 	Delete(tenant, ID string) error
 	Get(tenant, ID string) (Image, error)
 	GetAll(tenant string) ([]Image, error)
+	Shutdown() error
 }
 
 // RawDataStore is the raw data storage interface that's used by the

--- a/ciao-image/datastore/metads.go
+++ b/ciao-image/datastore/metads.go
@@ -18,7 +18,7 @@ import (
 	"github.com/01org/ciao/database"
 )
 
-// MetaDs implements the DataStore interface for persistent data
+// MetaDs implements the MetaDataStore interface for persistent data
 type MetaDs struct {
 	database.DbProvider
 	DbDir  string
@@ -68,4 +68,9 @@ func (m *MetaDs) GetAll(tenant string) (images []Image, err error) {
 	}
 
 	return images, err
+}
+
+// Shutdown closes the database connection
+func (m *MetaDs) Shutdown() error {
+	return m.DbClose()
 }

--- a/ciao-image/datastore/noop.go
+++ b/ciao-image/datastore/noop.go
@@ -48,3 +48,8 @@ func (n *Noop) Get(tenant, id string) (Image, error) {
 func (n *Noop) GetAll(tenant string) ([]Image, error) {
 	return []Image{}, nil
 }
+
+// Shutdown no-op
+func (n *Noop) Shutdown() error {
+	return nil
+}

--- a/ciao-image/datastore/posix.go
+++ b/ciao-image/datastore/posix.go
@@ -21,7 +21,7 @@ import (
 	"path"
 )
 
-// Posix implements the DataStore interface for posix filesystems
+// Posix implements the RawDataStore interface for posix filesystems
 type Posix struct {
 	MountPoint string
 }

--- a/ciao-image/datastore/store.go
+++ b/ciao-image/datastore/store.go
@@ -76,6 +76,11 @@ func (s *ImageStore) Init(rawDs RawDataStore, metaDs MetaDataStore) error {
 	return nil
 }
 
+// Shutdown is the opposite of Init()
+func (s *ImageStore) Shutdown() error {
+	return s.metaDs.Shutdown()
+}
+
 // CreateImage will add an image to the datastore.
 func (s *ImageStore) CreateImage(i Image) error {
 	s.ImageMap.Lock()

--- a/testutil/ciao-down/README.md
+++ b/testutil/ciao-down/README.md
@@ -4,7 +4,7 @@ ciao-down is a small utility for setting up a VM that contains
 everything you need to run ciao's Single VM. All you need to have
 installed on your machine is:
 
-- Go 1.7 or greater
+- Go 1.8 or greater
 
 Then simply type
 


### PR DESCRIPTION
This PR modifies controller to handle SIGINT and SIGTERM starting a shutdown process when they are received. To do this the new http.Server.Shutdown() added in Go 1.8 is used. This requires bumping the Go requirement to 1.8 which this PR does.