### PR TITLE
Fix kubicle

### DIFF
--- a/k8s/kubicle/README.md
+++ b/k8s/kubicle/README.md
@@ -86,11 +86,12 @@ To access k8s cluster:
 - export KUBECONFIG=$GOPATH/src/github.com/01org/ciao/testutil/singlevm/admin.conf
 - If you use proxies, set
   - export no_proxy=$no_proxy,198.51.100.2
+  - export NO_PROXY=$NO_PROXY,198.51.100.2
 ```
 
 The first thing you will notice is that the command takes a lot longer to complete.  This is because when you specify an external-ip address kubicle will wait until the k8s cluster is ready before completing, thereby avoiding the problem we encountered above where kubicle had completed successfully before our k8s cluster was up and running.
 
-The second thing you should notice is that the output is slightly different.  In addition to the extra information about the ciao external-ip resources created by kubicle we also see some information for configuring the kubectl tool.  Before we can use the kubectl tool on our host machine we need to download it.  Assuming your host machine is Ubuntu 16.04, kubectl can be installed as follows
+The second thing you should notice is that the output is slightly different.  In addition to the extra information about the ciao external-ip resources created by kubicle, we also see some information for configuring the kubectl tool.  Before we can use the kubectl tool on our host machine you may need to download and install it.  If your ciao cluster has been set up with [ciao-down](https://github.com/01org/ciao/tree/master/testutil/ciao-down) using the default ciao workload, kubectl will already be installed.  If not, you will need to install it yourself.  Assuming your host machine is Ubuntu 16.04, kubectl can be installed by running the following commands as root.
 
 ```
 apt-get update && apt-get install -y apt-transport-https
@@ -105,6 +106,7 @@ Now we can access of cluster from the outside.
 ```
 $ export KUBECONFIG=$GOPATH/src/github.com/01org/ciao/testutil/singlevm/admin.conf
 $ export no_proxy=$no_proxy,198.51.100.2
+$ export NO_PROXY=$NO_PROXY,198.51.100.2
 $ kubectl get nodes
 NAME                                   STATUS    AGE       VERSION
 1d96f6ac-a857-4f26-8c05-6a70ad57ee11   Ready     1m        v1.6.4

--- a/k8s/kubicle/cloudinit.go
+++ b/k8s/kubicle/cloudinit.go
@@ -82,7 +82,7 @@ const udMasterTemplate = `
  - echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" >/etc/apt/sources.list.d/kubernetes.list
  - apt-get update
  - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y docker-engine
- - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+ - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y kubelet=1.6.7-00 kubeadm=1.6.7-00 kubectl=1.6.7-00 kubernetes-cni
  - {{template "PROXIES" .}}no_proxy=` + "`hostname -i`" + ` kubeadm init --pod-network-cidr 10.244.0.0/16 --token {{.Token}} {{if len .ExternalIP}}--apiserver-cert-extra-sans={{.ExternalIP}}{{end}}
  - cp /etc/kubernetes/admin.conf /home/{{.User}}/
  - chown {{.User}}:{{.User}} /home/{{.User}}/admin.conf
@@ -100,7 +100,7 @@ const udNodeTemplate = `
  - echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" >/etc/apt/sources.list.d/kubernetes.list
  - apt-get update
  - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y docker-engine
- - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+ - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y kubelet=1.6.7-00 kubeadm=1.6.7-00 kubectl=1.6.7-00 kubernetes-cni
  - kubeadm join --token {{.Token}} {{.MasterIP}}:6443
 ...
 `

--- a/k8s/kubicle/cloudinit.go
+++ b/k8s/kubicle/cloudinit.go
@@ -82,7 +82,11 @@ const udMasterTemplate = `
  - echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" >/etc/apt/sources.list.d/kubernetes.list
  - apt-get update
  - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y docker-engine
- - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y kubelet=1.6.7-00 kubeadm=1.6.7-00 kubectl=1.6.7-00 kubernetes-cni
+{{with .K8sVersion}}
+ - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y kubelet={{.}}-00 kubeadm={{.}}-00 kubectl={{.}}-00 kubernetes-cni
+{{else}}
+ - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+{{end}}
  - {{template "PROXIES" .}}no_proxy=` + "`hostname -i`" + ` kubeadm init --pod-network-cidr 10.244.0.0/16 --token {{.Token}} {{if len .ExternalIP}}--apiserver-cert-extra-sans={{.ExternalIP}}{{end}}
  - cp /etc/kubernetes/admin.conf /home/{{.User}}/
  - chown {{.User}}:{{.User}} /home/{{.User}}/admin.conf
@@ -100,7 +104,11 @@ const udNodeTemplate = `
  - echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" >/etc/apt/sources.list.d/kubernetes.list
  - apt-get update
  - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y docker-engine
- - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y kubelet=1.6.7-00 kubeadm=1.6.7-00 kubectl=1.6.7-00 kubernetes-cni
+{{with .K8sVersion}}
+ - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y kubelet={{.}}-00 kubeadm={{.}}-00 kubectl={{.}}-00 kubernetes-cni
+{{else}}
+ - DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+{{end}}
  - kubeadm join --token {{.Token}} {{.MasterIP}}:6443
 ...
 `

--- a/k8s/kubicle/create.go
+++ b/k8s/kubicle/create.go
@@ -433,6 +433,7 @@ func (c *creator) status() {
 		fmt.Printf("- export KUBECONFIG=%s\n", c.adminPath)
 		fmt.Println("- If you use proxies, set")
 		fmt.Printf("  - export no_proxy=$no_proxy,%s\n", c.mc.ExternalIP)
+		fmt.Printf("  - export NO_PROXY=$NO_PROXY,%s\n", c.mc.ExternalIP)
 	}
 }
 

--- a/k8s/kubicle/create.go
+++ b/k8s/kubicle/create.go
@@ -195,6 +195,7 @@ func (c *creator) createMasterConfig() {
 			Token:        c.token,
 			UserDataFile: "k8s-master-ci.yaml",
 			Description:  masterWorkloadName,
+			K8sVersion:   c.opts.k8sVersion,
 		},
 		ExternalIP: c.opts.externalIP,
 	}
@@ -221,6 +222,7 @@ func (c *creator) createWorkerConfig() {
 			Token:        c.token,
 			UserDataFile: "k8s-worker-ci.yaml",
 			Description:  workerWorkloadName,
+			K8sVersion:   c.opts.k8sVersion,
 		},
 		MasterIP: c.masterIP,
 	}

--- a/k8s/kubicle/kubicle.go
+++ b/k8s/kubicle/kubicle.go
@@ -52,6 +52,7 @@ type options struct {
 	imageUUID     string
 	externalIP    string
 	keep          bool
+	k8sVersion    string
 }
 
 type baseConfig struct {
@@ -67,6 +68,7 @@ type baseConfig struct {
 	PublicKey    string
 	UserDataFile string
 	Description  string
+	K8sVersion   string
 }
 
 type proxyConfig struct {
@@ -97,7 +99,8 @@ func createFlags() (*options, error) {
 			memMiB:  2048,
 			diskGiB: 10,
 		},
-		workers: 1,
+		workers:    1,
+		k8sVersion: "1.6.7",
 	}
 
 	opts.user = os.Getenv("USER")
@@ -127,6 +130,7 @@ func createFlags() (*options, error) {
 	fs.StringVar(&opts.externalIP, "external-ip", opts.externalIP,
 		"External-ip to associate with the master node")
 	fs.BoolVar(&opts.keep, "keep", false, "Retains workload definition files if set to true")
+	fs.StringVar(&opts.k8sVersion, "k8s-version", opts.k8sVersion, "Specifies the version of k8s to install.  Should be either the empty string, meaning the latest, or a version, e.g, 1.6.7")
 
 	if err := fs.Parse(flag.Args()[1:]); err != nil {
 		return nil, err

--- a/testutil/ciao-down/workloads/ciao.yaml
+++ b/testutil/ciao-down/workloads/ciao.yaml
@@ -51,6 +51,9 @@ write_files:
  - content: |
      deb https://apt.dockerproject.org/repo ubuntu-xenial main
    path: /etc/apt/sources.list.d/docker.list
+ - content: |
+     deb http://apt.kubernetes.io/ kubernetes-xenial main
+   path: /etc/apt/sources.list.d/kubernetes.list
 
 apt:
 {{- if len $.HTTPProxy }}
@@ -109,12 +112,20 @@ runcmd:
  - {{template "ENV" .}}apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
  - {{endTaskCheck .}}
 
+ - {{beginTask . "Add Google GPG key" }}
+ - {{template "ENV" .}}curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+ - {{endTaskCheck .}}
+
  - {{beginTask . "Retrieving updated list of packages"}}
  - {{template "ENV" .}}apt-get update
  - {{endTaskCheck .}}
 
  - {{beginTask . "Installing Docker"}}
  - {{template "ENV" .}}apt-get install docker-engine -y
+ - {{endTaskCheck .}}
+
+ - {{beginTask . "Installing kubectl"}}
+ - {{template "ENV" .}}apt-get install kubectl -y
  - {{endTaskCheck .}}
 
  - {{beginTask . "Installing GCC"}}


### PR DESCRIPTION
This PR contains a number of small improvements to kubicle.

1. kubicle now installs version 1.6.7, a version known to work.  There is currently a race condition in kubicle 1.7.0 which can result in failed k8s installations using kubicle.  The worker nodes are unable to join the cluster.
2. kubectl tool is now installed by ciao-down
3. Some help and documentation updates.