### PR TITLE
ciao-down prepare

### DIFF
--- a/DeveloperQuickStart.md
+++ b/DeveloperQuickStart.md
@@ -123,14 +123,14 @@ Once Go is installed you simply need to type
 
 ```
 go get github.com/01org/ciao/testutil/ciao-down
-$GOPATH/bin/ciao-down prepare
+$GOPATH/bin/ciao-down create ciao
 ```
 
 ciao-down will install some needed dependencies on your local PC such
 as qemu and xorriso. It will then download an Ubuntu Cloud Image and
 create a VM based on this image. It will boot the VM and install in that
 VM everything you need to run ciao Single VM, including docker, ceph,
-go, gcc, etc. When ciao-down prepare has finished you can connect to the
+go, gcc, etc. When ciao-down create has finished you can connect to the
 newly created VM with
 
 ```
@@ -144,7 +144,7 @@ the ciao code on your host machine and test in Single VM.
 ## Proxies
 
 One of the nice things about using ciao-down is that it is proxy aware.
-When you run ciao-down prepare, ciao-down looks in its environment for
+When you run ciao-down create, ciao-down looks in its environment for
 proxy variables such as http_proxy, https_proxy and no_proxy.  If it
 finds them it ensures that these proxies are correctly configured for
 all the software that it installs and uses inside the VM, e.g., apt, docker,
@@ -155,17 +155,17 @@ before running ciao-down.
 ## Ciao-webui
 
 Ciao has a webui called ciao-webui (https://github.com/01org/ciao-webui).
-When ciao-down prepare is run, ciao-down downloads the source code for
+When ciao-down create is run, ciao-down downloads the source code for
 the ciao-webui and all the development tools needed to build it.  By
 default, ciao-down stores the code for the web-ui in ~/ciao-webui.
 
 If you wish to actively work on the sources of ciao-webui you can ask
-ciao-down prepare to mount a host directory containing the webui sources
-into the VM.  This is done using the -ui-path option of ciao-down prepare.
+ciao-down create to mount a host directory containing the webui sources
+into the VM.  This is done using the -ui-path option of ciao-down create.
 For example
 
 ```
-ciao-down prepare --ui-path $HOME/src/ciao-webui
+ciao-down create --ui-path $HOME/src/ciao-webui ciao
 ```
 
 would mount the $HOME/src/ciao-webui directory inside the VM at the

--- a/testutil/ciao-down/README.md
+++ b/testutil/ciao-down/README.md
@@ -12,7 +12,7 @@ Then simply type
 
 ```
 go get github.com/01org/ciao/testutil/ciao-down
-$GOPATH/bin/ciao-down prepare --vmtype=xenial
+$GOPATH/bin/ciao-down create xenial
 ```
 
 to create a new Ubuntu 16.04 VM.  ciao-down will install some needed
@@ -65,9 +65,9 @@ User created workloads are stored in ~/.ciao-down/workloads.  ciao-down always c
 with the same name, ciao-down will use the workload in ~/.ciao-down/workloads.
 
 You can tell ciao-down which workload to use when creating the VM with the
-prepare command.  This is done via the --vmtype option.  You specify the file name
+create command.  This is done via the --vmtype option.  You specify the file name
 of the workload without the .yaml extension.  The workload must be present in either
-of the two directories mentioned above.  For example, the prepare command in the
+of the two directories mentioned above.  For example, the create command in the
 introduction section used the option --vmtype xenial.  This caused ciao-down to
 load the workload definition in
 $GOPATH/src/github.com/01org/ciao/testutil/ciao-down/workloads/xenial.yaml.
@@ -300,7 +300,7 @@ Unpacking Go : [FAIL]
 
 if it fails.
 
-Reporting a failure back to ciao-down does not cause the prepare command to exit.  The
+Reporting a failure back to ciao-down does not cause the create command to exit.  The
 failure is presented to the user and the setup of the VM continues.
 
 #### Finished
@@ -330,23 +330,23 @@ mounts:
 ```
 
 The above command will arrange for all mounts specified in the instance data document or on
