### PR TITLE
SingleVM: Setup the NAT rules dynamically within ciao-down

### DIFF
--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -4,6 +4,7 @@
 
 ciao_gobin="$GOPATH"/bin
 ciao_host=$(hostname)
+ext_int=$(ip -o route get 8.8.8.8 | cut -d ' ' -f 5)
 sudo killall ciao-scheduler
 sudo killall ciao-controller
 sudo killall ciao-launcher
@@ -12,8 +13,8 @@ sudo "$ciao_gobin"/ciao-launcher --alsologtostderr -v 3 --hard-reset
 sudo iptables -D FORWARD -i ciao_br -j ACCEPT
 sudo iptables -D FORWARD -i ciaovlan -j ACCEPT
 if [ "$ciao_host" == "singlevm" ]; then
-	sudo iptables -D FORWARD -i ens2 -j ACCEPT
-	sudo iptables -t nat -D POSTROUTING -o ens2 -j MASQUERADE
+	sudo iptables -D FORWARD -i "$ext_int" -j ACCEPT
+	sudo iptables -t nat -D POSTROUTING -o "$ext_int" -j MASQUERADE
 fi
 sudo ip link del ciao_br
 sudo pkill -F /tmp/dnsmasq.ciaovlan.pid

--- a/testutil/singlevm/setup.sh
+++ b/testutil/singlevm/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 ciao_host=$(hostname)
 ciao_ip=$(hostname -i)
+ext_int=$(ip -o route get 8.8.8.8 | cut -d ' ' -f 5)
 ciao_bridge=ciao_br
 ciao_vlan_ip=198.51.100.1
 ciao_vlan_subnet=${ciao_vlan_ip}/24
@@ -262,9 +263,9 @@ if [ -x "$(command -v ip)" ]; then
     #open up the machine. On bare metal the user will need to explicitly
     #add this rule
     if [ "$ciao_host" == "singlevm" ]; then
-	sudo iptables -A FORWARD -p all -i ens2 -j ACCEPT
+	sudo iptables -A FORWARD -p all -i "$ext_int" -j ACCEPT
 	#NAT out all the traffic departing ciao-down
-	sudo iptables -t nat -A POSTROUTING -o ens2 -j MASQUERADE
+	sudo iptables -t nat -A POSTROUTING -o "$ext_int" -j MASQUERADE
     fi
 
 else


### PR DESCRIPTION
The single VM script had a hard coded ubuntu specific interface
naming convention. Now that ciao-down supports all types of
linux distributions, remove this assumption and discover the
primary outgoing interface name dynamically.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>