### PR TITLE
Remove gophercloud API use

### DIFF
--- a/ciao-cli/external_ips.go
+++ b/ciao-cli/external_ips.go
@@ -46,7 +46,7 @@ func getExternalIPRef(address string) (string, error) {
 		return "", err
 	}
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		return "", err
 	}
@@ -132,7 +132,7 @@ func (cmd *externalIPMapCommand) run(args []string) error {
 		fatalf(err.Error())
 	}
 
-	resp, err := sendCiaoRequest("POST", url, nil, body, &ver)
+	resp, err := sendCiaoRequest("POST", url, nil, body, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -179,7 +179,7 @@ func (cmd *externalIPListCommand) run(args []string) error {
 		fatalf(err.Error())
 	}
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -268,7 +268,7 @@ func (cmd *externalIPUnMapCommand) run(args []string) error {
 
 	ver := api.ExternalIPsV1
 
-	resp, err := sendCiaoRequest("DELETE", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("DELETE", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -319,7 +319,7 @@ func getCiaoPoolRef(name string) (string, error) {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("GET", url, []queryValue{query}, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, []queryValue{query}, nil, ver)
 	if err != nil {
 		return "", err
 	}
@@ -353,7 +353,7 @@ func getCiaoPool(name string) (types.Pool, error) {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		return pool, err
 	}
@@ -414,7 +414,7 @@ func (cmd *poolCreateCommand) run(args []string) error {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("POST", url, nil, body, &ver)
+	resp, err := sendCiaoRequest("POST", url, nil, body, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -467,7 +467,7 @@ func (cmd *poolListCommand) run(args []string) error {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -621,7 +621,7 @@ func (cmd *poolDeleteCommand) run(args []string) error {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("DELETE", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("DELETE", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -720,7 +720,7 @@ func (cmd *poolAddCommand) run(args []string) error {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("POST", url, nil, body, &ver)
+	resp, err := sendCiaoRequest("POST", url, nil, body, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -823,7 +823,7 @@ func (cmd *poolRemoveCommand) run(args []string) error {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("DELETE", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("DELETE", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}

--- a/ciao-cli/identity.go
+++ b/ciao-cli/identity.go
@@ -180,7 +180,7 @@ func getUserProjects(username string, password string) ([]Project, error) {
 
 	identity := fmt.Sprintf("%s/v3/users/%s/projects", *identityURL, user)
 
-	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil, nil)
+	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func getAllProjects(username string, password string) (*IdentityProjects, error)
 
 	identity := fmt.Sprintf("%s/v3/auth/projects", *identityURL)
 
-	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil, nil)
+	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil, "")
 	if err != nil {
 		return nil, err
 	}

--- a/ciao-cli/image.go
+++ b/ciao-cli/image.go
@@ -343,9 +343,8 @@ func uploadTenantImage(username, password, tenant, image, filename string) error
 	}
 	defer file.Close()
 
-	contentType := "octet-stream"
 	url := buildImageURL("images/%s/file", image)
-	resp, err := sendHTTPRequestToken("PUT", url, nil, scopedToken, file, &contentType)
+	resp, err := sendHTTPRequestToken("PUT", url, nil, scopedToken, file, "octet-stream")
 	defer func() { _ = resp.Body.Close() }()
 
 	return err

--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/01org/ciao/ciao-controller/api"
 	"github.com/01org/ciao/ciao-controller/types"
+	"github.com/01org/ciao/openstack/block"
 	"github.com/golang/glog"
 )
 
@@ -172,6 +173,11 @@ func buildComputeURL(format string, args ...interface{}) string {
 
 func buildCiaoURL(format string, args ...interface{}) string {
 	prefix := fmt.Sprintf("https://%s:%d/", *controllerURL, *ciaoPort)
+	return fmt.Sprintf(prefix+format, args...)
+}
+
+func buildBlockURL(format string, args ...interface{}) string {
+	prefix := fmt.Sprintf("https://%s:%d/v2/", *controllerURL, block.APIPort)
 	return fmt.Sprintf(prefix+format, args...)
 }
 

--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/01org/ciao/ciao-controller/api"
 	"github.com/01org/ciao/ciao-controller/types"
 	"github.com/01org/ciao/openstack/block"
+	"github.com/01org/ciao/openstack/image"
 	"github.com/golang/glog"
 )
 
@@ -178,6 +179,11 @@ func buildCiaoURL(format string, args ...interface{}) string {
 
 func buildBlockURL(format string, args ...interface{}) string {
 	prefix := fmt.Sprintf("https://%s:%d/v2/", *controllerURL, block.APIPort)
+	return fmt.Sprintf(prefix+format, args...)
+}
+
+func buildImageURL(format string, args ...interface{}) string {
+	prefix := fmt.Sprintf("https://%s:%d/v2/", *controllerURL, image.APIPort)
 	return fmt.Sprintf(prefix+format, args...)
 }
 

--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -187,7 +187,7 @@ func buildImageURL(format string, args ...interface{}) string {
 	return fmt.Sprintf(prefix+format, args...)
 }
 
-func sendHTTPRequestToken(method string, url string, values []queryValue, token string, body io.Reader, content *string) (*http.Response, error) {
+func sendHTTPRequestToken(method string, url string, values []queryValue, token string, body io.Reader, content string) (*http.Response, error) {
 	req, err := http.NewRequest(method, os.ExpandEnv(url), body)
 	if err != nil {
 		return nil, err
@@ -210,8 +210,8 @@ func sendHTTPRequestToken(method string, url string, values []queryValue, token 
 		req.Header.Add("X-Auth-Token", token)
 	}
 
-	if content != nil {
-		contentType := fmt.Sprintf("application/%s", *content)
+	if content != "" {
+		contentType := fmt.Sprintf("application/%s", content)
 		req.Header.Set("Content-Type", contentType)
 		req.Header.Set("Accept", contentType)
 	} else if body != nil {
@@ -253,7 +253,7 @@ func sendHTTPRequestToken(method string, url string, values []queryValue, token 
 }
 
 func sendHTTPRequest(method string, url string, values []queryValue, body io.Reader) (*http.Response, error) {
-	return sendHTTPRequestToken(method, url, values, scopedToken, body, nil)
+	return sendHTTPRequestToken(method, url, values, scopedToken, body, "")
 }
 
 func unmarshalHTTPResponse(resp *http.Response, v interface{}) error {
@@ -278,7 +278,7 @@ func unmarshalHTTPResponse(resp *http.Response, v interface{}) error {
 	return nil
 }
 
-func sendCiaoRequest(method string, url string, values []queryValue, body io.Reader, content *string) (*http.Response, error) {
+func sendCiaoRequest(method string, url string, values []queryValue, body io.Reader, content string) (*http.Response, error) {
 	return sendHTTPRequestToken(method, url, values, scopedToken, body, content)
 }
 
@@ -301,7 +301,7 @@ func getCiaoResource(name string, minVersion string) (string, error) {
 		url = buildCiaoURL(fmt.Sprintf("%s", *tenantID))
 	}
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, nil)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, "")
 	if err != nil {
 		return "", err
 	}

--- a/ciao-cli/quotas.go
+++ b/ciao-cli/quotas.go
@@ -123,7 +123,7 @@ func (cmd *quotasUpdateCommand) run(args []string) error {
 	ver := api.TenantsV1
 
 	url = fmt.Sprintf("%s/%s/quotas", url, cmd.tenantID)
-	resp, err := sendCiaoRequest("PUT", url, nil, body, &ver)
+	resp, err := sendCiaoRequest("PUT", url, nil, body, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -194,7 +194,7 @@ func (cmd *quotasListCommand) run(args []string) error {
 	}
 	ver := api.TenantsV1
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}

--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -334,7 +334,7 @@ func (cmd *workloadCreateCommand) run(args []string) error {
 
 	ver := api.WorkloadsV1
 
-	resp, err := sendCiaoRequest("POST", url, nil, body, &ver)
+	resp, err := sendCiaoRequest("POST", url, nil, body, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -397,7 +397,7 @@ func (cmd *workloadDeleteCommand) run(args []string) error {
 	// just hard code the path.
 	url = fmt.Sprintf("%s/%s", url, cmd.workload)
 
-	resp, err := sendCiaoRequest("DELETE", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("DELETE", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -455,7 +455,7 @@ func (cmd *workloadShowCommand) run(args []string) error {
 	// just hard code the path.
 	url = fmt.Sprintf("%s/%s", url, cmd.workload)
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}


### PR DESCRIPTION
This is the first stage in decoupling ourselves from our keystone requirement by pushing all HTTP requests through the ciao-cli sendHttpRequest() call where it will be possible to use HTTP basic authentication.
