### PR TITLE
Put all HTTP services on Ciao port

### DIFF
--- a/ciao-cli/README.md
+++ b/ciao-cli/README.md
@@ -21,8 +21,6 @@ The options are:
         log to standard error as well as files
   -ca-file string
         CA Certificate
-  -computeport int
-        Openstack Compute API port (default 8774)
   -controller string
         Controller URL
   -identity string
@@ -72,7 +70,6 @@ credentials and networking information:
 
 * `CIAO_CONTROLLER` exports the Ciao controller URL
 * `CIAO_IDENTITY` exports the Ciao keystone instance URL
-* `CIAO_COMPUTEPORT` exports the Ciao compute alternative port
 * `CIAO_USERNAME` exports the Ciao username
 * `CIAO_PASSWORD` export the Ciao password for `CIAO_USERNAME`
 * `CIAO_TENANT_NAME` export the Ciao tenant name for `CIAO_USERNAME`

--- a/ciao-cli/external_ips.go
+++ b/ciao-cli/external_ips.go
@@ -46,7 +46,7 @@ func getExternalIPRef(address string) (string, error) {
 		return "", err
 	}
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		return "", err
 	}
@@ -132,7 +132,7 @@ func (cmd *externalIPMapCommand) run(args []string) error {
 		fatalf(err.Error())
 	}
 
