### PR TITLE
Create GetTenantInstance

### DIFF
--- a/ciao-controller/api.go
+++ b/ciao-controller/api.go
@@ -347,15 +347,11 @@ func serversAction(c *controller, w http.ResponseWriter, r *http.Request) (APIRe
 	if len(servers.ServerIDs) > 0 {
 		for _, instanceID := range servers.ServerIDs {
 			// make sure the instance belongs to the tenant
-			instance, err := c.ds.GetInstance(instanceID)
-
+			_, err := c.ds.GetTenantInstance(tenant, instanceID)
 			if err != nil {
 				return errorResponse(err), err
 			}
 
-			if instance.TenantID != tenant {
-				return errorResponse(err), err
-			}
 			actionFunc(instanceID)
 		}
 	} else {

--- a/ciao-controller/api/api.go
+++ b/ciao-controller/api/api.go
@@ -396,6 +396,7 @@ func listMappedIPs(c *Context, w http.ResponseWriter, r *http.Request) (Response
 }
 
 func mapExternalIP(c *Context, w http.ResponseWriter, r *http.Request) (Response, error) {
+	vars := mux.Vars(r)
 	var req types.MapIPRequest
 
 	body, err := ioutil.ReadAll(r.Body)
@@ -408,7 +409,9 @@ func mapExternalIP(c *Context, w http.ResponseWriter, r *http.Request) (Response
 		return errorResponse(err), err
 	}
 
-	err = c.MapAddress(req.PoolName, req.InstanceID)
+	tenantID := vars["tenant"]
+
+	err = c.MapAddress(tenantID, req.PoolName, req.InstanceID)
 	if err != nil {
 		return errorResponse(err), err
 	}
@@ -578,7 +581,7 @@ type Service interface {
 	AddAddress(poolID string, subnet *string, IPs []string) error
 	RemoveAddress(poolID string, subnetID *string, IPID *string) error
 	ListMappedAddresses(tenantID *string) []types.MappedIP
-	MapAddress(poolName *string, instanceID string) error
+	MapAddress(tenantID string, poolName *string, instanceID string) error
 	UnMapAddress(ID string) error
 	CreateWorkload(req types.Workload) (types.Workload, error)
 	DeleteWorkload(tenantID string, workloadID string) error

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -268,7 +268,7 @@ func (ts testCiaoService) ListMappedAddresses(tenant *string) []types.MappedIP {
 	return []types.MappedIP{m}
 }
 
-func (ts testCiaoService) MapAddress(name *string, instanceID string) error {
+func (ts testCiaoService) MapAddress(tenantID string, name *string, instanceID string) error {
 	return nil
 }
 

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -1850,7 +1850,7 @@ func TestMapAddress(t *testing.T) {
 		}
 	}
 
-	err = ctl.MapAddress(&poolName, instances[0].ID)
+	err = ctl.MapAddress(instances[0].TenantID, &poolName, instances[0].ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1885,7 +1885,7 @@ func TestMapAddressNoPool(t *testing.T) {
 
 	testAddPool(t, poolName, nil, ips)
 
-	err := ctl.MapAddress(nil, instances[0].ID)
+	err := ctl.MapAddress(instances[0].TenantID, nil, instances[0].ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/external_ip.go
+++ b/ciao-controller/external_ip.go
@@ -180,10 +180,16 @@ func (c *controller) ListMappedAddresses(tenant *string) []types.MappedIP {
 	return IPs
 }
 
-func (c *controller) MapAddress(poolName *string, instanceID string) (err error) {
+func (c *controller) MapAddress(tenantID string, poolName *string, instanceID string) (err error) {
 	var m types.MappedIP
+	var i *types.Instance
 
-	i, err := c.ds.GetInstance(instanceID)
+	if tenantID == "" {
+		// we allow the admin to map anyone's instance
+		i, err = c.ds.GetInstance(instanceID)
+	} else {
+		i, err = c.ds.GetTenantInstance(tenantID, instanceID)
+	}
 	if err != nil {
 		return err
 	}

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -814,6 +814,22 @@ func (ds *Datastore) GetInstance(id string) (*types.Instance, error) {
 	return value, nil
 }
 
+// GetTenantInstance retrieves a tenant instance out of the datastore.
+func (ds *Datastore) GetTenantInstance(tenantID string, instanceID string) (*types.Instance, error) {
+	// always get from cache
+	ds.instancesLock.RLock()
+
+	value, ok := ds.instances[instanceID]
+
+	ds.instancesLock.RUnlock()
+
+	if !ok || value.TenantID != tenantID {
+		return nil, types.ErrInstanceNotFound
+	}
+
+	return value, nil
+}
+
 // GetAllInstancesFromTenant will retrieve all instances belonging to a specific tenant
 func (ds *Datastore) GetAllInstancesFromTenant(tenantID string) ([]*types.Instance, error) {
 	var instances []*types.Instance

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -483,6 +483,29 @@ func TestGetInstance(t *testing.T) {
 	}
 }
 
+func TestGetTenantInstance(t *testing.T) {
+	instances, stat := addTestInstanceStats(t)
+	instance, err := ds.GetTenantInstance(instances[0].TenantID, instances[0].ID)
+	if err != nil && err != sql.ErrNoRows {
+		t.Fatal(err)
+	}
+
+	for instance == nil {
+		instance, err = ds.GetTenantInstance(instances[0].TenantID, instances[0].ID)
+		if err != nil && err != sql.ErrNoRows {
+			t.Fatal(err)
+		}
+	}
+
+	if instance.NodeID != stat.NodeUUID {
+		t.Fatal("retrieved incorrect NodeID")
+	}
+
+	if instance.State != payloads.ComputeStatusRunning {
+		t.Fatal("retrieved incorrect state")
+	}
+}
+
 func TestHandleStats(t *testing.T) {
 	tenant, err := addTestTenant()
 	if err != nil {

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -455,13 +455,9 @@ func (c *controller) ListServersDetail(tenant string) ([]compute.ServerDetails, 
 func (c *controller) ShowServerDetails(tenant string, server string) (compute.Server, error) {
 	var s compute.Server
 
-	instance, err := c.ds.GetInstance(server)
+	instance, err := c.ds.GetTenantInstance(tenant, server)
 	if err != nil {
 		return s, err
-	}
-
-	if instance.TenantID != tenant {
-		return s, compute.ErrServerOwner
 	}
 
 	s.Server, err = instanceToServer(c, instance)
@@ -474,13 +470,9 @@ func (c *controller) ShowServerDetails(tenant string, server string) (compute.Se
 
 func (c *controller) DeleteServer(tenant string, server string) error {
 	/* First check that the instance belongs to this tenant */
-	i, err := c.ds.GetInstance(server)
+	_, err := c.ds.GetTenantInstance(tenant, server)
 	if err != nil {
 		return compute.ErrServerNotFound
-	}
-
-	if i.TenantID != tenant {
-		return compute.ErrServerOwner
 	}
 
 	err = c.deleteInstance(server)
@@ -492,13 +484,9 @@ func (c *controller) DeleteServer(tenant string, server string) error {
 }
 
 func (c *controller) StartServer(tenant string, ID string) error {
-	i, err := c.ds.GetInstance(ID)
+	_, err := c.ds.GetTenantInstance(tenant, ID)
 	if err != nil {
 		return err
-	}
-
-	if i.TenantID != tenant {
-		return compute.ErrServerOwner
 	}
 
 	err = c.restartInstance(ID)
@@ -510,13 +498,9 @@ func (c *controller) StartServer(tenant string, ID string) error {
 }
 
 func (c *controller) StopServer(tenant string, ID string) error {
-	i, err := c.ds.GetInstance(ID)
+	_, err := c.ds.GetTenantInstance(tenant, ID)
 	if err != nil {
 		return err
-	}
-
-	if i.TenantID != tenant {
-		return compute.ErrServerOwner
 	}
 
 	err = c.stopInstance(ID)

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -187,13 +187,9 @@ func (c *controller) AttachVolume(tenant string, volume string, instance string,
 	}
 
 	// check that the instance is owned by the tenant.
-	i, err := c.ds.GetInstance(instance)
+	i, err := c.ds.GetTenantInstance(tenant, instance)
 	if err != nil {
 		return block.ErrInstanceNotFound
-	}
-
-	if i.TenantID != tenant {
-		return block.ErrInstanceOwner
 	}
 
 	// update volume state to attaching
@@ -293,7 +289,7 @@ func (c *controller) DetachVolume(tenant string, volume string, attachment strin
 	// detach everything for this volume
 	for _, a := range attachments {
 		// get instance info
-		i, err := c.ds.GetInstance(a.InstanceID)
+		i, err := c.ds.GetTenantInstance(tenant, a.InstanceID)
 		if err != nil {
 			glog.Error(block.ErrInstanceNotFound)
 			// keep going


### PR DESCRIPTION
Make sure that any instance that a tenant requests to assign an external IP to is actually owned by the tenant by creating a new method "GetTenantInstance(tenantID, instanceID)". This method will only return the instance if it is owned by the tenant. In the case of an admin user, mapping external IPs to any valid instance will still be allowed, so the original GetInstance method will still be used.

Finally, use the new GetTenantInstance method to retrieve instances for verification of ownership in our apis.
