### PR TITLE
datastore: Don't allow duplicate IPs to be added

### DIFF
--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -2075,8 +2075,16 @@ func (ds *Datastore) AddExternalIPs(poolID string, IPs []string) error {
 		return types.ErrPoolNotFound
 	}
 
+	// sort to allow duplicate detection in IPs
+	sort.Strings(IPs)
+
 	// make sure valid and not duplicate
+	lastIP := ""
 	for _, newIP := range IPs {
+		if lastIP == newIP {
+			return types.ErrDuplicateIP
+		}
+
 		IP := net.ParseIP(newIP)
 		if IP == nil {
 			return types.ErrInvalidIP
@@ -2094,6 +2102,7 @@ func (ds *Datastore) AddExternalIPs(poolID string, IPs []string) error {
 		p.TotalIPs++
 		p.Free++
 		p.IPs = append(p.IPs, ExtIP)
+		lastIP = newIP
 	}
 
 	// update persistent store.

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -2245,6 +2245,13 @@ func TestAddExternalIPs(t *testing.T) {
 		t.Fatal("duplicate IP allowed")
 	}
 
+	// add duplicate in set
+	IPs = []string{"192.168.0.2", "192.168.0.2"}
+	err = ds.AddExternalIPs(orig.ID, IPs)
+	if err != types.ErrDuplicateIP {
+		t.Fatal("duplicate IP allowed")
+	}
+
 	// add to an invalid pool
 	IPs = []string{"192.168.0.2"}
 	err = ds.AddExternalIPs(uuid.Generate().String(), IPs)


### PR DESCRIPTION
Although adding IP addresses to the pool checks for duplicates in the IP
addresses already added it does not check for duplicates in the set to
be added.

This change checks that you can't add duplicates that are specified in
the same request.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>