### PR TITLE
ciao-down: Make workload and state files be only 2 YAML documents 

### DIFF
--- a/testutil/ciao-down/ciao_down.go
+++ b/testutil/ciao-down/ciao_down.go
@@ -207,7 +207,7 @@ func createFlags(ws *workspace) (*workload, bool, error) {
 	return wkl, debug, nil
 }
 
-func startFlags(in *instance) error {
+func startFlags(in *VMSpec) error {
 	var m mounts
 	var p ports
 

--- a/testutil/ciao-down/ciao_down.go
+++ b/testutil/ciao-down/ciao_down.go
@@ -196,7 +196,7 @@ func createFlags(ws *workspace) (*workload, bool, error) {
 	in.mergePorts(p)
 
 	ws.Mounts = in.Mounts
-	ws.Hostname = wkl.insSpec.Hostname
+	ws.Hostname = wkl.spec.Hostname
 	if ws.NoProxy != "" {
 		ws.NoProxy = fmt.Sprintf("%s,%s", ws.Hostname, ws.NoProxy)
 	} else if ws.HTTPProxy != "" || ws.HTTPSProxy != "" {
@@ -251,7 +251,7 @@ func create(ctx context.Context, errCh chan error) {
 		return
 	}
 
-	if wkld.insSpec.NeedsNestedVM && !hostSupportsNestedKVM() {
+	if wkld.spec.NeedsNestedVM && !hostSupportsNestedKVM() {
 		err = fmt.Errorf("nested KVM is not enabled.  Please enable and try again")
 		return
 	}
@@ -289,8 +289,8 @@ func create(ctx context.Context, errCh chan error) {
 		return
 	}
 
-	fmt.Printf("Downloading %s\n", wkld.insSpec.BaseImageName)
-	qcowPath, err := downloadFile(ctx, wkld.insSpec.BaseImageURL, ws.ciaoDir, downloadProgress)
+	fmt.Printf("Downloading %s\n", wkld.spec.BaseImageName)
+	qcowPath, err := downloadFile(ctx, wkld.spec.BaseImageURL, ws.ciaoDir, downloadProgress)
 	if err != nil {
 		return
 	}
@@ -348,7 +348,7 @@ func start(ctx context.Context, errCh chan error) {
 		return
 	}
 
-	if wkld.insSpec.NeedsNestedVM && !hostSupportsNestedKVM() {
+	if wkld.spec.NeedsNestedVM && !hostSupportsNestedKVM() {
 		errCh <- fmt.Errorf("nested KVM is not enabled.  Please enable and try again")
 		return
 	}
@@ -426,7 +426,7 @@ func status(ctx context.Context, errCh chan error) {
 		return
 	}
 
-	statusVM(ctx, ws.instanceDir, ws.keyPath, wkld.insSpec.WorkloadName,
+	statusVM(ctx, ws.instanceDir, ws.keyPath, wkld.spec.WorkloadName,
 		sshPort)
 	errCh <- err
 }

--- a/testutil/ciao-down/ciao_down.go
+++ b/testutil/ciao-down/ciao_down.go
@@ -184,7 +184,7 @@ func createFlags(ws *workspace) (*workload, bool, error) {
 		return nil, false, err
 	}
 
-	in := &wkl.insData
+	in := &wkl.spec.VM
 	if memGiB != 0 {
 		in.MemGiB = memGiB
 	}
@@ -256,7 +256,7 @@ func create(ctx context.Context, errCh chan error) {
 		return
 	}
 
-	in := &wkld.insData
+	in := &wkld.spec.VM
 	_, err = os.Stat(ws.instanceDir)
 	if err == nil {
 		err = fmt.Errorf("instance already exists")
@@ -332,7 +332,7 @@ func start(ctx context.Context, errCh chan error) {
 		errCh <- err
 		return
 	}
-	in := &wkld.insData
+	in := &wkld.spec.VM
 
 	memGiB, CPUs := getMemAndCpus()
 	if in.MemGiB == 0 {
@@ -418,7 +418,7 @@ func status(ctx context.Context, errCh chan error) {
 		errCh <- fmt.Errorf("Unable to load instance state: %v", err)
 		return
 	}
-	in := &wkld.insData
+	in := &wkld.spec.VM
 
 	sshPort, err := in.sshPort()
 	if err != nil {
@@ -443,7 +443,7 @@ func connect(ctx context.Context, errCh chan error) {
 		errCh <- fmt.Errorf("Unable to load instance state: %v", err)
 		return
 	}
-	in := &wkld.insData
+	in := &wkld.spec.VM
 
 	path, err := exec.LookPath("ssh")
 	if err != nil {

--- a/testutil/ciao-down/instance.go
+++ b/testutil/ciao-down/instance.go
@@ -63,7 +63,7 @@ type instance struct {
 	Mounts       []mount       `yaml:"mounts"`
 }
 
-type instanceSpec struct {
+type workloadSpec struct {
 	BaseImageURL  string `yaml:"base_image_url"`
 	BaseImageName string `yaml:"base_image_name"`
 	Hostname      string `yaml:"hostname"`
@@ -227,7 +227,7 @@ func (in *instance) sshPort() (int, error) {
 	return 0, fmt.Errorf("No SSH port configured")
 }
 
-func (ins *instanceSpec) unmarshal(data []byte) error {
+func (ins *workloadSpec) unmarshal(data []byte) error {
 	err := yaml.Unmarshal(data, ins)
 	if err != nil {
 		return fmt.Errorf("Unable to unmarshal instance specification : %v", err)
@@ -258,7 +258,7 @@ func (ins *instanceSpec) unmarshal(data []byte) error {
 	return nil
 }
 
-func (ins *instanceSpec) unmarshalWithTemplate(ws *workspace, data string) error {
+func (ins *workloadSpec) unmarshalWithTemplate(ws *workspace, data string) error {
 	tmpl, err := template.New("instance-spec").Parse(string(data))
 	if err != nil {
 		return fmt.Errorf("Unable to parse instance data template: %v", err)

--- a/testutil/ciao-down/instance.go
+++ b/testutil/ciao-down/instance.go
@@ -70,6 +70,7 @@ type workloadSpec struct {
 	Hostname      string `yaml:"hostname"`
 	WorkloadName  string `yaml:"workload"`
 	NeedsNestedVM bool   `yaml:"needs_nested_vm"`
+	VM            VMSpec `yaml:"vm"`
 }
 
 // This function creates a default instanceData object for legacy ciao-down

--- a/testutil/ciao-down/mock_test.go
+++ b/testutil/ciao-down/mock_test.go
@@ -1,0 +1,82 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"io/ioutil"
+	"path"
+	"testing"
+
+	"os"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const xenialWorkloadSpec = `
+base_image_url: ` + guestDownloadURL + `
+base_image_name: ` + guestImageFriendlyName + `
+`
+
+const sampleVMSpec = `
+mem_gib: 3
+cpus: 2
+ports:
+- host: 10022
+  guest: 22
+mounts: []
+`
+
+var mockVMSpec = instance{
+	MemGiB:       3,
+	CPUs:         2,
+	PortMappings: []portMapping{{Host: 10022, Guest: 22}},
+	Mounts:       []mount{},
+}
+
+const sampleCloudInit = `
+`
+
+const sampleWorkload = "---\n" + xenialWorkloadSpec + "...\n---\n" + sampleVMSpec + "...\n---\n" + sampleCloudInit + "...\n"
+
+func createMockWorkSpaceWithWorkload(t *testing.T, workload string) *workspace {
+	ciaoDir, err := ioutil.TempDir("", "ciao-down-tests-")
+	assert.Nil(t, err)
+
+	instanceDir := path.Join(ciaoDir, "foo")
+	err = os.Mkdir(instanceDir, 0750)
+	assert.Nil(t, err)
+
+	ws := &workspace{
+		ciaoDir:     ciaoDir,
+		instanceDir: instanceDir,
+	}
+
+	workloadFile := path.Join(ws.instanceDir, "state.yaml")
+	err = ioutil.WriteFile(workloadFile, []byte(workload), 0640)
+	assert.Nil(t, err)
+
+	return ws
+}
+
+func createMockWorkspace(t *testing.T) *workspace {
+	return createMockWorkSpaceWithWorkload(t, sampleWorkload)
+}
+
+func cleanupMockWorkspace(t *testing.T, ws *workspace) {
+	err := os.RemoveAll(ws.ciaoDir)
+	assert.Nil(t, err)
+}

--- a/testutil/ciao-down/mock_test.go
+++ b/testutil/ciao-down/mock_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const xenialWorkloadSpec = `
+const xenialWorkloadSpecNoVM = `
 base_image_url: ` + guestDownloadURL + `
 base_image_name: ` + guestImageFriendlyName + `
 `
@@ -40,6 +40,18 @@ ports:
 mounts: []
 `
 
+const xenialWorkloadSpec = `
+base_image_url: ` + guestDownloadURL + `
+base_image_name: ` + guestImageFriendlyName + `
+vm:
+  mem_gib: 3
+  cpus: 2
+  ports:
+  - host: 10022
+    guest: 22
+  mounts: []
+`
+
 var mockVMSpec = VMSpec{
 	MemGiB:       3,
 	CPUs:         2,
@@ -50,7 +62,8 @@ var mockVMSpec = VMSpec{
 const sampleCloudInit = `
 `
 
-const sampleWorkload = "---\n" + xenialWorkloadSpec + "...\n---\n" + sampleVMSpec + "...\n---\n" + sampleCloudInit + "...\n"
+const sampleWorkload3Docs = "---\n" + xenialWorkloadSpecNoVM + "...\n---\n" + sampleVMSpec + "...\n---\n" + sampleCloudInit + "...\n"
+const sampleWorkload = "---\n" + xenialWorkloadSpec + "...\n---\n" + sampleCloudInit + "...\n"
 
 func createMockWorkSpaceWithWorkload(t *testing.T, workload string) *workspace {
 	ciaoDir, err := ioutil.TempDir("", "ciao-down-tests-")

--- a/testutil/ciao-down/mock_test.go
+++ b/testutil/ciao-down/mock_test.go
@@ -40,7 +40,7 @@ ports:
 mounts: []
 `
 
-var mockVMSpec = instance{
+var mockVMSpec = VMSpec{
 	MemGiB:       3,
 	CPUs:         2,
 	PortMappings: []portMapping{{Host: 10022, Guest: 22}},

--- a/testutil/ciao-down/vm.go
+++ b/testutil/ciao-down/vm.go
@@ -39,7 +39,7 @@ const (
 	urlParam          = "url"
 )
 
-func bootVM(ctx context.Context, ws *workspace, in *instance) error {
+func bootVM(ctx context.Context, ws *workspace, in *VMSpec) error {
 	disconnectedCh := make(chan struct{})
 	socket := path.Join(ws.instanceDir, "socket")
 	qmp, _, err := qemu.QMPStart(ctx, socket, qemu.QMPConfig{}, disconnectedCh)

--- a/testutil/ciao-down/workload.go
+++ b/testutil/ciao-down/workload.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 type workload struct {
-	insSpec  instanceSpec
+	spec  workloadSpec
 	insData  instance
 	userData string
 }
@@ -47,7 +47,7 @@ func (wkld *workload) save(ws *workspace) error {
 	var buf bytes.Buffer
 
 	_, _ = buf.WriteString("---\n")
-	data, err := yaml.Marshal(wkld.insSpec)
+	data, err := yaml.Marshal(wkld.spec)
 	if err != nil {
 		return fmt.Errorf("Unable to marshal instance specification : %v", err)
 	}
@@ -96,9 +96,9 @@ func loadWorkloadData(ws *workspace, workloadName string) ([]byte, error) {
 	return wkld, nil
 }
 
-func unmarshalWorkload(ws *workspace, wkld *workload, insSpec, insData,
+func unmarshalWorkload(ws *workspace, wkld *workload, spec, insData,
 	userData string) error {
-	err := wkld.insSpec.unmarshalWithTemplate(ws, insSpec)
+	err := wkld.spec.unmarshalWithTemplate(ws, spec)
 	if err != nil {
 		return err
 	}
@@ -120,24 +120,24 @@ func createWorkload(ws *workspace, workloadName string) (*workload, error) {
 	}
 
 	var wkld workload
-	var insSpec, insData, userData string
+	var spec, insData, userData string
 	docs := splitYaml(data)
 	if len(docs) == 1 {
 		userData = string(docs[0])
 	} else if len(docs) >= 3 {
-		insSpec = string(docs[0])
+		spec = string(docs[0])
 		insData = string(docs[1])
 		userData = string(docs[2])
 	} else {
 		return nil, fmt.Errorf("Invalid workload")
 	}
 
-	err = unmarshalWorkload(ws, &wkld, insSpec, insData, userData)
+	err = unmarshalWorkload(ws, &wkld, spec, insData, userData)
 	if err != nil {
 		return nil, err
 	}
-	if wkld.insSpec.WorkloadName == "" {
-		wkld.insSpec.WorkloadName = workloadName
+	if wkld.spec.WorkloadName == "" {
+		wkld.spec.WorkloadName = workloadName
 	}
 	return &wkld, nil
 }

--- a/testutil/ciao-down/workload.go
+++ b/testutil/ciao-down/workload.go
@@ -38,8 +38,8 @@ func init() {
 }
 
 type workload struct {
-	spec  workloadSpec
-	insData  instance
+	spec     workloadSpec
+	insData  VMSpec
 	userData string
 }
 

--- a/testutil/ciao-down/workload_test.go
+++ b/testutil/ciao-down/workload_test.go
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const document1 = `# Just a simple document
+foo: "a string"
+bar: True
+`
+
+const document2 = `# A list
+- foo
+- bar
+`
+
+const twoDocuments = "---\n" + document1 + "...\n----\n" + document2 + "...\n"
+
+func TestSplitYaml(t *testing.T) {
+	tests := []struct {
+		content   string
+		documents [][]byte
+	}{
+		{"", [][]byte{}},
+		{document1, [][]byte{[]byte(document1)}},
+		{twoDocuments, [][]byte{[]byte(document1), []byte(document2)}},
+	}
+
+	for i := range tests {
+		test := &tests[i]
+
+		documents := splitYaml([]byte(test.content))
+		assert.Equal(t, test.documents, documents)
+	}
+}

--- a/testutil/ciao-down/workload_test.go
+++ b/testutil/ciao-down/workload_test.go
@@ -59,8 +59,10 @@ func TestRestoreWorkload(t *testing.T) {
 	}{
 		// 1 document: per-VM data (legacy)
 		{workload: sampleVMSpec},
-		// 3 documents: spec, per-VM data, cloud init file
+		// 2 documents: spec, cloud init file
 		{workload: sampleWorkload, checkSpec: true},
+		// 3 documents: spec, per-VM data, cloud init file (legacy)
+		{workload: sampleWorkload3Docs, checkSpec: true},
 	}
 
 	for i := range tests {

--- a/testutil/ciao-down/workload_test.go
+++ b/testutil/ciao-down/workload_test.go
@@ -70,7 +70,7 @@ func TestRestoreWorkload(t *testing.T) {
 
 		workload, err := restoreWorkload(ws)
 		assert.Nil(t, err)
-		assert.Equal(t, mockVMSpec, workload.insData)
+		assert.Equal(t, mockVMSpec, workload.spec.VM)
 		if test.checkSpec {
 			assert.Equal(t, guestDownloadURL, workload.spec.BaseImageURL)
 			assert.Equal(t, guestImageFriendlyName, workload.spec.BaseImageName)

--- a/testutil/ciao-down/workloads/ciao-fedora25.yaml
+++ b/testutil/ciao-down/workloads/ciao-fedora25.yaml
@@ -3,17 +3,16 @@ base_image_url: https://download.fedoraproject.org/pub/fedora/linux/releases/25/
 base_image_name: Fedora 25
 hostname: singlevm
 needs_nested_vm: true
-...
----
+vm:
 {{with .GoPath}}
-mounts:
-- tag: hostgo
-  security_model: passthrough
-  path: {{.}}
+  mounts:
+  - tag: hostgo
+    security_model: passthrough
+    path: {{.}}
 {{end}}
-ports:
-- host: 3000
-  guest: 3000
+  ports:
+  - host: 3000
+    guest: 3000
 ...
 ---
 {{ define "GOPATH" }}{{with .GoPath}}{{$.MountPath "hostgo"}}{{else}}/home/{{.User}}/go{{end}}{{end}}

--- a/testutil/ciao-down/workloads/ciao.yaml
+++ b/testutil/ciao-down/workloads/ciao.yaml
@@ -2,17 +2,16 @@
 base_image_url: https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
 base_image_name: Ubuntu 16.04
 needs_nested_vm: true
-...
----
+vm:
 {{with .GoPath}}
-mounts:
-- tag: hostgo
-  security_model: passthrough
-  path: {{.}}
+  mounts:
+  - tag: hostgo
+    security_model: passthrough
+    path: {{.}}
 {{end}}
-ports:
-- host: 3000
-  guest: 3000
+  ports:
+  - host: 3000
+    guest: 3000
 ...
 ---
 {{- define "ENV" -}}

--- a/testutil/ciao-down/workloads/clearcontainers.yaml
+++ b/testutil/ciao-down/workloads/clearcontainers.yaml
@@ -3,13 +3,12 @@ base_image_url: https://cloud-images.ubuntu.com/xenial/current/xenial-server-clo
 base_image_name: Ubuntu 16.04
 hostname: singlevm
 needs_nested_vm: true
-...
----
+vm:
 {{with .GoPath}}
-mounts:
-- tag: hostgo
-  security_model: none
-  path: {{.}}
+  mounts:
+  - tag: hostgo
+    security_model: none
+    path: {{.}}
 {{end}}
 ...
 ---

--- a/testutil/ciao-down/workloads/fedora25.yaml
+++ b/testutil/ciao-down/workloads/fedora25.yaml
@@ -4,8 +4,6 @@ base_image_name: Fedora 25
 hostname: singlevm
 ...
 ---
-...
----
 #cloud-config
 write_files:
 {{with proxyEnv . 5}}

--- a/testutil/ciao-down/workloads/xenial.yaml
+++ b/testutil/ciao-down/workloads/xenial.yaml
@@ -3,8 +3,6 @@ base_image_url: https://cloud-images.ubuntu.com/xenial/current/xenial-server-clo
 base_image_name: Ubuntu 16.04
 ...
 ---
-...
----
 {{- define "ENV" -}}
 {{proxyVars .}}
 {{- print " DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true " -}}


### PR DESCRIPTION
A bit of simplification in how workloads are written by folding the second document into a `vm` object in the workload description (1st document).

I kept compatibility with the current (and past) workloads by being able to load 1, 2 and 3 YAML documents description and state files. A "migration" happens when saving the state file.

The 2 first commits are part of PR https://github.com/01org/ciao/pull/1372 that should be merged first, but included them here so the two PRs don't conflict. 