### PR TITLE
ciao-controller: reduce complexity of newConfig

### DIFF
--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -257,6 +257,7 @@ func (c *controller) launchCNCI(tenantID string) error {
 		WorkloadID: workloadID,
 		TenantID:   tenantID,
 		Instances:  1,
+		Name:       "cnci-" + tenantID,
 	}
 	_, err = c.startWorkload(w)
 	if err != nil {


### PR DESCRIPTION
The complexity of newConfig is so high, that just about any change
pushes it over the edge of our gocyclo limit of 15. Refactor
newConfig a little bit to make it easier to read and reduce
complexity.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>