### PR TITLE
WIP: Keystoneless authentication

### DIFF
--- a/ciao-cli/external_ips.go
+++ b/ciao-cli/external_ips.go
@@ -46,7 +46,7 @@ func getExternalIPRef(address string) (string, error) {
 		return "", err
 	}
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		return "", err
 	}
@@ -132,7 +132,7 @@ func (cmd *externalIPMapCommand) run(args []string) error {
 		fatalf(err.Error())
 	}
 
-	resp, err := sendCiaoRequest("POST", url, nil, body, &ver)
+	resp, err := sendCiaoRequest("POST", url, nil, body, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -179,7 +179,7 @@ func (cmd *externalIPListCommand) run(args []string) error {
 		fatalf(err.Error())
 	}
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -268,7 +268,7 @@ func (cmd *externalIPUnMapCommand) run(args []string) error {
 
 	ver := api.ExternalIPsV1
 
-	resp, err := sendCiaoRequest("DELETE", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("DELETE", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -319,7 +319,7 @@ func getCiaoPoolRef(name string) (string, error) {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("GET", url, []queryValue{query}, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, []queryValue{query}, nil, ver)
 	if err != nil {
 		return "", err
 	}
@@ -353,7 +353,7 @@ func getCiaoPool(name string) (types.Pool, error) {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		return pool, err
 	}
@@ -414,7 +414,7 @@ func (cmd *poolCreateCommand) run(args []string) error {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("POST", url, nil, body, &ver)
+	resp, err := sendCiaoRequest("POST", url, nil, body, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -467,7 +467,7 @@ func (cmd *poolListCommand) run(args []string) error {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -621,7 +621,7 @@ func (cmd *poolDeleteCommand) run(args []string) error {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("DELETE", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("DELETE", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -720,7 +720,7 @@ func (cmd *poolAddCommand) run(args []string) error {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("POST", url, nil, body, &ver)
+	resp, err := sendCiaoRequest("POST", url, nil, body, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -823,7 +823,7 @@ func (cmd *poolRemoveCommand) run(args []string) error {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("DELETE", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("DELETE", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}

--- a/ciao-cli/identity.go
+++ b/ciao-cli/identity.go
@@ -180,7 +180,7 @@ func getUserProjects(username string, password string) ([]Project, error) {
 
 	identity := fmt.Sprintf("%s/v3/users/%s/projects", *identityURL, user)
 
-	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil, nil)
+	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func getAllProjects(username string, password string) (*IdentityProjects, error)
 
 	identity := fmt.Sprintf("%s/v3/auth/projects", *identityURL)
 
-	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil, nil)
+	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil, "")
 	if err != nil {
 		return nil, err
 	}

--- a/ciao-cli/image.go
+++ b/ciao-cli/image.go
@@ -343,9 +343,8 @@ func uploadTenantImage(username, password, tenant, image, filename string) error
 	}
 	defer file.Close()
 
-	contentType := "octet-stream"
 	url := buildImageURL("images/%s/file", image)
-	resp, err := sendHTTPRequestToken("PUT", url, nil, scopedToken, file, &contentType)
+	resp, err := sendHTTPRequestToken("PUT", url, nil, scopedToken, file, "octet-stream")
 	defer func() { _ = resp.Body.Close() }()
 
 	return err

--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/01org/ciao/ciao-controller/api"
 	"github.com/01org/ciao/ciao-controller/types"
+	"github.com/01org/ciao/openstack/block"
 	"github.com/golang/glog"
 )
 
@@ -172,6 +173,11 @@ func buildComputeURL(format string, args ...interface{}) string {
 
 func buildCiaoURL(format string, args ...interface{}) string {
 	prefix := fmt.Sprintf("https://%s:%d/", *controllerURL, *ciaoPort)
+	return fmt.Sprintf(prefix+format, args...)
+}
+
+func buildBlockURL(format string, args ...interface{}) string {
+	prefix := fmt.Sprintf("https://%s:%d/v2/", *controllerURL, block.APIPort)
 	return fmt.Sprintf(prefix+format, args...)
 }
 

--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/01org/ciao/ciao-controller/api"
 	"github.com/01org/ciao/ciao-controller/types"
 	"github.com/01org/ciao/openstack/block"
+	"github.com/01org/ciao/openstack/image"
 	"github.com/golang/glog"
 )
 
@@ -178,6 +179,11 @@ func buildCiaoURL(format string, args ...interface{}) string {
 
 func buildBlockURL(format string, args ...interface{}) string {
 	prefix := fmt.Sprintf("https://%s:%d/v2/", *controllerURL, block.APIPort)
+	return fmt.Sprintf(prefix+format, args...)
+}
+
+func buildImageURL(format string, args ...interface{}) string {
+	prefix := fmt.Sprintf("https://%s:%d/v2/", *controllerURL, image.APIPort)
 	return fmt.Sprintf(prefix+format, args...)
 }
 

--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -187,7 +187,7 @@ func buildImageURL(format string, args ...interface{}) string {
 	return fmt.Sprintf(prefix+format, args...)
 }
 
-func sendHTTPRequestToken(method string, url string, values []queryValue, token string, body io.Reader, content *string) (*http.Response, error) {
+func sendHTTPRequestToken(method string, url string, values []queryValue, token string, body io.Reader, content string) (*http.Response, error) {
 	req, err := http.NewRequest(method, os.ExpandEnv(url), body)
 	if err != nil {
 		return nil, err
@@ -210,8 +210,8 @@ func sendHTTPRequestToken(method string, url string, values []queryValue, token 
 		req.Header.Add("X-Auth-Token", token)
 	}
 
-	if content != nil {
-		contentType := fmt.Sprintf("application/%s", *content)
+	if content != "" {
+		contentType := fmt.Sprintf("application/%s", content)
 		req.Header.Set("Content-Type", contentType)
 		req.Header.Set("Accept", contentType)
 	} else if body != nil {
@@ -253,7 +253,7 @@ func sendHTTPRequestToken(method string, url string, values []queryValue, token 
 }
 
 func sendHTTPRequest(method string, url string, values []queryValue, body io.Reader) (*http.Response, error) {
-	return sendHTTPRequestToken(method, url, values, scopedToken, body, nil)
+	return sendHTTPRequestToken(method, url, values, scopedToken, body, "")
 }
 
 func unmarshalHTTPResponse(resp *http.Response, v interface{}) error {
@@ -278,7 +278,7 @@ func unmarshalHTTPResponse(resp *http.Response, v interface{}) error {
 	return nil
 }
 
-func sendCiaoRequest(method string, url string, values []queryValue, body io.Reader, content *string) (*http.Response, error) {
+func sendCiaoRequest(method string, url string, values []queryValue, body io.Reader, content string) (*http.Response, error) {
 	return sendHTTPRequestToken(method, url, values, scopedToken, body, content)
 }
 
@@ -301,7 +301,7 @@ func getCiaoResource(name string, minVersion string) (string, error) {
 		url = buildCiaoURL(fmt.Sprintf("%s", *tenantID))
 	}
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, nil)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, "")
 	if err != nil {
 		return "", err
 	}

--- a/ciao-cli/quotas.go
+++ b/ciao-cli/quotas.go
@@ -123,7 +123,7 @@ func (cmd *quotasUpdateCommand) run(args []string) error {
 	ver := api.TenantsV1
 
 	url = fmt.Sprintf("%s/%s/quotas", url, cmd.tenantID)
-	resp, err := sendCiaoRequest("PUT", url, nil, body, &ver)
+	resp, err := sendCiaoRequest("PUT", url, nil, body, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -194,7 +194,7 @@ func (cmd *quotasListCommand) run(args []string) error {
 	}
 	ver := api.TenantsV1
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}

--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -334,7 +334,7 @@ func (cmd *workloadCreateCommand) run(args []string) error {
 
 	ver := api.WorkloadsV1
 
-	resp, err := sendCiaoRequest("POST", url, nil, body, &ver)
+	resp, err := sendCiaoRequest("POST", url, nil, body, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -397,7 +397,7 @@ func (cmd *workloadDeleteCommand) run(args []string) error {
 	// just hard code the path.
 	url = fmt.Sprintf("%s/%s", url, cmd.workload)
 
-	resp, err := sendCiaoRequest("DELETE", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("DELETE", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -455,7 +455,7 @@ func (cmd *workloadShowCommand) run(args []string) error {
 	// just hard code the path.
 	url = fmt.Sprintf("%s/%s", url, cmd.workload)
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -308,6 +308,30 @@ func (ts testCiaoService) UpdateQuotas(tenantID string, qds []types.QuotaDetails
 	return nil
 }
 
+func (ts testCiaoService) AddUser(username, pwhash string) error {
+	return nil
+}
+
+func (ts testCiaoService) DelUser(username string) error {
+	return nil
+}
+
+func (ts testCiaoService) ListUsers() ([]string, error) {
+	return []string{}, nil
+}
+
+func (ts testCiaoService) ListUserGrants(username string) ([]string, error) {
+	return []string{}, nil
+}
+
+func (ts testCiaoService) GrantUser(username, tenantID string) error {
+	return nil
+}
+
+func (ts testCiaoService) RevokeUser(username, tenantID string) error {
+	return nil
+}
+
 func TestResponse(t *testing.T) {
 	var ts testCiaoService
 

--- a/ciao-controller/internal/auth/auth.go
+++ b/ciao-controller/internal/auth/auth.go
@@ -109,6 +109,7 @@ func (h *authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	if ok, isAdmin := h.Auth.Authenticate(username, password, vars["tenant"]); ok {
 		ctx := service.SetPrivilege(r.Context(), isAdmin)
+		ctx = service.SetUsername(ctx, username)
 
 		h.RealHandler.ServeHTTP(w, r.WithContext(ctx))
 		return

--- a/ciao-controller/internal/auth/auth.go
+++ b/ciao-controller/internal/auth/auth.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"net/http"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/01org/ciao/ciao-controller/internal/datastore"
+	"github.com/01org/ciao/ciao-controller/types"
+	"github.com/01org/ciao/service"
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+)
+
+// Auth provides ciao authentication service
+type Auth struct {
+	ds *datastore.Datastore
+}
+
+func (auth *Auth) setupAdminIfMissing(pwhash string) error {
+	if pwhash == "" {
+		return nil
+	}
+
+	_, err := auth.ds.GetUserInfo("admin")
+	if err == types.ErrUserNotFound {
+		err := auth.ds.AddUser("admin", pwhash)
+		if err != nil {
+			return errors.Wrap(err, "Error adding user")
+		}
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Init initialises the authentication manager
+func (auth *Auth) Init(ds *datastore.Datastore, initalAdminPasswordHash string) error {
+	auth.ds = ds
+
+	err := auth.setupAdminIfMissing(initalAdminPasswordHash)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Authenticate returns true if user has acess to the desired resource
+func (auth *Auth) Authenticate(username, password, tenantID string) (bool, bool) {
+	ui, err := auth.ds.GetUserInfo(username)
+	if err != nil {
+		return false, false
+	}
+
+	err = bcrypt.CompareHashAndPassword([]byte(ui.PasswordHash), []byte(password))
+	if err != nil {
+		return false, false
+	}
+
+	// Let admin work on any tenant
+	if username == "admin" {
+		return true, true
+	}
+
+	// Some API calls do not require a tenant
+	if tenantID == "" {
+		return true, false
+	}
+
+	// Otherwise check user has access to desired tenant
+	for _, g := range ui.Grants {
+		if g == tenantID {
+			return true, false
+		}
+	}
+
+	return false, false
+}
+
+type authHandler struct {
+	Auth        *Auth
+	RealHandler http.Handler
+	NextHandler http.Handler
+}
+
+func (h *authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	username, password, ok := r.BasicAuth()
+	if !ok {
+		h.NextHandler.ServeHTTP(w, r)
+		return
+	}
+
+	vars := mux.Vars(r)
+	if ok, isAdmin := h.Auth.Authenticate(username, password, vars["tenant"]); ok {
+		ctx := service.SetPrivilege(r.Context(), isAdmin)
+
+		h.RealHandler.ServeHTTP(w, r.WithContext(ctx))
+		return
+	}
+
+	h.NextHandler.ServeHTTP(w, r)
+}
+
+// GetHandler returns a handler for authenticating incoming requests
+func (auth *Auth) GetHandler(realHandler http.Handler, nextHandler http.Handler) http.Handler {
+	h := &authHandler{Auth: auth,
+		RealHandler: realHandler,
+		NextHandler: nextHandler,
+	}
+	return h
+}

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -134,6 +134,13 @@ type persistentStore interface {
 	// quotas
 	updateQuotas(tenantID string, qds []types.QuotaDetails) error
 	getQuotas(tenantID string) ([]types.QuotaDetails, error)
+
+	// user management
+	addUser(username, pwhash string) error
+	delUser(username string) error
+	grant(username, tenantID string) error
+	revoke(username, tenantID string) error
+	getUsers() (map[string]*types.UserInfo, error)
 }
 
 // Datastore provides context for the datastore package.

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -241,3 +241,24 @@ func (db *MemoryDB) updateQuotas(tenantID string, qds []types.QuotaDetails) erro
 func (db *MemoryDB) getQuotas(tenantID string) ([]types.QuotaDetails, error) {
 	return []types.QuotaDetails{}, nil
 }
+
+func (db *MemoryDB) addUser(username, pwhash string) error {
+	return nil
+}
+
+func (db *MemoryDB) delUser(username string) (err error) {
+	return nil
+}
+
+func (db *MemoryDB) grant(username string, tenantID string) error {
+	return nil
+}
+
+func (db *MemoryDB) revoke(username string, tenantID string) error {
+	return nil
+}
+
+func (db *MemoryDB) getUsers() (map[string]*types.UserInfo, error) {
+	users := make(map[string]*types.UserInfo)
+	return users, nil
+}

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -290,7 +290,7 @@ func (c *controller) createCiaoServer() (*http.Server, error) {
 			ValidAdmins:   validAdmins,
 		}
 
-		route.Handler(h)
+		route.Handler(c.auth.GetHandler(route.GetHandler(), h))
 
 		return nil
 	})

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/01org/ciao/ciao-controller/api"
+	"github.com/01org/ciao/ciao-controller/internal/auth"
 	"github.com/01org/ciao/ciao-controller/internal/datastore"
 	"github.com/01org/ciao/ciao-controller/internal/quotas"
 	storage "github.com/01org/ciao/ciao-storage"
@@ -59,6 +60,7 @@ type controller struct {
 	tenantReadinessLock sync.Mutex
 	qs                  *quotas.Quotas
 	httpServers         []*http.Server
+	auth                auth.Auth
 }
 
 var cert = flag.String("cert", "", "Client certificate")
@@ -165,6 +167,12 @@ func main() {
 	cnciVCPUs := clusterConfig.Configure.Controller.CNCIVcpus
 	cnciMem := clusterConfig.Configure.Controller.CNCIMem
 	cnciDisk := clusterConfig.Configure.Controller.CNCIDisk
+
+	err = ctl.auth.Init(ctl.ds, clusterConfig.Configure.Controller.InitialAdminPasswordHash)
+	if err != nil {
+		glog.Fatalf("Error setting initial admin credentials")
+		return
+	}
 
 	adminSSHKey = clusterConfig.Configure.Controller.AdminSSHKey
 

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -628,7 +628,7 @@ func (c *controller) createComputeServer() (*http.Server, error) {
 			ValidAdmins:   validAdmins,
 		}
 
-		route.Handler(h)
+		route.Handler(c.auth.GetHandler(route.GetHandler(), h))
 
 		return nil
 	})

--- a/ciao-controller/openstack_image.go
+++ b/ciao-controller/openstack_image.go
@@ -314,7 +314,7 @@ func (c *controller) createImageServer() (*http.Server, error) {
 			ValidAdmins:   validAdmins,
 		}
 
-		route.Handler(h)
+		route.Handler(c.auth.GetHandler(route.GetHandler(), h))
 		return nil
 	})
 	if err != nil {

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -456,7 +456,7 @@ func (c *controller) createVolumeServer() (*http.Server, error) {
 			ValidAdmins:   validAdmins,
 		}
 
-		route.Handler(h)
+		route.Handler(c.auth.GetHandler(route.GetHandler(), h))
 
 		return nil
 	})

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -544,6 +544,9 @@ var (
 
 	// ErrWorkloadInUse is returned by DeleteWorkload when an instance of a workload is still active.
 	ErrWorkloadInUse = errors.New("Workload definition still in use")
+
+	// ErrUserNotFound is returned when the user does not exist.
+	ErrUserNotFound = errors.New("User not found")
 )
 
 // Link provides a url and relationship for a resource.

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -716,3 +716,10 @@ type QuotaUpdateRequest struct {
 type QuotaListResponse struct {
 	Quotas []QuotaDetails `json:"quotas"`
 }
+
+// UserInfo represents users in Ciao's basic authentication architecture
+type UserInfo struct {
+	Username     string
+	PasswordHash string
+	Grants       []string
+}

--- a/ciao-controller/users.go
+++ b/ciao-controller/users.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+func (c *controller) AddUser(username, pwhash string) error {
+	return c.ds.AddUser(username, pwhash)
+}
+
+func (c *controller) DelUser(username string) error {
+	return c.ds.DelUser(username)
+}
+
+func (c *controller) ListUsers() ([]string, error) {
+	users, err := c.ds.GetUsers()
+	if err != nil {
+		return []string{}, err
+	}
+
+	res := make([]string, len(users))
+	for i := range users {
+		res[i] = users[i].Username
+	}
+
+	return res, nil
+}
+
+func (c *controller) ListUserGrants(username string) ([]string, error) {
+	ui, err := c.ds.GetUserInfo(username)
+	if err != nil {
+		return []string{}, err
+	}
+
+	return ui.Grants, nil
+}
+
+func (c *controller) GrantUser(username, tenantID string) error {
+	return c.ds.Grant(username, tenantID)
+}
+
+func (c *controller) RevokeUser(username, tenantID string) error {
+	return c.ds.Revoke(username, tenantID)
+}

--- a/payloads/configure.go
+++ b/payloads/configure.go
@@ -66,19 +66,20 @@ type ConfigureScheduler struct {
 // ConfigureController contains the unmarshalled configurations for the
 // controller service.
 type ConfigureController struct {
-	VolumePort       int    `yaml:"volume_port"`
-	ComputePort      int    `yaml:"compute_port"`
-	CiaoPort         int    `yaml:"ciao_port"`
-	ControllerFQDN   string `yaml:"compute_fqdn"`
-	HTTPSCACert      string `yaml:"compute_ca"`
-	HTTPSKey         string `yaml:"compute_cert"`
-	IdentityUser     string `yaml:"identity_user"`
-	IdentityPassword string `yaml:"identity_password"`
-	CNCIVcpus        int    `yaml:"cnci_vcpus"`
-	CNCIMem          int    `yaml:"cnci_mem"`
-	CNCIDisk         int    `yaml:"cnci_disk"`
-	AdminSSHKey      string `yaml:"admin_ssh_key"`
-	AdminPassword    string `yaml:"admin_password"`
+	VolumePort               int    `yaml:"volume_port"`
+	ComputePort              int    `yaml:"compute_port"`
+	CiaoPort                 int    `yaml:"ciao_port"`
+	ControllerFQDN           string `yaml:"compute_fqdn"`
+	HTTPSCACert              string `yaml:"compute_ca"`
+	HTTPSKey                 string `yaml:"compute_cert"`
+	IdentityUser             string `yaml:"identity_user"`
+	IdentityPassword         string `yaml:"identity_password"`
+	CNCIVcpus                int    `yaml:"cnci_vcpus"`
+	CNCIMem                  int    `yaml:"cnci_mem"`
+	CNCIDisk                 int    `yaml:"cnci_disk"`
+	AdminSSHKey              string `yaml:"admin_ssh_key"`
+	AdminPassword            string `yaml:"admin_password"`
+	InitialAdminPasswordHash string `yaml:"initial_admin_password_hash,omitempty"`
 }
 
 // ConfigureLauncher contains the unmarshalled configurations for the

--- a/service/service.go
+++ b/service/service.go
@@ -29,6 +29,9 @@ const PrivKey key = 0
 // tenant id which is being used in the API call
 const TenantIDKey key = 1
 
+// UsernameKey is the key for the username in the context map
+const UsernameKey key = 2
+
 // GetPrivilege returns the value of PrivKey
 func GetPrivilege(ctx context.Context) bool {
 	privilege, ok := ctx.Value(PrivKey).(bool)
@@ -52,4 +55,18 @@ func GetTenantID(ctx context.Context) (string, error) {
 // SetTenantID sets the value of Tenant ID
 func SetTenantID(ctx context.Context, tenantID string) context.Context {
 	return context.WithValue(ctx, TenantIDKey, tenantID)
+}
+
+// SetUsername sets the value of username
+func SetUsername(ctx context.Context, username string) context.Context {
+	return context.WithValue(ctx, UsernameKey, username)
+}
+
+// GetUsername returns the value of username on context
+func GetUsername(ctx context.Context) string {
+	username, ok := ctx.Value(UsernameKey).(string)
+	if ok {
+		return username
+	}
+	return ""
 }


### PR DESCRIPTION
His is my PR working towards authentication without keystone. It comprises of three main parts:

1. Removing the use of gophercloud APIs for image and volume
2. The introduction of datastore mechanics and HTTP APIs for adding and manipulating users
3. The use of HTTP basic auth against that use database.

This is still a WIP with the following TODO:

-  Make grants more like a simple RBAC
- Unit testing of HTTP API in controller
- Command line client to manage users
- BAT testing of said command line client
- The ability to pick a tenant for the user to use if one is not specified
- Tenant creation

If you want to test this out put a bcrypted password in initial_admin_password_hash in the controller section of configuration.yaml (remembering to restart scheduler **then** controller)

Then set CIAO_USERNAME=admin CIAO_PASSWORD=<your password> and then you can run ciao-cli commands as the admin user.