-the prepare command line to be mounted to the same location that they are mounted on the
+the create command line to be mounted to the same location that they are mounted on the
 host.
 
 Mounts added later via the start command will need to be mounted manually.
 
 ## Commands
 
-### prepare
+### create
 
-ciao-down prepare creates and configures a new ciao-down VM.  Currently,
+ciao-down create creates and configures a new ciao-down VM.  Currently,
 only one VM can be configured at any one time.  All the files associated
 with the VM are stored in ~/.ciao-down.
 
-An example of ciao-down prepare is given below:
+An example of ciao-down create is given below:
 
 ```
-$ ./ciao-down prepare
+$ ./ciao-down create xenial
 Booting VM with 7 GB RAM and 4 cpus
 Booting VM : [OK]
 Downloading Go : [OK]
@@ -385,7 +385,7 @@ host, ciao-down will assign 4GB of RAM and 4 VCPUs to the guest VM.  You
 can control this behaviour by using the --mem and --cpu options.  For
 example,
 
-ciao-down prepare --cpus 2 -mem 2
+ciao-down create --cpus 2 -mem 2 ciao
 
 Creates and boots a VM with 2 VCPUs and 2 GB of RAM.
 
@@ -398,17 +398,10 @@ option takes a path to the location on your host machine where the UI code is
 stored.  This path gets mounted to the same location inside the VM, allowing you to
 modify the sources on your host and compile inside the VM.  For example,
 
-ciao-down prepare --mount hostui,mapped,$HOME/src/ciao-webui
+ciao-down create --mount hostui,mapped,$HOME/src/ciao-webui ciao
 
 will create a new ciao-down VM in which the $HOME/src/ciao-webui folder on
 your host will be mounted at $HOME/src/ciao-webui.
-
-ciao-down by default creates a VM suitable for ciao development. It also supports
-setting up development environments for other projects, via the vmtype option
-
-ciao-down prepare -vmtype clearcontainers
-
-will create a new ciao-down VM for development of clearcontainers.
 
 The --package-upgrade option can be used to provide a hint to workloads
 indicating whether packages contained within the base image should be updated or not
@@ -429,7 +422,7 @@ the default settings on the command line.
 
 For example,
 
-./ciao-down prepare --mount docs,passthrough,$HOME/Documents --port 10000-80
+./ciao-down create --mount docs,passthrough,$HOME/Documents --port 10000-80 xenial
 
 shares the host directory, $HOME/Documents, with the ciao-down VM using the 9p
 passthrough security model.  The directory can be mounted inside the VM using
@@ -442,7 +435,7 @@ instance data document, can be overridden by specifying
 an existing tag with new options, and default ports can be overridden by
 mapping a new host port to an existing guest port.  For example,
 
-./ciao-down prepare --mount hostgo,none,$HOME/go -port 10023-22
+./ciao-down create --mount hostgo,none,$HOME/go -port 10023-22 xenial
 
 changes the security model of the mount with the hostgo tag and makes the instance
 available via ssh on 127.0.0.1:10023.
@@ -469,7 +462,7 @@ ciao-down stop is used to power down the ciao-down VM cleanly.
 
 ### start
 
-ciao-down start boots a previously prepared but not running ciao-down VM.
+ciao-down start boots a previously created but not running ciao-down VM.
 The start command also supports the --mem and --cpu options.  So it's
 possible to change the resources assigned to the guest VM by stopping it
 and restarting it, specifying --mem and --cpu.  It's also possible to
@@ -477,11 +470,11 @@ specify additional port mappings or mounts via the start command.  See
 the section on port mappings below.
 
 Any parameters you pass to the start command override the parameters
-you originally passed to prepare.  These settings are also persisted.
+you originally passed to create.  These settings are also persisted.
 For example, if you were to run
 
 ```
-./ciao-down prepare --mem=2
+./ciao-down create --mem=2 xenial
 ./ciao-down stop
 ./ciao-down start --mem=1
 ./ciao-down stop

