### PR TITLE
ciao-controller: Respect http.Error()s requirements

### DIFF
--- a/ciao-controller/api/api.go
+++ b/ciao-controller/api/api.go
@@ -129,15 +129,18 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		b, err := json.Marshal(code)
 		if err != nil {
 			http.Error(w, http.StatusText(resp.status), resp.status)
+			return
 		}
 
 		http.Error(w, string(b), resp.status)
+		return
 	}
 
 	b, err := json.Marshal(resp.response)
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError),
 			http.StatusInternalServerError)
+		return
 	}
 
 	w.Header().Set("Content-Type", contentType)

--- a/ciao-controller/legacy_api.go
+++ b/ciao-controller/legacy_api.go
@@ -59,15 +59,18 @@ func (h legacyAPIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		b, err := json.Marshal(code)
 		if err != nil {
 			http.Error(w, http.StatusText(resp.status), resp.status)
+			return
 		}
 
 		http.Error(w, string(b), resp.status)
+		return
 	}
 
 	b, err := json.Marshal(resp.response)
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError),
 			http.StatusInternalServerError)
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/openstack/block/api.go
+++ b/openstack/block/api.go
@@ -381,6 +381,7 @@ func (h APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	b, err := json.Marshal(resp.response)
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/openstack/compute/api.go
+++ b/openstack/compute/api.go
@@ -495,12 +495,14 @@ func (h APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		http.Error(w, string(b), resp.Status)
+		return
 	}
 
 	b, err := json.Marshal(resp.Response)
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError),
 			http.StatusInternalServerError)
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/openstack/image/api.go
+++ b/openstack/image/api.go
@@ -278,11 +278,13 @@ func (h APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	resp, err := h.Handler(h.Context, w, r)
 	if err != nil {
 		http.Error(w, err.Error(), resp.status)
+		return
 	}
 
 	b, err := json.Marshal(resp.response)
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/openstack/image/api_test.go
+++ b/openstack/image/api_test.go
@@ -60,7 +60,7 @@ var tests = []test{
 		createImage,
 		"",
 		http.StatusInternalServerError,
-		fmt.Sprintf("unexpected end of JSON input\nnull"),
+		fmt.Sprintf("unexpected end of JSON input\n"),
 	},
 	{
 		"GET",


### PR DESCRIPTION
http.Error() documentation says "Error replies to the request with the
specified error message and HTTP code. It does not otherwise end the
request; the caller should ensure no further writes are done to w. The
error message should be plain text."

This change ensures that in all codepaths where http.Error() is used
nothing else is written to the the http.ResponseWriter. In all cases
this is achieved by returning early.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>