### PR TITLE
ciao-down: Fix paths in ciao-fedora25 workload

### DIFF
--- a/testutil/ciao-down/workloads/ciao-fedora25.yaml
+++ b/testutil/ciao-down/workloads/ciao-fedora25.yaml
@@ -208,6 +208,8 @@ runcmd:
 
  - echo "export GOPATH={{template "GOPATH" . }}" >> /home/{{.User}}/.profile
  - echo "export PATH=$PATH:{{template "GOPATH" . }}/bin:/usr/local/go/bin" >> /home/{{.User}}/.profile
+ - echo "source /home/{{.User}}/.profile" >> /home/{{.User}}/.bashrc
+
 
  - {{finished .}}
   


### PR DESCRIPTION
The workload arranges for some paths to be initialised in the .profile
file, but this file is not read when logging in via an interactive shell.
This commit updates the workload to ensure that the newly created .profile
is read from .bashrc.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>