### PR TITLE
ciao-controller: remove noNetwork support

### DIFF
--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -118,7 +118,7 @@ func (c *controller) confirmTenantRaw(tenantID string) error {
 		return nil
 	}
 
-	if tenant.CNCIIP == "" && !*noNetwork {
+	if tenant.CNCIIP == "" {
 		err := c.launchCNCI(tenantID)
 		if err != nil {
 			return err

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -1410,8 +1410,14 @@ func TestDeleteVolume(t *testing.T) {
 		t.Fatal("Incorrect error")
 	}
 
+	// add second tenant to datastore to prevent CNCI launching.
+	tenant2, err := addTestTenant()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// attempt to delete with bad tenant ID
-	err = ctl.DeleteVolume("badID", volID)
+	err = ctl.DeleteVolume(tenant2.ID, volID)
 	if err != block.ErrVolumeOwner {
 		t.Fatal("Incorrect error")
 	}

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -949,17 +949,6 @@ func TestRestartFailure(t *testing.T) {
 	t.Error("Did not find failure message in Log")
 }
 
-func TestNoNetwork(t *testing.T) {
-	nn := true
-
-	noNetwork = &nn
-
-	var reason payloads.StartFailureReason
-
-	client, _ := testStartWorkload(t, 1, false, reason)
-	defer client.Shutdown()
-}
-
 // NOTE: the caller is responsible for calling Shutdown() on the *SsntpTestClient
 func testStartTracedWorkload(t *testing.T) *testutil.SsntpTestClient {
 	tenant, err := addTestTenant()

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -73,7 +73,6 @@ var controllerAPIPort = api.Port
 var httpsCAcert = "/etc/pki/ciao/ciao-controller-cacert.pem"
 var httpsKey = "/etc/pki/ciao/ciao-controller-key.pem"
 var workloadsPath = flag.String("workloads_path", "/var/lib/ciao/data/controller/workloads", "path to yaml files")
-var noNetwork = flag.Bool("nonetwork", false, "Debug with no networking")
 var persistentDatastoreLocation = flag.String("database_path", "/var/lib/ciao/data/controller/ciao-controller.db", "path to persistent database")
 var imageDatastoreLocation = flag.String("image_database_path", "/var/lib/ciao/data/image/ciao-image.db", "path to image persistent database")
 var logDir = "/var/lib/ciao/logs/controller"


### PR DESCRIPTION
We are no longer going to support the noNetwork option.

Also clean up a unit test which relied on noNetwork.
