### PR TITLE
ciao-controller: store CNCI instance with tenant instances

### DIFF
--- a/ciao-controller/api.go
+++ b/ciao-controller/api.go
@@ -522,9 +522,9 @@ func listCNCIs(c *controller, w http.ResponseWriter, r *http.Request) (APIRespon
 		return errorResponse(err), err
 	}
 
-	var subnets []types.CiaoCNCISubnet
-
 	for _, cnci := range cncis {
+		var subnets []types.CiaoCNCISubnet
+
 		if cnci.InstanceID == "" {
 			continue
 		}

--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -118,20 +118,12 @@ func (c *controller) confirmTenantRaw(tenantID string) error {
 		return nil
 	}
 
-	if tenant.CNCIIP == "" {
-		err := c.launchCNCI(tenantID)
-		if err != nil {
-			return err
-		}
-
-		tenant, err = c.ds.GetTenant(tenantID)
-		if err != nil {
-			return err
-		}
-
-		if tenant.CNCIIP == "" {
-			return errors.New("Unable to Launch Tenant CNCI")
-		}
+	if tenant.CNCIID != "" {
+		return nil
+	}
+	err = c.launchCNCI(tenantID)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/ciao-controller/compute_test.go
+++ b/ciao-controller/compute_test.go
@@ -35,6 +35,21 @@ import (
 	"github.com/01org/ciao/testutil"
 )
 
+// ByTenantID is used to sort CNCI instances by Tenant ID.
+type ByTenantID []types.CiaoCNCI
+
+func (c ByTenantID) Len() int {
+	return len(c)
+}
+
+func (c ByTenantID) Swap(i int, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
+func (c ByTenantID) Less(i int, j int) bool {
+	return c[i].TenantID < c[j].TenantID
+}
+
 func testHTTPRequest(t *testing.T, method string, URL string, expectedResponse int, data []byte, validToken bool) []byte {
 	req, err := http.NewRequest(method, URL, bytes.NewBuffer(data))
 	if err != nil {
@@ -989,9 +1004,9 @@ func testListCNCIs(t *testing.T, httpExpectedStatus int, validToken bool) {
 		t.Fatal(err)
 	}
 
-	var subnets []types.CiaoCNCISubnet
-
 	for _, cnci := range cncis {
+		var subnets []types.CiaoCNCISubnet
+
 		if cnci.InstanceID == "" {
 			continue
 		}
@@ -1014,6 +1029,8 @@ func testListCNCIs(t *testing.T, httpExpectedStatus int, validToken bool) {
 		)
 	}
 
+	sort.Sort(ByTenantID(expected.CNCIs))
+
 	url := testutil.ComputeURL + "/v2.1/cncis"
 
 	body := testHTTPRequest(t, "GET", url, httpExpectedStatus, nil, validToken)
@@ -1028,6 +1045,8 @@ func testListCNCIs(t *testing.T, httpExpectedStatus int, validToken bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	sort.Sort(ByTenantID(result.CNCIs))
 
 	if reflect.DeepEqual(expected, result) == false {
 		t.Fatalf("expected: \n%+v\n result: \n%+v\n", expected, result)

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/01org/ciao/ciao-controller/internal/datastore"
 	"github.com/01org/ciao/ciao-controller/internal/quotas"
 	"github.com/01org/ciao/ciao-controller/types"
+	"github.com/01org/ciao/ciao-controller/utils"
 	"github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/openstack/block"
 	"github.com/01org/ciao/payloads"
@@ -80,7 +81,7 @@ users:
 }
 
 func addFakeCNCI(tenant *types.Tenant) error {
-	mac, err := newHardwareAddr()
+	mac, err := utils.NewHardwareAddr()
 	if err != nil {
 		return err
 	}
@@ -306,18 +307,6 @@ func TestTenantOutOfBounds(t *testing.T) {
 		{Name: "tenant-instances-quota", Value: -1},
 	}
 	ctl.qs.Update(tenant.ID, quotas)
-}
-
-// TestNewTenantHardwareAddr
-// Confirm that the mac addresses generated from a given
-// IP address is as expected.
-func TestNewTenantHardwareAddr(t *testing.T) {
-	ip := net.ParseIP("172.16.0.2")
-	expectedMAC := "02:00:ac:10:00:02"
-	hw := newTenantHardwareAddr(ip)
-	if hw.String() != expectedMAC {
-		t.Error("Expected: ", expectedMAC, " Received: ", hw.String())
-	}
 }
 
 func TestStartWorkload(t *testing.T) {

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -80,14 +80,27 @@ users:
 }
 
 func addFakeCNCI(tenant *types.Tenant) error {
-	err := ctl.ds.AddTenantCNCI(tenant.ID, uuid.Generate().String(), tenant.CNCIMAC)
+	mac, err := newHardwareAddr()
 	if err != nil {
 		return err
 	}
-	err = ctl.ds.AddCNCIIP(tenant.CNCIMAC, "192.168.0.1")
+
+	// Add fake CNCI
+	CNCI := types.Instance{
+		TenantID:   tenant.ID,
+		State:      payloads.Running,
+		ID:         uuid.Generate().String(),
+		CNCI:       true,
+		IPAddress:  "192.168.0.1",
+		MACAddress: mac.String(),
+	}
+
+	err = ctl.ds.AddInstance(&CNCI)
 	if err != nil {
 		return err
 	}
+
+	tenant.CNCIID = CNCI.ID
 
 	return nil
 }

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -20,7 +20,6 @@
 package datastore
 
 import (
-	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"net"
@@ -94,7 +93,6 @@ type persistentStore interface {
 	addTenant(id string, MAC string) (err error)
 	getTenant(id string) (t *tenant, err error)
 	getTenants() ([]*tenant, error)
-	updateTenant(t *tenant) (err error)
 	releaseTenantIP(tenantID string, subnetInt int, rest int) (err error)
 	claimTenantIP(tenantID string, subnetInt int, rest int) (err error)
 
@@ -102,6 +100,7 @@ type persistentStore interface {
 	getInstances() (instances []*types.Instance, err error)
 	addInstance(instance *types.Instance) (err error)
 	deleteInstance(instanceID string) (err error)
+	updateInstance(instance *types.Instance) (err error)
 
 	// interfaces related to statistics
 	addNodeStat(stat payloads.Stat) (err error)
@@ -279,6 +278,9 @@ func (ds *Datastore) Init(config Config) error {
 		tenant := ds.tenants[i.TenantID]
 		if tenant != nil {
 			tenant.instances[i.ID] = i
+			if i.CNCI {
+				tenant.CNCIID = i.ID
+			}
 		}
 	}
 
@@ -335,38 +337,10 @@ func (ds *Datastore) AddTenantChan(c chan bool, tenantID string) {
 	ds.cnciAddedLock.Unlock()
 }
 
-func newHardwareAddr() (net.HardwareAddr, error) {
-	buf := make([]byte, 6)
-	_, err := rand.Read(buf)
-	if err != nil {
-		return nil, errors.Wrap(err, "error reading random data")
-	}
-
-	// vnic creation seems to require not just the
-	// bit 1 to be set, but the entire byte to be
-	// set to 2.  Also, ensure that we get no
-	// overlap with tenant mac addresses by not allowing
-	// byte 1 to ever be zero.
-	buf[0] = 2
-	if buf[1] == 0 {
-		buf[1] = 3
-	}
-
-	hw := net.HardwareAddr(buf)
-
-	return hw, nil
-}
-
 // AddTenant stores information about a tenant into the datastore.
-// it creates a MAC address for the tenant network and makes sure
-// that this new tenant is cached.
+// and makes sure that this new tenant is cached.
 func (ds *Datastore) AddTenant(id string) (*types.Tenant, error) {
-	hw, err := newHardwareAddr()
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating MAC address")
-	}
-
-	err = ds.db.addTenant(id, hw.String())
+	err := ds.db.addTenant(id, "")
 	if err != nil {
 		return nil, errors.Wrapf(err, "error adding tenant (%v) to database", id)
 	}
@@ -536,33 +510,9 @@ func (ds *Datastore) GetWorkloads(tenantID string) ([]types.Workload, error) {
 	return workloads, nil
 }
 
-// AddCNCIIP will associate a new IP address with an existing CNCI
-// via the mac address
-func (ds *Datastore) AddCNCIIP(cnciMAC string, ip string) error {
-	var ok bool
-	var tenantID string
-	var tenant *tenant
-
-	ds.tenantsLock.Lock()
-
-	for tenantID, tenant = range ds.tenants {
-		if tenant.CNCIMAC == cnciMAC {
-			ok = true
-			break
-		}
-	}
-
-	if !ok {
-		ds.tenantsLock.Unlock()
-		return ErrNoTenant
-	}
-
-	tenant.CNCIIP = ip
-
-	ds.tenantsLock.Unlock()
-
-	err := ds.db.updateTenant(tenant)
-
+// CNCIAdded will write to any associated tenant chans to indicate a
+// CNCI has been successfully launched.
+func (ds *Datastore) CNCIAdded(tenantID string) error {
 	ds.cnciAddedLock.Lock()
 
 	c, ok := ds.cnciAddedChans[tenantID]
@@ -576,28 +526,7 @@ func (ds *Datastore) AddCNCIIP(cnciMAC string, ip string) error {
 		c <- true
 	}
 
-	return errors.Wrap(err, "error updating tenant in database")
-}
-
-// AddTenantCNCI will associate a new CNCI instance with a specific tenant.
-// The instanceID of the new CNCI instance and the MAC address of the new instance
-// are stored in the sql database and updated in the cache.
-func (ds *Datastore) AddTenantCNCI(tenantID string, instanceID string, mac string) error {
-	// update tenants cache
-	ds.tenantsLock.Lock()
-
-	tenant, ok := ds.tenants[tenantID]
-	if !ok {
-		ds.tenantsLock.Unlock()
-		return ErrNoTenant
-	}
-
-	tenant.CNCIID = instanceID
-	tenant.CNCIMAC = mac
-
-	ds.tenantsLock.Unlock()
-
-	return ds.db.updateTenant(tenant)
+	return nil
 }
 
 func (ds *Datastore) removeTenantCNCI(tenantID string) error {
@@ -611,11 +540,15 @@ func (ds *Datastore) removeTenantCNCI(tenantID string) error {
 	}
 
 	tenant.CNCIID = ""
-	tenant.CNCIIP = ""
 
 	ds.tenantsLock.Unlock()
 
-	return errors.Wrap(ds.db.updateTenant(tenant), "error updating tenant in database")
+	return nil
+}
+
+// UpdateInstance will update certain fields of an instance
+func (ds *Datastore) UpdateInstance(instance *types.Instance) error {
+	return ds.db.updateInstance(instance)
 }
 
 // GetAllTenants returns all the tenants from the datastore.
@@ -751,8 +684,7 @@ func (ds *Datastore) AllocateTenantIP(tenantID string) (net.IP, error) {
 	return next, nil
 }
 
-// GetAllInstances retrieves all instances out of the datastore.
-func (ds *Datastore) GetAllInstances() ([]*types.Instance, error) {
+func (ds *Datastore) getInstances(cncis bool) ([]*types.Instance, error) {
 	var instances []*types.Instance
 
 	// always get from cache
@@ -760,13 +692,20 @@ func (ds *Datastore) GetAllInstances() ([]*types.Instance, error) {
 
 	if len(ds.instances) > 0 {
 		for _, val := range ds.instances {
-			instances = append(instances, val)
+			if val.CNCI == cncis {
+				instances = append(instances, val)
+			}
 		}
 	}
 
 	ds.instancesLock.RUnlock()
 
 	return instances, nil
+}
+
+// GetAllInstances retrieves all instances out of the datastore.
+func (ds *Datastore) GetAllInstances() ([]*types.Instance, error) {
+	return ds.getInstances(false)
 }
 
 // GetInstance retrieves an instance out of the datastore.
@@ -786,6 +725,7 @@ func (ds *Datastore) GetInstance(id string) (*types.Instance, error) {
 }
 
 // GetTenantInstance retrieves a tenant instance out of the datastore.
+// the CNCI will be excluded from this search.
 func (ds *Datastore) GetTenantInstance(tenantID string, instanceID string) (*types.Instance, error) {
 	// always get from cache
 	ds.instancesLock.RLock()
@@ -794,15 +734,14 @@ func (ds *Datastore) GetTenantInstance(tenantID string, instanceID string) (*typ
 
 	ds.instancesLock.RUnlock()
 
-	if !ok || value.TenantID != tenantID {
+	if !ok || value.TenantID != tenantID || value.CNCI == true {
 		return nil, types.ErrInstanceNotFound
 	}
 
 	return value, nil
 }
 
-// GetAllInstancesFromTenant will retrieve all instances belonging to a specific tenant
-func (ds *Datastore) GetAllInstancesFromTenant(tenantID string) ([]*types.Instance, error) {
+func (ds *Datastore) getTenantInstances(tenantID string, cncis bool) ([]*types.Instance, error) {
 	var instances []*types.Instance
 
 	ds.tenantsLock.RLock()
@@ -810,7 +749,9 @@ func (ds *Datastore) GetAllInstancesFromTenant(tenantID string) ([]*types.Instan
 	t, ok := ds.tenants[tenantID]
 	if ok {
 		for _, val := range t.instances {
-			instances = append(instances, val)
+			if val.CNCI == cncis {
+				instances = append(instances, val)
+			}
 		}
 
 		ds.tenantsLock.RUnlock()
@@ -823,6 +764,17 @@ func (ds *Datastore) GetAllInstancesFromTenant(tenantID string) ([]*types.Instan
 	return nil, nil
 }
 
+// GetAllInstancesFromTenant will retrieve all instances belonging to a specific tenant.
+// This will exclude any CNCI instances.
+func (ds *Datastore) GetAllInstancesFromTenant(tenantID string) ([]*types.Instance, error) {
+	return ds.getTenantInstances(tenantID, false)
+}
+
+// GetTenantCNCIs will retrieve all CNCI instances belonging to a tenant
+func (ds *Datastore) GetTenantCNCIs(tenantID string) ([]*types.Instance, error) {
+	return ds.getTenantInstances(tenantID, true)
+}
+
 // GetAllInstancesByNode will retrieve all the instances running on a specific compute Node.
 func (ds *Datastore) GetAllInstancesByNode(nodeID string) ([]*types.Instance, error) {
 	var instances []*types.Instance
@@ -832,7 +784,9 @@ func (ds *Datastore) GetAllInstancesByNode(nodeID string) ([]*types.Instance, er
 	n, ok := ds.nodes[nodeID]
 	if ok {
 		for _, val := range n.instances {
-			instances = append(instances, val)
+			if val.CNCI == false {
+				instances = append(instances, val)
+			}
 		}
 	}
 
@@ -914,24 +868,20 @@ func (ds *Datastore) StopFailure(instanceID string, reason payloads.StopFailureR
 // an instance does not result in it being deleted.
 func (ds *Datastore) StartFailure(instanceID string, reason payloads.StartFailureReason, migration bool) error {
 	var tenantID string
-	var cnci bool
 
-	ds.tenantsLock.RLock()
-
-	for key, t := range ds.tenants {
-		if t.CNCIID == instanceID {
-			cnci = true
-			tenantID = key
-			break
-		}
+	i, err := ds.GetInstance(instanceID)
+	if err != nil {
+		return errors.Wrapf(err, "error getting instance (%v)", instanceID)
 	}
+	tenantID = i.TenantID
 
-	ds.tenantsLock.RUnlock()
-
-	if cnci == true {
+	if i.CNCI == true {
 		glog.Warning("CNCI ", instanceID, " Failed to start")
 
 		err := ds.removeTenantCNCI(tenantID)
+		if err != nil {
+			return errors.Wrap(err, "error removing CNCI for tenant")
+		}
 
 		msg := fmt.Sprintf("CNCI Start Failure %s: %s", instanceID, reason.String())
 		_ = ds.db.logEvent(tenantID, string(userError), msg)
@@ -948,13 +898,6 @@ func (ds *Datastore) StartFailure(instanceID string, reason payloads.StartFailur
 		if c != nil {
 			c <- false
 		}
-
-		return errors.Wrap(err, "error removing CNCI for tenant")
-	}
-
-	i, err := ds.GetInstance(instanceID)
-	if err != nil {
-		return errors.Wrapf(err, "error getting instance (%v)", instanceID)
 	}
 
 	if reason.IsFatal() && !migration {
@@ -1058,10 +1001,12 @@ func (ds *Datastore) deleteInstance(instanceID string) (string, error) {
 	}
 
 	var err error
-	if tmpErr := ds.ReleaseTenantIP(i.TenantID, i.IPAddress); tmpErr != nil {
-		glog.Warningf("error releasing IP for instance (%v): %v", i.ID, err)
-		if err == nil {
-			err = errors.Wrapf(tmpErr, "error releasing IP for instance (%v)", i.ID)
+	if i.CNCI == false {
+		if tmpErr := ds.ReleaseTenantIP(i.TenantID, i.IPAddress); tmpErr != nil {
+			glog.Warningf("error releasing IP for instance (%v): %v", i.ID, err)
+			if err == nil {
+				err = errors.Wrapf(tmpErr, "error releasing IP for instance (%v)", i.ID)
+			}
 		}
 	}
 
@@ -1239,7 +1184,16 @@ func (ds *Datastore) GetInstanceLastStats(nodeID string) types.CiaoServersStats 
 		if instance.NodeID != nodeID {
 			continue
 		}
-		serversStats.Servers = append(serversStats.Servers, instance)
+
+		i, err := ds.GetInstance(instance.ID)
+		if err != nil {
+			glog.Warningf("skipping stat for instance %s: %v", instance.ID, err)
+			continue
+		}
+
+		if i.CNCI != true {
+			serversStats.Servers = append(serversStats.Servers, instance)
+		}
 	}
 	ds.instanceLastStatLock.RUnlock()
 
@@ -1453,10 +1407,24 @@ func (ds *Datastore) GetTenantCNCISummary(cnci string) ([]types.TenantCNCI, erro
 			continue
 		}
 
+		var IPAddress string
+		var MACAddress string
+
+		if t.CNCIID != "" {
+			i, err := ds.GetInstance(t.CNCIID)
+			if err != nil {
+				glog.Warningf("CNCI assigned to tenant but unable to retrieve instance: %v", err)
+				continue
+			}
+
+			IPAddress = i.IPAddress
+			MACAddress = i.MACAddress
+		}
+
 		cn := types.TenantCNCI{
 			TenantID:   t.ID,
-			IPAddress:  t.CNCIIP,
-			MACAddress: t.CNCIMAC,
+			IPAddress:  IPAddress,
+			MACAddress: MACAddress,
 			InstanceID: t.CNCIID,
 		}
 

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -17,6 +17,7 @@
 package datastore
 
 import (
+	"crypto/rand"
 	"database/sql"
 	"encoding/binary"
 	"flag"
@@ -31,6 +32,7 @@ import (
 	"github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp/uuid"
+	"github.com/pkg/errors"
 )
 
 func newTenantHardwareAddr(ip net.IP) (hw net.HardwareAddr) {
@@ -41,6 +43,28 @@ func newTenantHardwareAddr(ip net.IP) (hw net.HardwareAddr) {
 	copy(buf[2:6], ipBytes)
 	hw = net.HardwareAddr(buf)
 	return
+}
+
+func newHardwareAddr() (net.HardwareAddr, error) {
+	buf := make([]byte, 6)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return nil, errors.Wrap(err, "error reading random data")
+	}
+
+	// vnic creation seems to require not just the
+	// bit 1 to be set, but the entire byte to be
+	// set to 2.  Also, ensure that we get no
+	// overlap with tenant mac addresses by not allowing
+	// byte 1 to ever be zero.
+	buf[0] = 2
+	if buf[1] == 0 {
+		buf[1] = 3
+	}
+
+	hw := net.HardwareAddr(buf)
+
+	return hw, nil
 }
 
 func addInstance(tenant *types.Tenant, workload types.Workload, name string) (instance *types.Instance, err error) {
@@ -150,15 +174,27 @@ func addTestTenant() (tenant *types.Tenant, err error) {
 		return
 	}
 
+	mac, err := newHardwareAddr()
+	if err != nil {
+		return
+	}
+
 	// Add fake CNCI
-	err = ds.AddTenantCNCI(tuuid.String(), uuid.Generate().String(), tenant.CNCIMAC)
+	CNCI := types.Instance{
+		TenantID:   tenant.ID,
+		State:      payloads.Running,
+		ID:         uuid.Generate().String(),
+		CNCI:       true,
+		IPAddress:  "192.168.0.1",
+		MACAddress: mac.String(),
+	}
+
+	err = ds.AddInstance(&CNCI)
 	if err != nil {
 		return
 	}
-	err = ds.AddCNCIIP(tenant.CNCIMAC, "192.168.0.1")
-	if err != nil {
-		return
-	}
+
+	tenant.CNCIID = CNCI.ID
 
 	err = addTestWorkload(tuuid.String())
 
@@ -896,37 +932,6 @@ func TestGetCNCIWorkloadID(t *testing.T) {
 	}
 }
 
-func TestRemoveTenantCNCI(t *testing.T) {
-	tenant, err := addTestTenant()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = ds.removeTenantCNCI(tenant.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// make sure cache was updated
-	ds.tenantsLock.Lock()
-	t2 := ds.tenants[tenant.ID]
-	delete(ds.tenants, tenant.ID)
-	ds.tenantsLock.Unlock()
-
-	if t2.CNCIID != "" || t2.CNCIIP != "" {
-		t.Fatal("Cache Not Updated")
-	}
-
-	// check database was updated
-	testTenant, err := ds.GetTenant(tenant.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if testTenant.CNCIID != "" || testTenant.CNCIIP != "" {
-		t.Fatal("Database not updated")
-	}
-}
-
 func TestGetTenant(t *testing.T) {
 	tenant, err := addTestTenant()
 	if err != nil {
@@ -951,16 +956,8 @@ func TestGetAllTenants(t *testing.T) {
 	// errors.
 }
 
-func TestAddCNCIIP(t *testing.T) {
-	/* add a new tenant */
-	tuuid := uuid.Generate()
-	tenant, err := ds.AddTenant(tuuid.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Add fake CNCI
-	err = ds.AddTenantCNCI(tenant.ID, uuid.Generate().String(), tenant.CNCIMAC)
+func TestCNCIAdded(t *testing.T) {
+	tenant, err := addTestTenant()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -972,7 +969,7 @@ func TestAddCNCIIP(t *testing.T) {
 	ds.cnciAddedLock.Unlock()
 
 	go func() {
-		err := ds.AddCNCIIP(tenant.CNCIMAC, "192.168.0.1")
+		err := ds.CNCIAdded(tenant.ID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -79,11 +79,11 @@ func (db *MemoryDB) getEventLog() ([]*types.LogEntry, error) {
 	return db.logEntries, nil
 }
 
-func (db *MemoryDB) addTenant(id string, MAC string) error {
+func (db *MemoryDB) addTenant(id string, name string) error {
 	t := &tenant{
 		Tenant: types.Tenant{
-			ID:      id,
-			CNCIMAC: MAC,
+			ID:   id,
+			Name: name,
 		},
 		network:   make(map[int]map[int]bool),
 		instances: make(map[string]*types.Instance),
@@ -107,15 +107,6 @@ func (db *MemoryDB) getTenants() ([]*tenant, error) {
 		tenants = append(tenants, t)
 	}
 	return tenants, nil
-}
-
-func (db *MemoryDB) updateTenant(t *tenant) error {
-	_, ok := db.tenants[t.ID]
-	if !ok {
-		return fmt.Errorf("Tenant %s not found", t.ID)
-	}
-	db.tenants[t.ID] = t
-	return nil
 }
 
 func (db *MemoryDB) releaseTenantIP(tenantID string, subnetInt int, rest int) error {
@@ -240,4 +231,8 @@ func (db *MemoryDB) updateQuotas(tenantID string, qds []types.QuotaDetails) erro
 
 func (db *MemoryDB) getQuotas(tenantID string) ([]types.QuotaDetails, error) {
 	return []types.QuotaDetails{}, nil
+}
+
+func (db *MemoryDB) updateInstance(instance *types.Instance) error {
+	return nil
 }

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -140,11 +140,9 @@ func (s SortedNodesByID) Less(i, j int) bool { return s[i].ID < s[j].ID }
 
 // Tenant contains information about a tenant or project.
 type Tenant struct {
-	ID      string
-	Name    string
-	CNCIID  string
-	CNCIMAC string
-	CNCIIP  string
+	ID     string
+	Name   string
+	CNCIID string
 }
 
 // LogEntry stores information about events.

--- a/ciao-controller/utils/utils.go
+++ b/ciao-controller/utils/utils.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"crypto/rand"
+	"net"
+)
+
+// NewTenantHardwareAddr will generate a MAC address for a tenant instance.
+func NewTenantHardwareAddr(ip net.IP) net.HardwareAddr {
+	buf := make([]byte, 6)
+	ipBytes := ip.To4()
+	buf[0] |= 2
+	buf[1] = 0
+	copy(buf[2:6], ipBytes)
+	return net.HardwareAddr(buf)
+}
+
+// NewHardwareAddr will generate a MAC address for a CNCI.
+func NewHardwareAddr() (net.HardwareAddr, error) {
+	buf := make([]byte, 6)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	// vnic creation seems to require not just the
+	// bit 1 to be set, but the entire byte to be
+	// set to 2.  Also, ensure that we get no
+	// overlap with tenant mac addresses by not allowing
+	// byte 1 to ever be zero.
+	buf[0] = 2
+	if buf[1] == 0 {
+		buf[1] = 3
+	}
+
+	hw := net.HardwareAddr(buf)
+
+	return hw, nil
+}

--- a/ciao-controller/utils/utils_test.go
+++ b/ciao-controller/utils/utils_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"net"
+	"testing"
+)
+
+// TestNewTenantHardwareAddr
+// Confirm that the mac addresses generated from a given
+// IP address is as expected.
+func TestNewTenantHardwareAddr(t *testing.T) {
+	ip := net.ParseIP("172.16.0.2")
+	expectedMAC := "02:00:ac:10:00:02"
+	hw := NewTenantHardwareAddr(ip)
+	if hw.String() != expectedMAC {
+		t.Error("Expected: ", expectedMAC, " Received: ", hw.String())
+	}
+}
+
+// TestHardwareAddr
+// Confirm that the mac addresses generated from a given
+// IP address is as expected.
+func TestHardwareAddr(t *testing.T) {
+	hw, err := NewHardwareAddr()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// byte 0 has to be 2, byte 1 can never be zero
+	if hw[0] != 2 {
+		t.Fatalf("Expected byte zero to be 2, Got %v", hw[0])
+	}
+
+	if hw[1] == 0 {
+		t.Fatal("Byte 1 may never be zero")
+	}
+}


### PR DESCRIPTION
Start storing CNCI instances in the datastore, and treat CNCI
as a special tenant instance. This will allow us to use normal
controller commands (such as restart and delete) in the future to
operate on the CNCI.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>