### PR TITLE
Complete removal of workload Image ID

### DIFF
--- a/_release/bat/base_bat/base_bat_test.go
+++ b/_release/bat/base_bat/base_bat_test.go
@@ -236,7 +236,7 @@ func TestStartAllWorkloads(t *testing.T) {
 
 func checkInstances(t *testing.T, a, b *bat.Instance) {
 	if !(a.TenantID == b.TenantID &&
-		a.FlavorID == b.FlavorID && a.ImageID == b.ImageID &&
+		a.FlavorID == b.FlavorID &&
 		a.PrivateIP == b.PrivateIP && a.MacAddress == b.MacAddress &&
 		a.SSHIP == b.SSHIP && a.SSHPort == b.SSHPort) {
 		t.Fatalf("Instance details do not match: %v %v", a, b)

--- a/bat/compute.go
+++ b/bat/compute.go
@@ -36,7 +36,7 @@ import (
 
 const instanceTemplateDesc = `{ "host_id" : "{{.HostID | js }}", 
     "tenant_id" : "{{.TenantID | js }}", "flavor_id" : "{{.Flavor.ID | js}}",
-    "image_id" : "{{.Image.ID | js}}", "status" : "{{.Status | js}}",
+    "status" : "{{.Status | js}}",
     "ssh_ip" : "{{.SSHIP | js }}", "ssh_port" : {{.SSHPort}},
     "volumes" : {{tojson .OsExtendedVolumesVolumesAttached}}
     {{ $addrLen := len .Addresses.Private }}
@@ -67,7 +67,6 @@ type Instance struct {
 	HostID     string   `json:"host_id"`
 	TenantID   string   `json:"tenant_id"`
 	FlavorID   string   `json:"flavor_id"`
-	ImageID    string   `json:"image_id"`
 	Status     string   `json:"status"`
 	PrivateIP  string   `json:"private_ip"`
 	MacAddress string   `json:"mac_address"`

--- a/ciao-cli/examples/README.md
+++ b/ciao-cli/examples/README.md
@@ -42,19 +42,22 @@ provided, however, `vm_type` is set to `qemu`. Additionally, a `fw_type` is
 required to specify whether the image that is provided has a UEFI based
 firmware, or a legacy firmware. If the workload should be booted from an
 image, the image must have already been added to the ciao image service.
-The `image_id` is the UUID of the image, and can be obtained with `ciao-cli
-image list`.
 
 ```
 description: "My favorite pet VM"
 vm_type: qemu
 fw_type: legacy
-image_id: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
+disks:
+  - source:
+       service: image
+       id: "73a86d7e-93c0-480e-9c41-ab42f69b7799"
+    ephemeral: true
+    bootable: true
 ```
 
 Workloads may also be specified to boot from volumes created in ciao's volume
-service. To create a workload which boots from an existing volume, leave the
-image_id blank and include a definition for a bootable disk.
+service. To create a workload which boots from an existing volume include a
+definition for a bootable disk.
 
 ```
 description: "My favorite pet VM"

--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -156,7 +156,6 @@ type workloadOptions struct {
 	VMType          string           `yaml:"vm_type"`
 	FWType          string           `yaml:"fw_type,omitempty"`
 	ImageName       string           `yaml:"image_name,omitempty"`
-	ImageID         string           `yaml:"image_id,omitempty"`
 	Defaults        defaultResources `yaml:"defaults"`
 	CloudConfigFile string           `yaml:"cloud_init,omitempty"`
 	Disks           []disk           `yaml:"disks,omitempty"`
@@ -229,7 +228,6 @@ func optToReq(opt workloadOptions, req *types.Workload) error {
 	req.VMType = payloads.Hypervisor(opt.VMType)
 	req.FWType = opt.FWType
 	req.ImageName = opt.ImageName
-	req.ImageID = opt.ImageID
 	req.Config = config
 	req.Storage, err = optToReqStorage(opt)
 
@@ -262,7 +260,6 @@ func outputWorkload(w types.Workload) {
 	opt.VMType = string(w.VMType)
 	opt.FWType = w.FWType
 	opt.ImageName = w.ImageName
-	opt.ImageID = w.ImageID
 	for _, d := range w.Defaults {
 		if d.Type == payloads.VCPUs {
 			opt.Defaults.VCPUs = d.Value

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -145,10 +145,10 @@ var tests = []test{
 		"POST",
 		"/workloads",
 		addWorkload,
-		`{"id":"","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_id":"73a86d7e-93c0-480e-9c41-ab42f69b7799","image_name":"","config":"this will totally work!","defaults":[]}`,
+		`{"id":"","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","defaults":[]}`,
 		"application/x.ciao.v1.workloads",
 		http.StatusCreated,
-		`{"workload":{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_id":"73a86d7e-93c0-480e-9c41-ab42f69b7799","image_name":"","config":"this will totally work!","defaults":[],"storage":null},"link":{"rel":"self","href":"/workloads/ba58f471-0735-4773-9550-188e2d012941"}}`,
+		`{"workload":{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","defaults":[],"storage":null},"link":{"rel":"self","href":"/workloads/ba58f471-0735-4773-9550-188e2d012941"}}`,
 	},
 	{
 		"DELETE",
@@ -166,7 +166,7 @@ var tests = []test{
 		"",
 		"application/x.ciao.v1.workloads",
 		http.StatusOK,
-		`{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_id":"73a86d7e-93c0-480e-9c41-ab42f69b7799","image_name":"","config":"this will totally work!","defaults":null,"storage":null}`,
+		`{"id":"ba58f471-0735-4773-9550-188e2d012941","description":"testWorkload","fw_type":"legacy","vm_type":"qemu","image_name":"","config":"this will totally work!","defaults":null,"storage":null}`,
 	},
 	{
 		"GET",
@@ -298,7 +298,6 @@ func (ts testCiaoService) ShowWorkload(tenant string, ID string) (types.Workload
 		Description: "testWorkload",
 		FWType:      payloads.Legacy,
 		VMType:      payloads.QEMU,
-		ImageID:     "73a86d7e-93c0-480e-9c41-ab42f69b7799",
 		Config:      "this will totally work!",
 	}, nil
 }

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -70,7 +70,6 @@ users:
 		Description: "testWorkload",
 		FWType:      string(payloads.EFI),
 		VMType:      payloads.QEMU,
-		ImageID:     uuid.Generate().String(),
 		ImageName:   "",
 		Config:      testConfig,
 		Defaults:    []payloads.RequestedResource{cpus, mem},

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -293,7 +293,6 @@ func newConfig(ctl *controller, wl *types.Workload, instanceID string, tenantID 
 
 	baseConfig := wl.Config
 	defaults := wl.Defaults
-	imageID := wl.ImageID
 	fwType := wl.FWType
 
 	tenant, err := ctl.ds.GetTenant(tenantID)
@@ -398,7 +397,6 @@ func newConfig(ctl *controller, wl *types.Workload, instanceID string, tenantID 
 	startCmd := payloads.StartCmd{
 		TenantUUID:          tenantID,
 		InstanceUUID:        instanceID,
-		ImageUUID:           imageID,
 		FWType:              payloads.Firmware(fwType),
 		VMType:              wl.VMType,
 		InstancePersistence: payloads.Host,

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -133,7 +133,6 @@ users:
 		Description: fmt.Sprintf("Private workload for %s", tenantID),
 		FWType:      string(payloads.EFI),
 		VMType:      payloads.QEMU,
-		ImageID:     uuid.Generate().String(),
 		ImageName:   "",
 		Config:      testConfig,
 		Defaults:    []payloads.RequestedResource{cpus, mem},

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -247,7 +247,6 @@ func (d workloadTemplateData) Init() error {
 		filename text,
 		fw_type text,
 		vm_type text,
-		image_id varchar(32),
 		image_name text,
 		internal integer,
 		foreign key(tenant_id) references tenants(id)
@@ -833,7 +832,6 @@ func (ds *sqliteDB) getTenantWorkloads(tenantID string) ([]types.Workload, error
 			 description,
 			 fw_type,
 			 vm_type,
-			 image_id,
 			 image_name
 		  FROM workload_template
 		  WHERE internal = 0 AND tenant_id = ?`
@@ -850,7 +848,7 @@ func (ds *sqliteDB) getTenantWorkloads(tenantID string) ([]types.Workload, error
 
 		var VMType string
 
-		err = rows.Scan(&wl.ID, &wl.TenantID, &wl.Description, &wl.FWType, &VMType, &wl.ImageID, &wl.ImageName)
+		err = rows.Scan(&wl.ID, &wl.TenantID, &wl.Description, &wl.FWType, &VMType, &wl.ImageName)
 		if err != nil {
 			return nil, err
 		}
@@ -933,7 +931,7 @@ func (ds *sqliteDB) updateWorkload(w types.Workload) error {
 			return err
 		}
 
-		_, err = tx.Exec("INSERT INTO workload_template (id, tenant_id, description, filename, fw_type, vm_type, image_id, image_name, internal) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", w.ID, w.TenantID, w.Description, filename, w.FWType, string(w.VMType), w.ImageID, w.ImageName, false)
+		_, err = tx.Exec("INSERT INTO workload_template (id, tenant_id, description, filename, fw_type, vm_type, image_name, internal) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", w.ID, w.TenantID, w.Description, filename, w.FWType, string(w.VMType), w.ImageName, false)
 		if err != nil {
 			tx.Rollback()
 			return err

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -971,7 +971,6 @@ users:
 		Description: "testWorkload",
 		FWType:      string(payloads.EFI),
 		VMType:      payloads.QEMU,
-		ImageID:     uuid.Generate().String(),
 		ImageName:   "",
 		Config:      testConfig,
 		Defaults:    []payloads.RequestedResource{mem, cpus},

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -32,11 +32,6 @@ import (
 )
 
 func instanceToServer(ctl *controller, instance *types.Instance) (compute.ServerDetails, error) {
-	workload, err := ctl.ds.GetWorkload(instance.TenantID, instance.WorkloadID)
-	if err != nil {
-		return compute.ServerDetails{}, err
-	}
-
 	var volumes []string
 
 	instance.Attachments = ctl.ds.GetStorageAttachments(instance.ID)
@@ -45,17 +40,12 @@ func instanceToServer(ctl *controller, instance *types.Instance) (compute.Server
 		volumes = append(volumes, vol.BlockID)
 	}
 
-	imageID := workload.ImageID
-
 	server := compute.ServerDetails{
 		HostID:   instance.NodeID,
 		ID:       instance.ID,
 		TenantID: instance.TenantID,
 		Flavor: compute.FlavorLinks{
 			ID: instance.WorkloadID,
-		},
-		Image: compute.Image{
-			ID: imageID,
 		},
 		Status: instance.State,
 		Addresses: compute.Addresses{

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -81,7 +81,6 @@ type Workload struct {
 	Description string                       `json:"description"`
 	FWType      string                       `json:"fw_type"`
 	VMType      payloads.Hypervisor          `json:"vm_type"`
-	ImageID     string                       `json:"image_id"`
 	ImageName   string                       `json:"image_name"`
 	Config      string                       `json:"config"`
 	Defaults    []payloads.RequestedResource `json:"defaults"`

--- a/ciao-controller/workload.go
+++ b/ciao-controller/workload.go
@@ -122,16 +122,6 @@ func validateWorkloadRequest(req types.Workload) error {
 		}
 	}
 
-	if req.ImageID != "" {
-		// validate that the image id is at least valid
-		// uuid4.
-		_, err := uuid.Parse(req.ImageID)
-		if err != nil {
-			glog.V(2).Info("Invalid workload request: ImageID is not uuid4")
-			return types.ErrBadRequest
-		}
-	}
-
 	if req.Config == "" {
 		glog.V(2).Info("Invalid workload request: config is blank")
 		return types.ErrBadRequest
@@ -157,26 +147,6 @@ func (c *controller) CreateWorkload(req types.Workload) (types.Workload, error) 
 	err = c.confirmTenant(req.TenantID)
 	if err != nil {
 		return req, err
-	}
-
-	// create a workload storage resource for this new workload.
-	if req.ImageID != "" {
-		// validate that the image id is at least valid
-		// uuid4.
-		_, err = uuid.Parse(req.ImageID)
-		if err != nil {
-			return req, err
-		}
-
-		storage := types.StorageResource{
-			Bootable:   true,
-			Ephemeral:  true,
-			SourceType: types.ImageService,
-			SourceID:   req.ImageID,
-		}
-
-		req.ImageID = ""
-		req.Storage = append(req.Storage, storage)
 	}
 
 	req.ID = uuid.Generate().String()

--- a/ciao-scheduler/scheduler_internal_test.go
+++ b/ciao-scheduler/scheduler_internal_test.go
@@ -124,7 +124,6 @@ func createStartWorkload(vCpus int, memMB int, diskMB int) *payloads.Start {
 	var work payloads.Start
 
 	work.Start.InstanceUUID = "c73322e8-d5fe-4d57-874c-dcee4fd368cd"
-	work.Start.ImageUUID = "b265f62b-e957-47fd-a0a2-6dc261c7315c"
 
 	reqVcpus := payloads.RequestedResource{
 		Type:      "vcpus",

--- a/payloads/restart_test.go
+++ b/payloads/restart_test.go
@@ -55,7 +55,6 @@ func TestRestartMarshal(t *testing.T) {
 	var cmd Restart
 	cmd.Restart.TenantUUID = testutil.TenantUUID
 	cmd.Restart.InstanceUUID = testutil.InstanceUUID
-	cmd.Restart.ImageUUID = testutil.ImageUUID
 	cmd.Restart.WorkloadAgentUUID = testutil.AgentUUID
 	cmd.Restart.RequestedResources = append(cmd.Restart.RequestedResources, reqVcpus)
 	cmd.Restart.RequestedResources = append(cmd.Restart.RequestedResources, reqMem)

--- a/payloads/start.go
+++ b/payloads/start.go
@@ -208,10 +208,6 @@ type StartCmd struct {
 	// InstanceUUID is the UUID of the instance itself.
 	InstanceUUID string `yaml:"instance_uuid"`
 
-	// ImageUUID is the UUID of the image upon which the RootFS of this
-	// instance will be based.  Only used for qemu instances.
-	ImageUUID string `yaml:"image_uuid"`
-
 	// DockerImage is the name of the docker base image from which the
 	// container will be created.  It should match the name of an
 	// existing image in the docker registry.  Only used for docker
@@ -263,9 +259,6 @@ type RestartCmd struct {
 
 	// InstanceUUID is the UUID of the instance to restart.
 	InstanceUUID string `yaml:"instance_uuid"`
-
-	// ImageUUID  is the image ID fo the instance to restart.
-	ImageUUID string `yaml:"image_uuid"`
 
 	// WorkloadAgentUUID identifies the node on which the instance is
 	// running.  This information is needed by the scheduler to route

--- a/payloads/start_test.go
+++ b/payloads/start_test.go
@@ -55,7 +55,6 @@ func TestStartMarshal(t *testing.T) {
 	var cmd Start
 	cmd.Start.TenantUUID = testutil.TenantUUID
 	cmd.Start.InstanceUUID = testutil.InstanceUUID
-	cmd.Start.ImageUUID = testutil.ImageUUID
 	cmd.Start.DockerImage = testutil.DockerImage
 	cmd.Start.RequestedResources = append(cmd.Start.RequestedResources, reqVcpus)
 	cmd.Start.RequestedResources = append(cmd.Start.RequestedResources, reqMem)
@@ -86,7 +85,6 @@ func TestStartUnmarshalPartial(t *testing.T) {
 
 	var expectedCmd Start
 	expectedCmd.Start.InstanceUUID = testutil.InstanceUUID
-	expectedCmd.Start.ImageUUID = testutil.ImageUUID
 	expectedCmd.Start.DockerImage = testutil.DockerImage
 	expectedCmd.Start.FWType = EFI
 	expectedCmd.Start.InstancePersistence = Host
@@ -99,7 +97,6 @@ func TestStartUnmarshalPartial(t *testing.T) {
 	expectedCmd.Start.RequestedResources = append(expectedCmd.Start.RequestedResources, vcpus)
 
 	if cmd.Start.InstanceUUID != expectedCmd.Start.InstanceUUID ||
-		cmd.Start.ImageUUID != expectedCmd.Start.ImageUUID ||
 		cmd.Start.DockerImage != expectedCmd.Start.DockerImage ||
 		cmd.Start.FWType != expectedCmd.Start.FWType ||
 		cmd.Start.InstancePersistence != expectedCmd.Start.InstancePersistence ||

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -96,9 +96,6 @@ const HTTPSCACert = "/etc/pki/ciao/compute_ca.pem"
 // DockerImage is a docker image name for use in start/restart tests
 const DockerImage = "docker/latest"
 
-// ImageUUID is a disk image UUID for use in start/restart tests
-const ImageUUID = "59460b8a-5f53-4e3e-b5ce-b71fed8c7e64"
-
 // InstanceUUID is an instance UUID for use in start/stop/restart/delete tests
 const InstanceUUID = "3390740c-dce9-48d6-b83a-a717417072ce"
 
@@ -147,7 +144,6 @@ var MultipleComputeNetworks = []payloads.NetworkStat{
 const StartYaml = `start:
   tenant_uuid: ` + TenantUUID + `
   instance_uuid: ` + InstanceUUID + `
-  image_uuid: ` + ImageUUID + `
   docker_image: ` + DockerImage + `
   fw_type: efi
   persistence: host
@@ -180,7 +176,6 @@ const StartYaml = `start:
 // CNCIStartYaml is a sample CNCI workload START ssntp.Command payload for test cases
 const CNCIStartYaml = `start:
   instance_uuid: ` + CNCIInstanceUUID + `
-  image_uuid: ` + ImageUUID + `
   fw_type: efi
   persistence: host
   vm_type: qemu
@@ -211,7 +206,6 @@ const CNCIStartYaml = `start:
 // PartialStartYaml is a sample minimal workload START ssntp.Command payload for test cases
 const PartialStartYaml = `start:
   instance_uuid: ` + InstanceUUID + `
-  image_uuid: ` + ImageUUID + `
   docker_image: ` + DockerImage + `
   fw_type: efi
   persistence: host
@@ -232,7 +226,6 @@ restart: false
 const RestartYaml = `restart:
   tenant_uuid: ` + TenantUUID + `
   instance_uuid: ` + InstanceUUID + `
-  image_uuid: ` + ImageUUID + `
   workload_agent_uuid: ` + AgentUUID + `
   fw_type: efi
   persistence: host


### PR DESCRIPTION
The image ID in the workload has been non-functional since we moved to specifying the image ID as source for a disk in the workload. This PR cleans up the remaining references to image ID by removing the field from the database, payloads and the ciao-cli reporting.

Fixes: #988 
Fixes: #1232