-	resp, err := sendCiaoRequest("POST", url, nil, body, &ver)
+	resp, err := sendCiaoRequest("POST", url, nil, body, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -179,7 +179,7 @@ func (cmd *externalIPListCommand) run(args []string) error {
 		fatalf(err.Error())
 	}
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -268,7 +268,7 @@ func (cmd *externalIPUnMapCommand) run(args []string) error {
 
 	ver := api.ExternalIPsV1
 
-	resp, err := sendCiaoRequest("DELETE", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("DELETE", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -319,7 +319,7 @@ func getCiaoPoolRef(name string) (string, error) {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("GET", url, []queryValue{query}, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, []queryValue{query}, nil, ver)
 	if err != nil {
 		return "", err
 	}
@@ -353,7 +353,7 @@ func getCiaoPool(name string) (types.Pool, error) {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		return pool, err
 	}
@@ -414,7 +414,7 @@ func (cmd *poolCreateCommand) run(args []string) error {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("POST", url, nil, body, &ver)
+	resp, err := sendCiaoRequest("POST", url, nil, body, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -467,7 +467,7 @@ func (cmd *poolListCommand) run(args []string) error {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -621,7 +621,7 @@ func (cmd *poolDeleteCommand) run(args []string) error {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("DELETE", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("DELETE", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -720,7 +720,7 @@ func (cmd *poolAddCommand) run(args []string) error {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("POST", url, nil, body, &ver)
+	resp, err := sendCiaoRequest("POST", url, nil, body, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -823,7 +823,7 @@ func (cmd *poolRemoveCommand) run(args []string) error {
 
 	ver := api.PoolsV1
 
-	resp, err := sendCiaoRequest("DELETE", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("DELETE", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}

--- a/ciao-cli/identity.go
+++ b/ciao-cli/identity.go
@@ -180,7 +180,7 @@ func getUserProjects(username string, password string) ([]Project, error) {
 
 	identity := fmt.Sprintf("%s/v3/users/%s/projects", *identityURL, user)
 
-	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil, nil)
+	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func getAllProjects(username string, password string) (*IdentityProjects, error)
 
 	identity := fmt.Sprintf("%s/v3/auth/projects", *identityURL)
 
-	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil, nil)
+	resp, err := sendHTTPRequestToken("GET", identity, nil, token, nil, "")
 	if err != nil {
 		return nil, err
 	}

--- a/ciao-cli/image.go
+++ b/ciao-cli/image.go
@@ -343,9 +343,8 @@ func uploadTenantImage(username, password, tenant, image, filename string) error
 	}
 	defer file.Close()
 
-	contentType := "octet-stream"
 	url := buildImageURL("images/%s/file", image)
-	resp, err := sendHTTPRequestToken("PUT", url, nil, scopedToken, file, &contentType)
+	resp, err := sendHTTPRequestToken("PUT", url, nil, scopedToken, file, "octet-stream")
 	defer func() { _ = resp.Body.Close() }()
 
 	return err

--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -33,8 +33,6 @@ import (
 
 	"github.com/01org/ciao/ciao-controller/api"
 	"github.com/01org/ciao/ciao-controller/types"
-	"github.com/01org/ciao/openstack/block"
-	"github.com/01org/ciao/openstack/image"
 	"github.com/golang/glog"
 )
 
@@ -168,7 +166,7 @@ func dumpJSON(body interface{}) {
 }
 
 func buildComputeURL(format string, args ...interface{}) string {
-	prefix := fmt.Sprintf("https://%s:%d/%s/", *controllerURL, *computePort, openstackComputeVersion)
+	prefix := fmt.Sprintf("https://%s:%d/%s/", *controllerURL, *ciaoPort, openstackComputeVersion)
 	return fmt.Sprintf(prefix+format, args...)
 }
 
@@ -178,12 +176,12 @@ func buildCiaoURL(format string, args ...interface{}) string {
 }
 
 func buildBlockURL(format string, args ...interface{}) string {
-	prefix := fmt.Sprintf("https://%s:%d/v2/", *controllerURL, block.APIPort)
+	prefix := fmt.Sprintf("https://%s:%d/v2/", *controllerURL, *ciaoPort)
 	return fmt.Sprintf(prefix+format, args...)
 }
 
 func buildImageURL(format string, args ...interface{}) string {
-	prefix := fmt.Sprintf("https://%s:%d/v2/", *controllerURL, image.APIPort)
+	prefix := fmt.Sprintf("https://%s:%d/v2/", *controllerURL, *ciaoPort)
 	return fmt.Sprintf(prefix+format, args...)
 }
 

--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -28,7 +28,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"strconv"
 	"text/template"
 
 	"github.com/01org/ciao/ciao-controller/api"
@@ -99,9 +98,6 @@ var commands = map[string]subCommand{
 
 var scopedToken string
 
-const openstackComputePort = 8774
-const openstackComputeVersion = "v2.1"
-
 func infof(format string, args ...interface{}) {
 	if glog.V(1) {
 		glog.InfoDepth(1, fmt.Sprintf("ciao-cli INFO: "+format, args...))
@@ -127,19 +123,17 @@ var (
 	controllerURL    = flag.String("controller", "", "Controller URL")
 	tenantID         = flag.String("tenant-id", "", "Tenant UUID")
 	tenantName       = flag.String("tenant-name", "", "Tenant name")
-	computePort      = flag.Int("computeport", openstackComputePort, "Openstack Compute API port")
 	ciaoPort         = flag.Int("ciaoport", api.Port, "ciao API port")
 	caCertFile       = flag.String("ca-file", "", "CA Certificate")
 )
 
 const (
-	ciaoIdentityEnv    = "CIAO_IDENTITY"
-	ciaoControllerEnv  = "CIAO_CONTROLLER"
-	ciaoUsernameEnv    = "CIAO_USERNAME"
-	ciaoPasswordEnv    = "CIAO_PASSWORD"
-	ciaoComputePortEnv = "CIAO_COMPUTEPORT"
-	ciaoTenantNameEnv  = "CIAO_TENANT_NAME"
-	ciaoCACertFileEnv  = "CIAO_CA_CERT_FILE"
+	ciaoIdentityEnv   = "CIAO_IDENTITY"
+	ciaoControllerEnv = "CIAO_CONTROLLER"
+	ciaoUsernameEnv   = "CIAO_USERNAME"
+	ciaoPasswordEnv   = "CIAO_PASSWORD"
+	ciaoTenantNameEnv = "CIAO_TENANT_NAME"
+	ciaoCACertFileEnv = "CIAO_CA_CERT_FILE"
 )
 
 var caCertPool *x509.CertPool
@@ -166,7 +160,7 @@ func dumpJSON(body interface{}) {
 }
 
 func buildComputeURL(format string, args ...interface{}) string {
-	prefix := fmt.Sprintf("https://%s:%d/%s/", *controllerURL, *ciaoPort, openstackComputeVersion)
+	prefix := fmt.Sprintf("https://%s:%d/v2.1/", *controllerURL, *ciaoPort)
 	return fmt.Sprintf(prefix+format, args...)
 }
 
@@ -339,7 +333,6 @@ func getCiaoEnvVariables() {
 	controller := os.Getenv(ciaoControllerEnv)
 	username := os.Getenv(ciaoUsernameEnv)
 	password := os.Getenv(ciaoPasswordEnv)
-	port := os.Getenv(ciaoComputePortEnv)
 	tenant := os.Getenv(ciaoTenantNameEnv)
 	ca := os.Getenv(ciaoCACertFileEnv)
 
@@ -348,7 +341,6 @@ func getCiaoEnvVariables() {
 	infof("\t%s:%s\n", ciaoControllerEnv, controller)
 	infof("\t%s:%s\n", ciaoUsernameEnv, username)
 	infof("\t%s:%s\n", ciaoPasswordEnv, password)
-	infof("\t%s:%s\n", ciaoComputePortEnv, port)
 	infof("\t%s:%s\n", ciaoTenantNameEnv, tenantName)
 	infof("\t%s:%s\n", ciaoCACertFileEnv, ca)
 
@@ -366,10 +358,6 @@ func getCiaoEnvVariables() {
 
 	if password != "" && *identityPassword == "" {
 		*identityPassword = password
-	}
-
-	if port != "" && *computePort == openstackComputePort {
-		*computePort, _ = strconv.Atoi(port)
 	}
 
 	if tenant != "" && *tenantName == "" {

--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/01org/ciao/ciao-controller/api"
 	"github.com/01org/ciao/ciao-controller/types"
+	"github.com/01org/ciao/openstack/block"
 	"github.com/golang/glog"
 )
 
@@ -172,6 +173,11 @@ func buildComputeURL(format string, args ...interface{}) string {
 
 func buildCiaoURL(format string, args ...interface{}) string {
 	prefix := fmt.Sprintf("https://%s:%d/", *controllerURL, *ciaoPort)
+	return fmt.Sprintf(prefix+format, args...)
+}
+
+func buildBlockURL(format string, args ...interface{}) string {
+	prefix := fmt.Sprintf("https://%s:%d/v2/", *controllerURL, block.APIPort)
 	return fmt.Sprintf(prefix+format, args...)
 }
 

--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/01org/ciao/ciao-controller/api"
 	"github.com/01org/ciao/ciao-controller/types"
 	"github.com/01org/ciao/openstack/block"
+	"github.com/01org/ciao/openstack/image"
 	"github.com/golang/glog"
 )
 
@@ -178,6 +179,11 @@ func buildCiaoURL(format string, args ...interface{}) string {
 
 func buildBlockURL(format string, args ...interface{}) string {
 	prefix := fmt.Sprintf("https://%s:%d/v2/", *controllerURL, block.APIPort)
+	return fmt.Sprintf(prefix+format, args...)
+}
+
+func buildImageURL(format string, args ...interface{}) string {
+	prefix := fmt.Sprintf("https://%s:%d/v2/", *controllerURL, image.APIPort)
 	return fmt.Sprintf(prefix+format, args...)
 }
 

--- a/ciao-cli/main.go
+++ b/ciao-cli/main.go
@@ -187,7 +187,7 @@ func buildImageURL(format string, args ...interface{}) string {
 	return fmt.Sprintf(prefix+format, args...)
 }
 
-func sendHTTPRequestToken(method string, url string, values []queryValue, token string, body io.Reader, content *string) (*http.Response, error) {
+func sendHTTPRequestToken(method string, url string, values []queryValue, token string, body io.Reader, content string) (*http.Response, error) {
 	req, err := http.NewRequest(method, os.ExpandEnv(url), body)
 	if err != nil {
 		return nil, err
@@ -210,8 +210,8 @@ func sendHTTPRequestToken(method string, url string, values []queryValue, token 
 		req.Header.Add("X-Auth-Token", token)
 	}
 
-	if content != nil {
-		contentType := fmt.Sprintf("application/%s", *content)
+	if content != "" {
+		contentType := fmt.Sprintf("application/%s", content)
 		req.Header.Set("Content-Type", contentType)
 		req.Header.Set("Accept", contentType)
 	} else if body != nil {
@@ -253,7 +253,7 @@ func sendHTTPRequestToken(method string, url string, values []queryValue, token 
 }
 
 func sendHTTPRequest(method string, url string, values []queryValue, body io.Reader) (*http.Response, error) {
-	return sendHTTPRequestToken(method, url, values, scopedToken, body, nil)
+	return sendHTTPRequestToken(method, url, values, scopedToken, body, "")
 }
 
 func unmarshalHTTPResponse(resp *http.Response, v interface{}) error {
@@ -278,7 +278,7 @@ func unmarshalHTTPResponse(resp *http.Response, v interface{}) error {
 	return nil
 }
 
-func sendCiaoRequest(method string, url string, values []queryValue, body io.Reader, content *string) (*http.Response, error) {
+func sendCiaoRequest(method string, url string, values []queryValue, body io.Reader, content string) (*http.Response, error) {
 	return sendHTTPRequestToken(method, url, values, scopedToken, body, content)
 }
 
@@ -301,7 +301,7 @@ func getCiaoResource(name string, minVersion string) (string, error) {
 		url = buildCiaoURL(fmt.Sprintf("%s", *tenantID))
 	}
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, nil)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, "")
 	if err != nil {
 		return "", err
 	}

--- a/ciao-cli/quotas.go
+++ b/ciao-cli/quotas.go
@@ -123,7 +123,7 @@ func (cmd *quotasUpdateCommand) run(args []string) error {
 	ver := api.TenantsV1
 
 	url = fmt.Sprintf("%s/%s/quotas", url, cmd.tenantID)
-	resp, err := sendCiaoRequest("PUT", url, nil, body, &ver)
+	resp, err := sendCiaoRequest("PUT", url, nil, body, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -194,7 +194,7 @@ func (cmd *quotasListCommand) run(args []string) error {
 	}
 	ver := api.TenantsV1
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}

--- a/ciao-cli/workload.go
+++ b/ciao-cli/workload.go
@@ -334,7 +334,7 @@ func (cmd *workloadCreateCommand) run(args []string) error {
 
 	ver := api.WorkloadsV1
 
-	resp, err := sendCiaoRequest("POST", url, nil, body, &ver)
+	resp, err := sendCiaoRequest("POST", url, nil, body, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -397,7 +397,7 @@ func (cmd *workloadDeleteCommand) run(args []string) error {
 	// just hard code the path.
 	url = fmt.Sprintf("%s/%s", url, cmd.workload)
 
-	resp, err := sendCiaoRequest("DELETE", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("DELETE", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}
@@ -455,7 +455,7 @@ func (cmd *workloadShowCommand) run(args []string) error {
 	// just hard code the path.
 	url = fmt.Sprintf("%s/%s", url, cmd.workload)
 
-	resp, err := sendCiaoRequest("GET", url, nil, nil, &ver)
+	resp, err := sendCiaoRequest("GET", url, nil, nil, ver)
 	if err != nil {
 		fatalf(err.Error())
 	}

--- a/ciao-controller/api/api.go
+++ b/ciao-controller/api/api.go
@@ -610,11 +610,13 @@ type Config struct {
 // since we only have one version of this api so far, that means
 // most routes will match both json as well as our custom
 // content type.
-func Routes(config Config) *mux.Router {
+func Routes(config Config, r *mux.Router) *mux.Router {
 	// make new Context
 	context := &Context{config.URL, config.CiaoService}
 
-	r := mux.NewRouter()
+	if r == nil {
+		r = mux.NewRouter()
+	}
 
 	// external IP pools
 	route := r.Handle("/", Handler{context, listResources, true})

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -297,7 +297,7 @@ func (ts testCiaoService) UpdateQuotas(tenantID string, qds []types.QuotaDetails
 func TestResponse(t *testing.T) {
 	var ts testCiaoService
 
-	mux := Routes(Config{"", ts})
+	mux := Routes(Config{"", ts}, nil)
 
 	for i, tt := range tests {
 		req, err := http.NewRequest(tt.method, tt.request, bytes.NewBuffer([]byte(tt.requestBody)))
@@ -327,7 +327,7 @@ func TestRoutes(t *testing.T) {
 	var ts testCiaoService
 	config := Config{"", ts}
 
-	r := Routes(config)
+	r := Routes(config, nil)
 	if r == nil {
 		t.Fatalf("No routes returned")
 	}

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -1991,10 +1991,13 @@ func TestMain(m *testing.M) {
 	}
 
 	_, _ = addComputeTestTenant()
-	s, _ := ctl.createComputeServer()
-	go s.ListenAndServeTLS(httpsCAcert, httpsKey)
-	time.Sleep(1 * time.Second)
-	s, _ = ctl.createVolumeServer()
+
+	s, err := ctl.createCiaoServer()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating ciao server: %v", err)
+		os.Exit(1)
+	}
+
 	go s.ListenAndServeTLS(httpsCAcert, httpsKey)
 	time.Sleep(1 * time.Second)
 

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -113,6 +113,7 @@ func main() {
 	ctl.tenantReadiness = make(map[string]*tenantConfirmMemo)
 	ctl.ds = new(datastore.Datastore)
 	ctl.qs = new(quotas.Quotas)
+	ctl.is = new(ImageService)
 
 	dsConfig := datastore.Config{
 		PersistentURI:     "file:" + *persistentDatastoreLocation,
@@ -170,6 +171,10 @@ func main() {
 
 	if clusterConfig.Configure.Controller.AdminPassword != "" {
 		adminPassword = clusterConfig.Configure.Controller.AdminPassword
+	}
+
+	if err := ctl.is.Init(ctl.qs); err != nil {
+		glog.Fatalf("Error initialising image service: %v", err)
 	}
 
 	ctl.ds.GenerateCNCIWorkload(cnciVCPUs, cnciMem, cnciDisk, adminSSHKey, adminPassword)

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -33,8 +33,6 @@ import (
 	storage "github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/clogger/gloginterface"
 	"github.com/01org/ciao/database"
-	"github.com/01org/ciao/openstack/block"
-	"github.com/01org/ciao/openstack/compute"
 	osIdentity "github.com/01org/ciao/openstack/identity"
 	"github.com/01org/ciao/osprepare"
 	"github.com/01org/ciao/ssntp"
@@ -67,8 +65,6 @@ var serverURL = flag.String("url", "", "Server URL")
 var identityURL = "identity:35357"
 var serviceUser = "csr"
 var servicePassword = ""
-var volumeAPIPort = block.APIPort
-var computeAPIPort = compute.APIPort
 var controllerAPIPort = api.Port
 var httpsCAcert = "/etc/pki/ciao/ciao-controller-cacert.pem"
 var httpsKey = "/etc/pki/ciao/ciao-controller-key.pem"
@@ -151,8 +147,6 @@ func main() {
 		return
 	}
 
-	volumeAPIPort = clusterConfig.Configure.Controller.VolumePort
-	computeAPIPort = clusterConfig.Configure.Controller.ComputePort
 	controllerAPIPort = clusterConfig.Configure.Controller.CiaoPort
 	httpsCAcert = clusterConfig.Configure.Controller.HTTPSCACert
 	httpsKey = clusterConfig.Configure.Controller.HTTPSKey

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 	"regexp"
 	"sort"
 	"strconv"
@@ -626,24 +625,4 @@ func (c *controller) createComputeRoutes(r *mux.Router) error {
 	})
 
 	return err
-}
-
-// Start will get the Compute API endpoints from the OpenStack compute api,
-// then wrap them in keystone validation.
-func (c *controller) createComputeServer() (*http.Server, error) {
-	r := mux.NewRouter()
-
-	err := c.createComputeRoutes(r)
-	if err != nil {
-		return nil, err
-	}
-
-	service := fmt.Sprintf(":%d", computeAPIPort)
-
-	server := &http.Server{
-		Handler: r,
-		Addr:    service,
-	}
-
-	return server, nil
 }

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -593,7 +593,7 @@ func (c *controller) ShowFlavorDetails(tenant string, flavorID string) (compute.
 	return flavor, nil
 }
 func (c *controller) createComputeRoutes(r *mux.Router) error {
-	config := compute.APIConfig{Port: computeAPIPort, ComputeService: c}
+	config := compute.APIConfig{ComputeService: c}
 	r = compute.Routes(config, r)
 
 	// we add on some ciao specific routes for legacy purposes

--- a/ciao-controller/openstack_image.go
+++ b/ciao-controller/openstack_image.go
@@ -290,16 +290,14 @@ type ImageConfig struct {
 	MetaDataStore imageDatastore.MetaDataStore
 }
 
-// createImageServer will get the Image API endpoints from the OpenStack image api,
-// then wrap them in keystone validation.
-func (c *controller) createImageServer() (*http.Server, error) {
+func (c *controller) createImageRoutes(r *mux.Router) error {
 	apiConfig := image.APIConfig{
 		Port:         image.APIPort,
 		ImageService: c.is,
 	}
 
 	// get our routes.
-	r := image.Routes(apiConfig, c.id.scV3)
+	image.Routes(apiConfig, c.id.scV3, r)
 
 	// setup identity for these routes.
 	validServices := []osIdentity.ValidService{
@@ -323,6 +321,16 @@ func (c *controller) createImageServer() (*http.Server, error) {
 		route.Handler(h)
 		return nil
 	})
+
+	return err
+}
+
+// createImageServer will get the Image API endpoints from the OpenStack image api,
+// then wrap them in keystone validation.
+func (c *controller) createImageServer() (*http.Server, error) {
+	r := mux.NewRouter()
+
+	err := c.createImageRoutes(r)
 	if err != nil {
 		return nil, err
 	}

--- a/ciao-controller/openstack_image.go
+++ b/ciao-controller/openstack_image.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"net/http"
 	"path/filepath"
 	"strings"
 	"time"
@@ -323,24 +322,4 @@ func (c *controller) createImageRoutes(r *mux.Router) error {
 	})
 
 	return err
-}
-
-// createImageServer will get the Image API endpoints from the OpenStack image api,
-// then wrap them in keystone validation.
-func (c *controller) createImageServer() (*http.Server, error) {
-	r := mux.NewRouter()
-
-	err := c.createImageRoutes(r)
-	if err != nil {
-		return nil, err
-	}
-
-	service := fmt.Sprintf(":%d", image.APIPort)
-
-	server := &http.Server{
-		Handler: r,
-		Addr:    service,
-	}
-
-	return server, nil
 }

--- a/ciao-controller/openstack_image.go
+++ b/ciao-controller/openstack_image.go
@@ -247,7 +247,6 @@ func (is *ImageService) Init(qs *quotas.Quotas) error {
 	glog.Infof("ID           : %v", rawDs.BlockDriver.ID)
 
 	config := ImageConfig{
-		Port:          image.APIPort,
 		HTTPSCACert:   httpsCAcert,
 		HTTPSKey:      httpsKey,
 		RawDataStore:  rawDs,
@@ -255,7 +254,6 @@ func (is *ImageService) Init(qs *quotas.Quotas) error {
 	}
 
 	glog.Info("ciao-image - Configuration")
-	glog.Infof("Port          : %v", config.Port)
 	glog.Infof("HTTPSCACert   : %v", config.HTTPSCACert)
 	glog.Infof("HTTPSKey      : %v", config.HTTPSKey)
 	glog.Infof("RawDataStore  : %T", config.RawDataStore)
@@ -273,9 +271,6 @@ func (is *ImageService) Init(qs *quotas.Quotas) error {
 
 // ImageConfig is required to setup the API context for the image service.
 type ImageConfig struct {
-	// Port represents the http port that should be used for the service.
-	Port int
-
 	// HTTPSCACert is the path to the http ca cert to use.
 	HTTPSCACert string
 
@@ -291,7 +286,6 @@ type ImageConfig struct {
 
 func (c *controller) createImageRoutes(r *mux.Router) error {
 	apiConfig := image.APIConfig{
-		Port:         image.APIPort,
 		ImageService: c.is,
 	}
 

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -424,16 +424,10 @@ func (c *controller) ShowVolumeDetails(tenant string, volume string) (block.Volu
 	return vol, nil
 }
 
-// Start will get the Volume API endpoints from the OpenStack block api,
-// then wrap them in keystone validation. It will then start the https
-// service.
-func (c *controller) createVolumeServer() (*http.Server, error) {
+func (c *controller) createVolumeRoutes(r *mux.Router) error {
 	config := block.APIConfig{Port: volumeAPIPort, VolService: c}
 
-	r := block.Routes(config)
-	if r == nil {
-		return nil, errors.New("Unable to start Volume Service")
-	}
+	r = block.Routes(config, r)
 
 	// setup identity for these routes.
 	validServices := []osIdentity.ValidService{
@@ -461,6 +455,16 @@ func (c *controller) createVolumeServer() (*http.Server, error) {
 		return nil
 	})
 
+	return err
+}
+
+// Start will get the Volume API endpoints from the OpenStack block api,
+// then wrap them in keystone validation. It will then start the https
+// service.
+func (c *controller) createVolumeServer() (*http.Server, error) {
+	r := mux.NewRouter()
+
+	err := c.createVolumeRoutes(r)
 	if err != nil {
 		return nil, err
 	}

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -423,7 +423,7 @@ func (c *controller) ShowVolumeDetails(tenant string, volume string) (block.Volu
 }
 
 func (c *controller) createVolumeRoutes(r *mux.Router) error {
-	config := block.APIConfig{Port: volumeAPIPort, VolService: c}
+	config := block.APIConfig{VolService: c}
 
 	r = block.Routes(config, r)
 

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
-	"net/http"
 	"strconv"
 	"time"
 
@@ -456,25 +454,4 @@ func (c *controller) createVolumeRoutes(r *mux.Router) error {
 	})
 
 	return err
-}
-
-// Start will get the Volume API endpoints from the OpenStack block api,
-// then wrap them in keystone validation. It will then start the https
-// service.
-func (c *controller) createVolumeServer() (*http.Server, error) {
-	r := mux.NewRouter()
-
-	err := c.createVolumeRoutes(r)
-	if err != nil {
-		return nil, err
-	}
-
-	service := fmt.Sprintf(":%d", block.APIPort)
-
-	server := &http.Server{
-		Handler: r,
-		Addr:    service,
-	}
-
-	return server, nil
 }

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -63,8 +63,6 @@ const fullValidConf = `configure:
   storage:
     ceph_id: ciao
   controller:
-    volume_port: 8776
-    compute_port: 8774
     ciao_port: 8889
     compute_fqdn: ""
     compute_ca: /etc/pki/ciao/compute_ca.pem
@@ -181,9 +179,7 @@ func TestPayloadCorrectBlob(t *testing.T) {
 }
 
 func saneDefaults(conf *payloads.Configure) bool {
-	return (conf.Configure.Controller.VolumePort == 8776 &&
-		conf.Configure.Controller.ComputePort == 8774 &&
-		conf.Configure.Controller.CiaoPort == 8889 &&
+	return (conf.Configure.Controller.CiaoPort == 8889 &&
 		conf.Configure.IdentityService.Type == payloads.Keystone &&
 		conf.Configure.Launcher.DiskLimit == true &&
 		conf.Configure.Launcher.MemoryLimit == true)

--- a/openstack/block/api.go
+++ b/openstack/block/api.go
@@ -24,9 +24,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// APIPort is the standard OpenStack Volume port
-const APIPort = 8776
-
 // VersionStatus defines whether a reported version is supported or not.
 type VersionStatus string
 
@@ -329,7 +326,6 @@ func errorResponse(err error) APIResponse {
 
 // APIConfig contains information needed to start the block api service.
 type APIConfig struct {
-	Port       int     // the https port of the block api service
 	VolService Service // the service interface
 }
 
@@ -350,7 +346,6 @@ type Service interface {
 // Context contains data and interfaces that the block api will need.
 // TBD: do we really need this, or is just a service interface sufficient?
 type Context struct {
-	port int
 	Service
 }
 
@@ -578,7 +573,7 @@ func volumeAction(bc *Context, w http.ResponseWriter, r *http.Request) (APIRespo
 // Routes provides gorilla mux routes for the supported endpoints.
 func Routes(config APIConfig, r *mux.Router) *mux.Router {
 	// make new Context
-	context := &Context{config.Port, config.VolService}
+	context := &Context{config.VolService}
 
 	if r == nil {
 		r = mux.NewRouter()

--- a/openstack/block/api.go
+++ b/openstack/block/api.go
@@ -665,11 +665,13 @@ func volumeAction(bc *Context, w http.ResponseWriter, r *http.Request) (APIRespo
 }
 
 // Routes provides gorilla mux routes for the supported endpoints.
-func Routes(config APIConfig) *mux.Router {
+func Routes(config APIConfig, r *mux.Router) *mux.Router {
 	// make new Context
 	context := &Context{config.Port, config.VolService}
 
-	r := mux.NewRouter()
+	if r == nil {
+		r = mux.NewRouter()
+	}
 
 	// API versions
 	r.Handle("/", APIHandler{context, listAPIVersions}).Methods("GET")

--- a/openstack/block/api_test.go
+++ b/openstack/block/api_test.go
@@ -296,7 +296,7 @@ func TestRoutes(t *testing.T) {
 	var vs testVolumeService
 	config := APIConfig{8776, vs}
 
-	r := Routes(config)
+	r := Routes(config, nil)
 	if r == nil {
 		t.Fatalf("No routes returned")
 	}

--- a/openstack/block/api_test.go
+++ b/openstack/block/api_test.go
@@ -16,7 +16,6 @@ package block
 
 import (
 	"bytes"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -39,22 +38,6 @@ func myHostname() string {
 }
 
 var tests = []test{
-	{
-		"GET",
-		"/",
-		listAPIVersions,
-		"",
-		http.StatusOK,
-		`{"versions":[{"status":"SUPPORTED","updated":"2014-06-28T12:20:21Z","links":[{"href":"http://docs.openstack.org/","type":"text/html","rel":"describedby"},{"href":"` + fmt.Sprintf("https://%s:8776/v2/", myHostname()) + `","rel":"self"}],"min_version":"","version":"","media-types":[{"base":"application/json","type":"application/vnd.openstack.volume+json;version=1"}],"id":"v2.0"}]}`,
-	},
-	{
-		"GET",
-		"/v2",
-		showAPIv2Details,
-		"",
-		http.StatusOK,
-		`{"choices":[{"status":"CURRENT","media-types":[{"base":"application/json","type":"application/vnd.openstack.volume+json;version=1"}],"id":"v2.0","links":[{"href":"` + fmt.Sprintf("https://%s:8776/v2/v2.json", myHostname()) + `","rel":"self"}]}]}`,
-	},
 	{
 		"GET",
 		"/v2/validtenantid/limits",

--- a/openstack/block/api_test.go
+++ b/openstack/block/api_test.go
@@ -251,7 +251,7 @@ func TestAPIResponse(t *testing.T) {
 	// TBD: add context to test definition so it can be created per
 	// endpoint with either a pass testVolumeService or a failure
 	// one.
-	context := &Context{8776, vs}
+	context := &Context{vs}
 
 	for _, tt := range tests {
 		req, err := http.NewRequest(tt.method, tt.pattern, bytes.NewBuffer([]byte(tt.request)))
@@ -277,7 +277,7 @@ func TestAPIResponse(t *testing.T) {
 
 func TestRoutes(t *testing.T) {
 	var vs testVolumeService
-	config := APIConfig{8776, vs}
+	config := APIConfig{vs}
 
 	r := Routes(config, nil)
 	if r == nil {

--- a/openstack/compute/api.go
+++ b/openstack/compute/api.go
@@ -700,10 +700,12 @@ func showFlavorDetails(c *Context, w http.ResponseWriter, r *http.Request) (APIR
 }
 
 // Routes returns a gorilla mux router for the compute endpoints.
-func Routes(config APIConfig) *mux.Router {
+func Routes(config APIConfig, r *mux.Router) *mux.Router {
 	context := &Context{config.Port, config.ComputeService}
 
-	r := mux.NewRouter()
+	if r == nil {
+		r = mux.NewRouter()
+	}
 
 	// servers endpoints
 	r.Handle("/v2.1/{tenant}/servers",

--- a/openstack/compute/api.go
+++ b/openstack/compute/api.go
@@ -29,9 +29,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// APIPort is the OpenStack compute port
-const APIPort = 8774
-
 // PrivateAddresses contains information about a single instance network
 // interface.
 type PrivateAddresses struct {
@@ -280,7 +277,6 @@ type CreateServerRequest struct {
 
 // APIConfig contains information needed to start the compute api service.
 type APIConfig struct {
-	Port           int     // the https port of the compute api service
 	ComputeService Service // the service interface
 }
 
@@ -454,7 +450,6 @@ type HTTPReturnErrorCode struct {
 
 // Context contains information needed by the compute API service
 type Context struct {
-	port int
 	Service
 }
 
@@ -701,7 +696,7 @@ func showFlavorDetails(c *Context, w http.ResponseWriter, r *http.Request) (APIR
 
 // Routes returns a gorilla mux router for the compute endpoints.
 func Routes(config APIConfig, r *mux.Router) *mux.Router {
-	context := &Context{config.Port, config.ComputeService}
+	context := &Context{config.ComputeService}
 
 	if r == nil {
 		r = mux.NewRouter()

--- a/openstack/compute/api_test.go
+++ b/openstack/compute/api_test.go
@@ -271,7 +271,7 @@ func TestRoutes(t *testing.T) {
 	var cs testComputeService
 	config := APIConfig{8774, cs}
 
-	r := Routes(config)
+	r := Routes(config, nil)
 	if r == nil {
 		t.Fatalf("No routes returned")
 	}

--- a/openstack/compute/api_test.go
+++ b/openstack/compute/api_test.go
@@ -243,7 +243,7 @@ func TestAPIResponse(t *testing.T) {
 	// TBD: add context to test definition so it can be created per
 	// endpoint with either a pass testComputeService or a failure
 	// one.
-	context := &Context{8774, cs}
+	context := &Context{cs}
 
 	for _, tt := range tests {
 		req, err := http.NewRequest(tt.method, tt.pattern, bytes.NewBuffer([]byte(tt.request)))
@@ -269,7 +269,7 @@ func TestAPIResponse(t *testing.T) {
 
 func TestRoutes(t *testing.T) {
 	var cs testComputeService
-	config := APIConfig{8774, cs}
+	config := APIConfig{cs}
 
 	r := Routes(config, nil)
 	if r == nil {

--- a/openstack/image/api.go
+++ b/openstack/image/api.go
@@ -540,11 +540,13 @@ func deleteImage(context *Context, w http.ResponseWriter, r *http.Request) (APIR
 }
 
 // Routes provides gorilla mux routes for the supported endpoints.
-func Routes(config APIConfig, serviceClient *gophercloud.ServiceClient) *mux.Router {
+func Routes(config APIConfig, serviceClient *gophercloud.ServiceClient, r *mux.Router) *mux.Router {
 	// make new Context
 	context := &Context{config.Port, config.ImageService, serviceClient}
 
-	r := mux.NewRouter()
+	if r == nil {
+		r = mux.NewRouter()
+	}
 
 	// API versions
 	r.Handle("/", APIHandler{context, listAPIVersions}).Methods("GET")

--- a/openstack/image/api.go
+++ b/openstack/image/api.go
@@ -28,9 +28,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// APIPort is the standard OpenStack Image port
-const APIPort = 9292
-
 // TBD - are these thing shared enough between OpenStack services
 // to be pulled out to a common area?
 // ---------
@@ -234,7 +231,6 @@ type NoContentImageResponse struct {
 
 // APIConfig contains information needed to start the block api service.
 type APIConfig struct {
-	Port         int     // the https port of the block api service
 	ImageService Service // the service interface
 }
 
@@ -251,7 +247,6 @@ type Service interface {
 // Context contains data and interfaces that the image api will need.
 // TBD: do we really need this, or is just a service interface sufficient?
 type Context struct {
-	port int
 	Service
 	*gophercloud.ServiceClient
 }
@@ -506,7 +501,7 @@ func deleteImage(context *Context, w http.ResponseWriter, r *http.Request) (APIR
 // Routes provides gorilla mux routes for the supported endpoints.
 func Routes(config APIConfig, serviceClient *gophercloud.ServiceClient, r *mux.Router) *mux.Router {
 	// make new Context
-	context := &Context{config.Port, config.ImageService, serviceClient}
+	context := &Context{config.ImageService, serviceClient}
 
 	if r == nil {
 		r = mux.NewRouter()

--- a/openstack/image/api_test.go
+++ b/openstack/image/api_test.go
@@ -221,7 +221,7 @@ func TestRoutes(t *testing.T) {
 	var is testImageService
 	config := APIConfig{9292, is}
 
-	r := Routes(config, nil)
+	r := Routes(config, nil, nil)
 	if r == nil {
 		t.Fatalf("No routes returned")
 	}

--- a/openstack/image/api_test.go
+++ b/openstack/image/api_test.go
@@ -39,14 +39,6 @@ type test struct {
 
 var tests = []test{
 	{
-		"GET",
-		"/",
-		listAPIVersions,
-		"",
-		http.StatusOK,
-		`{"versions":[{"status":"CURRENT","id":"v2.3","links":[{"href":"` + fmt.Sprintf("https://%s:9292/v2/", myHostname()) + `","rel":"self"}]}]}`,
-	},
-	{
 		"POST",
 		"/v2/images",
 		createImage,

--- a/openstack/image/api_test.go
+++ b/openstack/image/api_test.go
@@ -211,7 +211,7 @@ func (is testImageService) DeleteImage(string, string) (NoContentImageResponse, 
 
 func TestRoutes(t *testing.T) {
 	var is testImageService
-	config := APIConfig{9292, is}
+	config := APIConfig{is}
 
 	r := Routes(config, nil, nil)
 	if r == nil {
@@ -225,7 +225,7 @@ func TestAPIResponse(t *testing.T) {
 	// TBD: add context to test definition so it can be created per
 	// endpoint with either a pass testVolumeService or a failure
 	// one.
-	context := &Context{9292, is, nil}
+	context := &Context{is, nil}
 
 	for _, tt := range tests {
 		req, err := http.NewRequest(tt.method, tt.pattern, bytes.NewBuffer([]byte(tt.request)))

--- a/payloads/configure.go
+++ b/payloads/configure.go
@@ -66,8 +66,6 @@ type ConfigureScheduler struct {
 // ConfigureController contains the unmarshalled configurations for the
 // controller service.
 type ConfigureController struct {
-	VolumePort       int    `yaml:"volume_port"`
-	ComputePort      int    `yaml:"compute_port"`
 	CiaoPort         int    `yaml:"ciao_port"`
 	ControllerFQDN   string `yaml:"compute_fqdn"`
 	HTTPSCACert      string `yaml:"compute_ca"`
@@ -121,8 +119,6 @@ type Configure struct {
 
 // InitDefaults initializes default vaulues for Configure structure.
 func (conf *Configure) InitDefaults() {
-	conf.Configure.Controller.VolumePort = 8776
-	conf.Configure.Controller.ComputePort = 8774
 	conf.Configure.Controller.CiaoPort = 8889
 	conf.Configure.IdentityService.Type = Keystone
 	conf.Configure.Launcher.DiskLimit = true

--- a/payloads/configure_test.go
+++ b/payloads/configure_test.go
@@ -49,15 +49,6 @@ func TestConfigureUnmarshal(t *testing.T) {
 	if cfg.Configure.Storage.CephID != testutil.ManagementID {
 		t.Errorf("Wrong launcher ceph id %v", cfg.Configure.Storage.CephID)
 	}
-
-	p, _ := strconv.Atoi(testutil.VolumePort)
-	if cfg.Configure.Controller.VolumePort != p {
-		t.Errorf("Wrong controller volume port [%d]", cfg.Configure.Controller.VolumePort)
-	}
-	p, _ = strconv.Atoi(testutil.ComputePort)
-	if cfg.Configure.Controller.ComputePort != p {
-		t.Errorf("Wrong controller compute port [%d]", cfg.Configure.Controller.ComputePort)
-	}
 }
 
 func TestConfigureMarshal(t *testing.T) {
@@ -71,11 +62,7 @@ func TestConfigureMarshal(t *testing.T) {
 	cfg.Configure.Launcher.DiskLimit = false
 	cfg.Configure.Launcher.MemoryLimit = false
 
-	p, _ := strconv.Atoi(testutil.VolumePort)
-	cfg.Configure.Controller.VolumePort = p
-	p, _ = strconv.Atoi(testutil.ComputePort)
-	cfg.Configure.Controller.ComputePort = p
-	p, _ = strconv.Atoi(testutil.CiaoPort)
+	p, _ := strconv.Atoi(testutil.CiaoPort)
 	cfg.Configure.Controller.CiaoPort = p
 	cfg.Configure.Controller.HTTPSCACert = testutil.HTTPSCACert
 	cfg.Configure.Controller.HTTPSKey = testutil.HTTPSKey

--- a/testutil/identity.go
+++ b/testutil/identity.go
@@ -24,23 +24,17 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// ComputeAPIPort is the compute service port the testutil identity service will use by default
-const ComputeAPIPort = "8774"
-
-// VolumeAPIPort is the volume service port the testutil identity service will use by default
-const VolumeAPIPort = "8776"
-
-// ImageAPIPort is the image service port the testutil identity service will use by default
-const ImageAPIPort = "9292"
+// CiaoAPIPort is the Ciao API port that API services are running on
+const CiaoAPIPort = "8889"
 
 // ComputeURL is the compute service URL the testutil identity service will use by default
-var ComputeURL = "https://localhost:" + ComputeAPIPort
+var ComputeURL = "https://localhost:" + CiaoAPIPort
 
 // VolumeURL is the volume service URL the testutil identity service will use by default
-var VolumeURL = "https://localhost:" + VolumeAPIPort
+var VolumeURL = "https://localhost:" + CiaoAPIPort
 
 // ImageURL is the image service URL the testutil identity service will use by default
-var ImageURL = "https://localhost:" + ImageAPIPort
+var ImageURL = "https://localhost:" + CiaoAPIPort
 
 // IdentityURL is the URL for the testutil identity service
 var IdentityURL string

--- a/testutil/payloads.go
+++ b/testutil/payloads.go
@@ -78,12 +78,6 @@ const IdentityUser = "controller"
 // IdentityPassword is a test password for the test identity server
 const IdentityPassword = "ciao"
 
-// VolumePort is a test port for the compute service
-const VolumePort = "446"
-
-// ComputePort is a test port for the compute service
-const ComputePort = "443"
-
 // CiaoPort is a test port for ciao's api service
 const CiaoPort = "447"
 
@@ -379,8 +373,6 @@ const ConfigureYaml = `configure:
   storage:
     ceph_id: ` + ManagementID + `
   controller:
-    volume_port: ` + VolumePort + `
-    compute_port: ` + ComputePort + `
     ciao_port: ` + CiaoPort + `
     compute_fqdn: ""
     compute_ca: ` + HTTPSCACert + `


### PR DESCRIPTION
Move all API serving and and requests to use Ciao API port rather than the separate openstack block, image and compute ports.

Follow this change with a cleanup of now unused variables.