### PR TITLE
deviceinfo: Return -1 when failing to open /proc/meminfo

### DIFF
--- a/deviceinfo/deviceinfo.go
+++ b/deviceinfo/deviceinfo.go
@@ -100,7 +100,7 @@ func GetMemoryInfo() (total, available int) {
 
 	file, err := os.Open("/proc/meminfo")
 	if err != nil {
-		return
+		return -1, -1
 	}
 
 	total, available = getMemoryInfo(file)


### PR DESCRIPTION
GetMemoryInfo needs to return -1, -1 on error. At the moment, failing to
open /proc/meminfo would return the zero values for total and available.

Signed-off-by: Damien Lespiau <damien.lespiau@intel.com>