### PR TITLE
qemu: Update virtio-net-pci command line

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -390,6 +390,9 @@ func (netdev NetDevice) QemuParams(config *Config) []string {
 	var deviceParams []string
 	var qemuParams []string
 
+	if netdev.Driver == VirtioNetPCI {
+		deviceParams = append(deviceParams, "driver=")
+	}
 	deviceParams = append(deviceParams, fmt.Sprintf("%s", netdev.Driver))
 	deviceParams = append(deviceParams, fmt.Sprintf(",netdev=%s", netdev.ID))
 	deviceParams = append(deviceParams, fmt.Sprintf(",mac=%s", netdev.MACAddress))

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -143,7 +143,7 @@ func TestAppendDeviceNetwork(t *testing.T) {
 	testAppend(netdev, deviceNetworkString, t)
 }
 
-var deviceNetworkPCIString = "-device virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,bus=/pci-bus/pcie.0,addr=ff -netdev tap,id=tap0,ifname=ceth0,downscript=no,script=no,fds=3:4,vhost=on"
+var deviceNetworkPCIString = "-device driver=virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,bus=/pci-bus/pcie.0,addr=ff -netdev tap,id=tap0,ifname=ceth0,downscript=no,script=no,fds=3:4,vhost=on"
 
 func TestAppendDeviceNetworkPCI(t *testing.T) {
 	foo, _ := ioutil.TempFile(os.TempDir(), "qemu-ciao-test")


### PR DESCRIPTION
In case of a network device, and specifically virtio-net-pci, we need
to update to what is expected by qemu. In this case, the driver name
should be prefixed with "driver=".