### PR TITLE
ciao-cert: Only set x509.KeyUsageCertSign on anchor certificate

### DIFF
--- a/ciao-cert/main.go
+++ b/ciao-cert/main.go
@@ -112,6 +112,7 @@ func createCertificates(role ssntp.Role) {
 	CAcertName := fmt.Sprintf("%s/CAcert-%s.pem", *installDir, firstHost)
 	certName := fmt.Sprintf("%s/cert-%s-%s.pem", *installDir, role.String(), firstHost)
 	if *isAnchor == true {
+		template.KeyUsage = template.KeyUsage | x509.KeyUsageCertSign
 		CAcertOut, err := os.Create(CAcertName)
 		if err != nil {
 			log.Fatalf("Failed to open %s for writing: %s", CAcertName, err)

--- a/ssntp/certs/certs.go
+++ b/ssntp/certs/certs.go
@@ -156,7 +156,7 @@ func CreateCertTemplate(role ssntp.Role, organization string, email string, host
 		NotBefore: notBefore,
 		NotAfter:  notAfter,
 
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 		EmailAddresses:        []string{email},
 		BasicConstraintsValid: true,
@@ -278,7 +278,7 @@ func createCertTemplateFromCSR(role ssntp.Role, request *x509.CertificateRequest
 		PublicKeyAlgorithm: request.PublicKeyAlgorithm,
 		PublicKey:          request.PublicKey,
 
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 		EmailAddresses:        request.EmailAddresses,
 		BasicConstraintsValid: true,


### PR DESCRIPTION
This PR moves the setting of the bit needed for anchor certificates
from the convenience function that generates a template to the caller.
With this fix every certificate we generate is no longer a CA.

Fixes: #1294

Signed-off-by: Rob Bradford <robert.bradford@intel.com>