### PR TITLE
docs: Remove broken link from the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,12 @@ set of [payloads](https://github.com/01org/ciao/blob/master/payloads).
 
 This GitHub repository contains documentation on the
 various sub-components of ciao in their respective
-subdirectories.  A comprehensive [ciao cluster setup
-document](https://clearlinux.org/documentation/ciao-cluster-setup.html)
-is also available.
+subdirectories.
 
 If you would like to contribute to ciao, check our [Contributing
 guide](https://github.com/01org/ciao/blob/master/CONTRIBUTING.md).
-The [wiki](https://github.com/01org/ciao/wiki/Single-Machine-Development-Environment)
-page ilustrates how to easily setup a development environment without
+There's a [wiki page](https://github.com/01org/ciao/blob/master/DeveloperQuickStart.md)
+that illustrates how to easily setup a development environment without
 needing a cluster. We also recommend taking a look at the ['janitorial'
 bugs](https://github.com/01org/ciao/issues?q=is%3Aopen+is%3Aissue+label%3AJanitorial)
 in our list of open issues as these bugs can be solved without an


### PR DESCRIPTION
The ciao README.md contains a link to the old very outdated cluster installation
instructions.  To make matters worse, the link doesn't even exist any more.
This commit simply removes the reference to the broken link.  We can add a new
link once we have a document describing how to set up a cluster using ciao-deploy.

I've also modified the SingleVM link so that it points directly to the main
SingleVM page.

Fixes #1335

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>