### PR TITLE
Ensure help can be printed at any time

### DIFF
--- a/testutil/ciao-down/ciao_down.go
+++ b/testutil/ciao-down/ciao_down.go
@@ -231,11 +231,6 @@ func prepare(ctx context.Context, errCh chan error) {
 		errCh <- err
 	}()
 
-	if !hostSupportsNestedKVM() {
-		err = fmt.Errorf("nested KVM is not enabled.  Please enable and try again")
-		return
-	}
-
 	ws, err := prepareEnv(ctx)
 	if err != nil {
 		return
@@ -243,6 +238,11 @@ func prepare(ctx context.Context, errCh chan error) {
 
 	wkld, debug, err := prepareFlags(ws)
 	if err != nil {
+		return
+	}
+
+	if !hostSupportsNestedKVM() {
+		err = fmt.Errorf("nested KVM is not enabled.  Please enable and try again")
 		return
 	}
 
@@ -311,11 +311,6 @@ func prepare(ctx context.Context, errCh chan error) {
 }
 
 func start(ctx context.Context, errCh chan error) {
-	if !hostSupportsNestedKVM() {
-		errCh <- fmt.Errorf("nested KVM is not enabled.  Please enable and try again")
-		return
-	}
-
 	ws, err := prepareEnv(ctx)
 	if err != nil {
 		errCh <- err
@@ -340,6 +335,11 @@ func start(ctx context.Context, errCh chan error) {
 	err = startFlags(in)
 	if err != nil {
 		errCh <- err
+		return
+	}
+
+	if !hostSupportsNestedKVM() {
+		errCh <- fmt.Errorf("nested KVM is not enabled.  Please enable and try again")
 		return
 	}
 

--- a/testutil/ciao-down/ciao_down.go
+++ b/testutil/ciao-down/ciao_down.go
@@ -236,8 +236,6 @@ func prepare(ctx context.Context, errCh chan error) {
 		return
 	}
 
-	fmt.Println("Checking environment")
-
 	ws, err := prepareEnv(ctx)
 	if err != nil {
 		return


### PR DESCRIPTION
We want to able to access the help at any point, so defer the nested VM check until after the flag parsing.
    
Today, ciao-down can print the nested VM error and exit before it has the change to print the help.