--- a/testutil/ciao-down/ciao_down.go
+++ b/testutil/ciao-down/ciao_down.go
@@ -46,8 +46,8 @@ const (
 func init() {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage of %s:\n\n", os.Args[0])
-		fmt.Fprintf(os.Stderr, "%s [prepare|start|stop|quit|status|connect|delete]\n\n", os.Args[0])
-		fmt.Fprintln(os.Stderr, "- prepare : creates a new VM for ciao or clear containers")
+		fmt.Fprintf(os.Stderr, "%s [create|start|stop|quit|status|connect|delete]\n\n", os.Args[0])
+		fmt.Fprintln(os.Stderr, "- create : creates a new VM")
 		fmt.Fprintln(os.Stderr, "- start : boots a stopped VM")
 		fmt.Fprintln(os.Stderr, "- stop : cleanly powers down a running VM")
 		fmt.Fprintln(os.Stderr, "- quit : quits a running VM")
@@ -144,7 +144,7 @@ func checkDirectory(dir string) error {
 	return nil
 }
 
-func prepareFlags(ws *workspace) (*workload, bool, error) {
+func createFlags(ws *workspace) (*workload, bool, error) {
 	var debug bool
 	var workloadName string
 	var m mounts
@@ -152,7 +152,7 @@ func prepareFlags(ws *workspace) (*workload, bool, error) {
 	var memGiB, CPUs int
 	var update packageUpgrade
 
-	fs := flag.NewFlagSet("prepare", flag.ExitOnError)
+	fs := flag.NewFlagSet("create", flag.ExitOnError)
 	vmFlags(fs, &memGiB, &CPUs, &m, &p)
 	fs.BoolVar(&debug, "debug", false, "Enables debug mode")
 	fs.StringVar(&workloadName, "vmtype", CIAO, "Type of VM to launch.")
@@ -224,7 +224,7 @@ func startFlags(in *instance) error {
 	return nil
 }
 
-func prepare(ctx context.Context, errCh chan error) {
+func create(ctx context.Context, errCh chan error) {
 	var err error
 
 	defer func() {
@@ -236,7 +236,7 @@ func prepare(ctx context.Context, errCh chan error) {
 		return
 	}
 
-	wkld, debug, err := prepareFlags(ws)
+	wkld, debug, err := createFlags(ws)
 	if err != nil {
 		return
 	}
@@ -500,8 +500,8 @@ func runCommand(signalCh <-chan os.Signal) error {
 	errCh := make(chan error)
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	switch os.Args[1] {
-	case "prepare":
-		go prepare(ctx, errCh)
+	case "create":
+		go create(ctx, errCh)
 	case "start":
 		go start(ctx, errCh)
 	case "stop":
@@ -529,7 +529,7 @@ func runCommand(signalCh <-chan os.Signal) error {
 func main() {
 	flag.Parse()
 	if len(os.Args) < 2 ||
-		!(os.Args[1] == "prepare" || os.Args[1] == "start" || os.Args[1] == "stop" ||
+		!(os.Args[1] == "create" || os.Args[1] == "start" || os.Args[1] == "stop" ||
 			os.Args[1] == "quit" || os.Args[1] == "status" ||
 			os.Args[1] == "connect" || os.Args[1] == "delete") {
 		flag.Usage()

--- a/testutil/ciao-down/ciao_down.go
+++ b/testutil/ciao-down/ciao_down.go
@@ -146,7 +146,7 @@ func checkDirectory(dir string) error {
 
 func prepareFlags(ws *workspace) (*workload, bool, error) {
 	var debug bool
-	var vmType string
+	var workloadName string
 	var m mounts
 	var p ports
 	var memGiB, CPUs int
@@ -155,7 +155,7 @@ func prepareFlags(ws *workspace) (*workload, bool, error) {
 	fs := flag.NewFlagSet("prepare", flag.ExitOnError)
 	vmFlags(fs, &memGiB, &CPUs, &m, &p)
 	fs.BoolVar(&debug, "debug", false, "Enables debug mode")
-	fs.StringVar(&vmType, "vmtype", CIAO, "Type of VM to launch.")
+	fs.StringVar(&workloadName, "vmtype", CIAO, "Type of VM to launch.")
 	fs.Var(&update, "package-upgrade",
 		"Hint to enable or disable update of VM packages. Should be true or false")
 
@@ -169,7 +169,7 @@ func prepareFlags(ws *workspace) (*workload, bool, error) {
 		}
 	}
 
-	wkl, err := createWorkload(ws, vmType)
+	wkl, err := createWorkload(ws, workloadName)
 	if err != nil {
 		return nil, false, err
 	}

--- a/testutil/ciao-down/vm.go
+++ b/testutil/ciao-down/vm.go
@@ -143,7 +143,7 @@ func sshReady(ctx context.Context, sshPort int) bool {
 	return retval
 }
 
-func statusVM(ctx context.Context, instanceDir, keyPath, vmType string, sshPort int) {
+func statusVM(ctx context.Context, instanceDir, keyPath, workloadName string, sshPort int) {
 	status := "ciao down"
 	ssh := "N/A"
 	if sshReady(ctx, sshPort) {
@@ -153,7 +153,7 @@ func statusVM(ctx context.Context, instanceDir, keyPath, vmType string, sshPort 
 
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 0, 8, 0, '\t', 0)
-	fmt.Fprintf(w, "Workload\t:\t%s\n", vmType)
+	fmt.Fprintf(w, "Workload\t:\t%s\n", workloadName)
 	fmt.Fprintf(w, "Status\t:\t%s\n", status)
 	fmt.Fprintf(w, "SSH\t:\t%s\n", ssh)
 	w.Flush()

--- a/testutil/ciao-down/workload.go
+++ b/testutil/ciao-down/workload.go
@@ -75,9 +75,9 @@ func (wkld *workload) save(ws *workspace) error {
 	return nil
 }
 
-func loadWorkloadData(ws *workspace, vmType string) ([]byte, error) {
+func loadWorkloadData(ws *workspace, workloadName string) ([]byte, error) {
 	localPath := filepath.Join(ws.Home, ".ciao-down", "workloads",
-		fmt.Sprintf("%s.yaml", vmType))
+		fmt.Sprintf("%s.yaml", workloadName))
 	wkld, err := ioutil.ReadFile(localPath)
 	if err == nil {
 		return wkld, nil
@@ -87,7 +87,7 @@ func loadWorkloadData(ws *workspace, vmType string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Unable to locate ciao-down workload directory: %v", err)
 	}
-	workloadPath := filepath.Join(p.Dir, "workloads", fmt.Sprintf("%s.yaml", vmType))
+	workloadPath := filepath.Join(p.Dir, "workloads", fmt.Sprintf("%s.yaml", workloadName))
 	wkld, err = ioutil.ReadFile(workloadPath)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to load workload %s", workloadPath)
@@ -113,8 +113,8 @@ func unmarshalWorkload(ws *workspace, wkld *workload, insSpec, insData,
 	return nil
 }
 
-func createWorkload(ws *workspace, vmType string) (*workload, error) {
-	data, err := loadWorkloadData(ws, vmType)
+func createWorkload(ws *workspace, workloadName string) (*workload, error) {
+	data, err := loadWorkloadData(ws, workloadName)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func createWorkload(ws *workspace, vmType string) (*workload, error) {
 		return nil, err
 	}
 	if wkld.insSpec.WorkloadName == "" {
-		wkld.insSpec.WorkloadName = vmType
+		wkld.insSpec.WorkloadName = workloadName
 	}
 	return &wkld, nil
 }


### PR DESCRIPTION
As discussed with Mark and Rob, sadly offline, `ciao-down create` would be a nicer name. Also we want to detach ciao-down from ciao a bit and have explicit workload names instead of defaulting to the ciao workload.