### PR TITLE
ciao-controller: add a CNCI controller to manage CNCI lifecycle

### DIFF
--- a/ciao-controller/cnci.go
+++ b/ciao-controller/cnci.go
@@ -1,0 +1,573 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/01org/ciao/ciao-controller/types"
+	"github.com/01org/ciao/payloads"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+)
+
+// CNCIState represents specific allowed state strings
+type CNCIState string
+
+var (
+	exited CNCIState = payloads.Exited
+	active CNCIState = payloads.Running
+	failed CNCIState = payloads.ExitFailed
+)
+
+type event string
+
+var (
+	added        event = "concentrator added"
+	startFailure event = "cnci start failure"
+	removed      event = "concentrator removed"
+)
+
+var cnciEventTimeout = (2 * time.Minute)
+
+// CNCI represents a cnci instance that manages a single subnet.
+type CNCI struct {
+	instance *types.Instance
+	ctrl     *controller
+	eventCh  *chan event
+	subnet   int
+	timer    *time.Timer
+}
+
+// CNCIManager is a structure which defines a manager for CNCI instances
+// TBD: managing multiple CNCI instances.
+type CNCIManager struct {
+	tenant string
+	ctrl   *controller
+
+	// there's no reason to have separate lock for each map.
+	cnciLock sync.RWMutex
+
+	// this is a map of CNCI instance IDs to CNCI structs
+	cncis map[string]*CNCI
+
+	// this is a map of subnet (integer) to CNCI structs
+	subnets map[int]*CNCI
+}
+
+func (c *CNCI) stop() error {
+	err := transitionInstanceState(c.instance, payloads.Stopping)
+	if err != nil {
+		return err
+	}
+
+	err = c.ctrl.deleteInstance(c.instance.ID)
+	if err != nil {
+		return errors.Wrapf(err, "error deleting CNCI instance")
+	}
+
+	return nil
+}
+
+func waitForEventTimeout(ch chan event, e event, timeout time.Duration) error {
+	select {
+	case recv := <-ch:
+		if recv != e {
+			return fmt.Errorf("expecting %v got %v", e, recv)
+		}
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("timeout waiting for event %v", e)
+	}
+}
+
+func (c *CNCI) transitionState(to CNCIState) {
+	transitionInstanceState(c.instance, (string(to)))
+
+	// some state changes cause events
+	ch := c.eventCh
+
+	if ch == nil {
+		return
+	}
+
+	switch to {
+	case exited:
+		*ch <- removed
+	case active:
+		*ch <- added
+	case failed:
+		*ch <- startFailure
+	}
+}
+
+// Active will return true if the CNCI has been launched successfully
+func (c *CNCIManager) Active(ID string) bool {
+	c.cnciLock.RLock()
+	defer c.cnciLock.RUnlock()
+
+	cnci, ok := c.cncis[ID]
+	if !ok {
+		return false
+	}
+
+	return instanceActive(cnci.instance)
+}
+
+func (c *CNCIManager) launch(subnet string) (*types.Instance, error) {
+	glog.V(2).Infof("launching cnci for subnet %s", subnet)
+
+	b := make([]byte, 4)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, err
+	}
+
+	name := fmt.Sprintf("cnci-%s-%s", c.tenant, hex.EncodeToString(b))
+
+	workloadID, err := c.ctrl.ds.GetCNCIWorkloadID()
+	if err != nil {
+		return nil, err
+	}
+
+	w := types.WorkloadRequest{
+		WorkloadID: workloadID,
+		TenantID:   c.tenant,
+		Instances:  1,
+		Subnet:     subnet,
+		Name:       name,
+	}
+
+	instances, err := c.ctrl.startWorkload(w)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to Launch CNCI")
+	}
+
+	return instances[0], nil
+}
+
+// WaitForActive will launch a cnci if needed and wait for it to be active,
+// or wait for an existing cnci to become active.
+func (c *CNCIManager) WaitForActive(subnet int) error {
+	c.cnciLock.Lock()
+
+	cnci, ok := c.subnets[subnet]
+	if ok {
+		if cnci.timer != nil {
+			cnci.timer.Stop()
+			cnci.timer = nil
+		}
+
+		// subnet already exists
+		c.cnciLock.Unlock()
+
+		// block until subnet is active
+		return c.waitForActive(subnet)
+	}
+
+	glog.V(2).Infof("cnci does not exist for subnet %s", subnet)
+
+	ch := make(chan event)
+
+	cnci = &CNCI{
+		ctrl:    c.ctrl,
+		eventCh: &ch,
+		subnet:  subnet,
+	}
+
+	// we initialized the eventCh because we are going to wait for
+	// an event. Close and delete at the conclusion of this function.
+	defer func() {
+		close(ch)
+		cnci.eventCh = nil
+	}()
+
+	c.subnets[subnet] = cnci
+
+	subnetBytes := make([]byte, 2)
+	binary.BigEndian.PutUint16(subnetBytes, uint16(subnet))
+	ip := net.IPv4(172, subnetBytes[0], subnetBytes[1], 0)
+	ipNet := net.IPNet{
+		IP:   ip,
+		Mask: net.IPv4Mask(255, 255, 255, 0),
+	}
+	subnetStr := ipNet.String()
+
+	// send a launch command
+	instance, err := c.launch(subnetStr)
+	if err != nil {
+		c.cnciLock.Unlock()
+		return err
+	}
+
+	glog.V(2).Infof("AddSubnet CNCI instance is %s", instance.ID)
+
+	cnci.instance = instance
+	cnci.subnet = subnet
+
+	c.cncis[instance.ID] = cnci
+
+	c.cnciLock.Unlock()
+
+	// we release the lock before waiting because
+	// we need to be able to read the event channel.
+	return waitForEventTimeout(ch, added, cnciEventTimeout)
+}
+
+// ScheduleRemoveSubnet will kick off a timer to remove a subnet after 5 min.
+// If a subnet is requested to be used again before the timer expires, the
+// timer will get cancelled and the subnet will not be removed.
+func (c *CNCIManager) ScheduleRemoveSubnet(subnet int) error {
+	c.cnciLock.Lock()
+
+	cnci, ok := c.subnets[subnet]
+	if !ok {
+		// there is no cnci for this subnet
+		c.cnciLock.Unlock()
+		return errors.New("Subnet doesn't exist")
+	}
+
+	if cnci.timer != nil {
+		// we are already scheduled to remove
+		c.cnciLock.Unlock()
+		return nil
+	}
+
+	cnci.timer = time.AfterFunc(time.Minute*5, func() {
+		c.cnciLock.Lock()
+		cnci.timer = nil
+		c.cnciLock.Unlock()
+
+		err := c.RemoveSubnet(subnet)
+		if err != nil {
+			glog.Warningf("Unable to remove subnet: (%v)\n", err)
+		}
+	})
+
+	c.cnciLock.Unlock()
+
+	return nil
+}
+
+// RemoveSubnet is called when a subnet no longer is needed.
+// a cnci can be stopped.
+func (c *CNCIManager) RemoveSubnet(subnet int) error {
+	glog.V(2).Infof("RemoveSubnet %d", subnet)
+
+	c.cnciLock.Lock()
+
+	cnci, ok := c.subnets[subnet]
+	if !ok {
+		// there is no cnci for this subnet
+		c.cnciLock.Unlock()
+		return errors.New("Subnet doesn't exist")
+	}
+
+	delete(c.subnets, subnet)
+
+	err := cnci.stop()
+	if err != nil {
+		c.cnciLock.Unlock()
+		return err
+	}
+
+	ch := make(chan event)
+
+	cnci.eventCh = &ch
+
+	defer func() {
+		close(ch)
+		cnci.eventCh = nil
+	}()
+
+	c.cnciLock.Unlock()
+
+	return waitForEventTimeout(ch, removed, cnciEventTimeout)
+}
+
+// CNCIRemoved will move the CNCI back to the initial state
+// and send an event through the event channel.
+func (c *CNCIManager) CNCIRemoved(id string) error {
+	c.cnciLock.Lock()
+	defer c.cnciLock.Unlock()
+
+	cnci, ok := c.cncis[id]
+	if !ok {
+		return errors.New("No CNCI found")
+	}
+
+	cnci.transitionState(exited)
+
+	delete(c.cncis, cnci.instance.ID)
+
+	return nil
+}
+
+// CNCIAdded will move the CNCI into the active state
+// and send an event through the event channel.
+func (c *CNCIManager) CNCIAdded(id string) error {
+	c.cnciLock.Lock()
+	defer c.cnciLock.Unlock()
+
+	cnci, ok := c.cncis[id]
+	if !ok {
+		return errors.New("No CNCI found")
+	}
+
+	cnci.transitionState(active)
+
+	return nil
+}
+
+// StartFailure will move the CNCI to the error state and
+// send an event through the event channel.
+func (c *CNCIManager) StartFailure(id string) error {
+	c.cnciLock.Lock()
+	defer c.cnciLock.Unlock()
+
+	cnci, ok := c.cncis[id]
+	if !ok {
+		return errors.New("No CNCI found")
+	}
+
+	cnci.transitionState(failed)
+
+	// we should probably not do this, and instead we should
+	// delete from the map?
+	cnci.instance = nil
+
+	return nil
+}
+
+func (c *CNCIManager) waitForActive(subnet int) error {
+	c.cnciLock.RLock()
+
+	cnci, ok := c.subnets[subnet]
+
+	c.cnciLock.RUnlock()
+
+	if !ok {
+		return errors.New("No CNCI found")
+	}
+
+	if instanceActive(cnci.instance) {
+		return nil
+	}
+
+	// lock eventCh
+	eCh := cnci.eventCh
+
+	// CNCI launch not in process, and it's not active.
+	if eCh == nil {
+		return errors.New("CNCI not active")
+	}
+
+	// CNCI launch in process. we wait here till
+	// the channel is closed. When it is, the cnci
+	// is either active, or it failed to start.
+	<-*eCh
+	if instanceActive(cnci.instance) {
+		return nil
+	}
+
+	return errors.New("CNCI not active")
+}
+
+// GetInstanceCNCI will return the CNCI Instance for a specific tenant Instance
+func (c *CNCIManager) GetInstanceCNCI(ID string) (*types.Instance, error) {
+	// figure out what subnet we are looking for.
+	instance, err := c.ctrl.ds.GetInstance(ID)
+	if err != nil {
+		return nil, err
+	}
+
+	// convert subnet string to int
+	subnetInt, err := subnetStringToInt(instance.Subnet)
+	if err != nil {
+		return nil, err
+	}
+
+	c.cnciLock.Lock()
+	defer c.cnciLock.Unlock()
+
+	cnci, ok := c.subnets[int(subnetInt)]
+	if !ok {
+		// there is no cnci for this subnet
+		return nil, errors.New("Subnet doesn't exist")
+	}
+
+	return cnci.instance, nil
+}
+
+func subnetStringToInt(cidr string) (int, error) {
+	ipAddr, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return 0, err
+	}
+
+	ipBytes := ipAddr.To4()
+	if ipBytes == nil {
+		return 0, errors.New("Unable to convert ip to bytes")
+	}
+
+	return int(binary.BigEndian.Uint16(ipBytes[1:3])), nil
+}
+
+// GetSubnetCNCI will return the CNCI Instance for a specific subnet string
+func (c *CNCIManager) GetSubnetCNCI(subnet string) (*types.Instance, error) {
+	subnetInt, err := subnetStringToInt(subnet)
+	if err != nil {
+		return nil, err
+	}
+
+	c.cnciLock.Lock()
+	defer c.cnciLock.Unlock()
+
+	cnci, ok := c.subnets[subnetInt]
+	if !ok {
+		// there is no cnci for this subnet
+		return nil, errors.New("Subnet doesn't exist")
+	}
+
+	return cnci.instance, nil
+}
+
+func (c *CNCIManager) getInstanceCount(subnet string) (int, error) {
+	var count int
+
+	instances, err := c.ctrl.ds.GetAllInstancesFromTenant(c.tenant)
+	if err != nil {
+		return 0, err
+	}
+
+	for _, i := range instances {
+		if i.Subnet == subnet {
+			count++
+		}
+	}
+
+	return count, nil
+}
+
+// Shutdown cleans up a CNCIManager in anticipation of a shutdown.
+func (c *CNCIManager) Shutdown() {
+	// the only thing we need to do right now at shutdown time
+	// is to make sure any in progress timers are cancelled.
+	c.cnciLock.Lock()
+	defer c.cnciLock.Unlock()
+
+	for _, cnci := range c.subnets {
+		if cnci.timer != nil {
+			cnci.timer.Stop()
+			cnci.timer = nil
+		}
+	}
+}
+
+func newCNCIManager(ctrl *controller, tenant string) (*CNCIManager, error) {
+	mgr := CNCIManager{
+		tenant: tenant,
+		ctrl:   ctrl,
+
+		cncis:   make(map[string]*CNCI),
+		subnets: make(map[int]*CNCI),
+	}
+
+	instances, err := ctrl.ds.GetTenantCNCIs(tenant)
+	if err != nil {
+		return nil, err
+	}
+
+	// you need to see if this cnci instance is actually needed
+	// anymore.
+
+	for _, i := range instances {
+		cnci := CNCI{
+			ctrl: ctrl,
+		}
+
+		cnci.instance = i
+
+		// convert cnci instance string to int for map
+		subnetInt, err := subnetStringToInt(i.Subnet)
+		if err != nil {
+			return nil, err
+		}
+
+		cnci.subnet = subnetInt
+		mgr.cncis[i.ID] = &cnci
+		mgr.subnets[subnetInt] = &cnci
+
+		// if we got shutdown prior to being able to remove
+		// an unused subnet, we might be left with CNCIs that
+		// are not needed. Check and see if any instances
+		// in this subnet exist. If they don't, schedule this
+		// cnci for removal after timeout.
+		count, err := mgr.getInstanceCount(i.Subnet)
+		if err != nil {
+			return nil, err
+		}
+
+		if count == 0 {
+			err = mgr.ScheduleRemoveSubnet(subnetInt)
+			if err != nil {
+				// keep going, but log error.
+				glog.Warningf("Unable to remove subnet (%v)", err)
+			}
+		}
+
+	}
+
+	return &mgr, nil
+}
+
+func shutdownCNCICtrls(c *controller) {
+	// get all the current tenants
+	ts, err := c.ds.GetAllTenants()
+	if err != nil {
+		return
+	}
+
+	// the only thing we need to do right now at shutdown time
+	// is to make sure any in progress timers are cancelled.
+	for _, t := range ts {
+		t.CNCIctrl.Shutdown()
+	}
+
+	return
+}
+
+func initializeCNCICtrls(c *controller) error {
+	// get all the current tenants
+	ts, err := c.ds.GetAllTenants()
+	if err != nil {
+		return errors.Wrap(err, "error getting tenants")
+	}
+
+	for _, t := range ts {
+		t.CNCIctrl, err = newCNCIManager(c, t.ID)
+		if err != nil {
+			return errors.Wrap(err, "error allocating CNCI manager")
+		}
+	}
+
+	return nil
+}

--- a/ciao-controller/cnci_test.go
+++ b/ciao-controller/cnci_test.go
@@ -16,7 +16,27 @@ package main
 
 import (
 	"testing"
+
+	"github.com/01org/ciao/ssntp"
 )
+
+func TestCNCIInitializeCtrls(t *testing.T) {
+	err := initializeCNCICtrls(ctl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ts, err := ctl.ds.GetAllTenants()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tenant := range ts {
+		if tenant.CNCIctrl == nil {
+			t.Fatal("CNCIctrl not initialized properly")
+		}
+	}
+}
 
 func TestCNCILaunch(t *testing.T) {
 	testClient, client, instances := testStartWorkloadLaunchCNCI(t, 1)
@@ -26,21 +46,121 @@ func TestCNCILaunch(t *testing.T) {
 	id := instances[0].TenantID
 
 	// get CNCI info for this tenant
-	cncis, err := ctl.ds.GetTenantCNCISummary("")
+	instances, err := ctl.ds.GetTenantCNCIs(id)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	for _, c := range cncis {
-		if c.TenantID != id {
-			continue
-		}
-
-		if c.IPAddress == "" {
-			t.Fatal("CNCI Info not updated")
-		}
-		return
+	if len(instances) != 1 {
+		t.Fatal("Incorrect number of CNCIs")
 	}
 
-	t.Fatal("CNCI not found")
+	if instances[0].IPAddress == "" {
+		t.Fatal("CNCI Info not updated")
+	}
+
+	tenant, err := ctl.ds.GetTenant(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !tenant.CNCIctrl.Active(instances[0].ID) {
+		t.Fatal(err)
+	}
+}
+
+func TestCNCIRemoved(t *testing.T) {
+	netClient, client, instances := testStartWorkloadLaunchCNCI(t, 1)
+	defer client.Shutdown()
+	defer netClient.Shutdown()
+
+	sendStatsCmd(client, t)
+	sendStatsCmd(netClient, t)
+
+	instanceID := instances[0].ID
+	tenantID := instances[0].TenantID
+
+	// get the tenant
+	tenant, err := ctl.ds.GetTenant(tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get CNCI for this instance.
+	cnci, err := tenant.CNCIctrl.GetInstanceCNCI(instanceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// confirm that instance is added.
+	_, err = ctl.ds.GetInstance(instanceID)
+	if err != nil {
+		t.Fatal("Instance not actually created")
+	}
+
+	serverCh := server.AddCmdChan(ssntp.DELETE)
+	clientCh := client.AddCmdChan(ssntp.DELETE)
+	netClientCh := netClient.AddCmdChan(ssntp.DELETE)
+
+	err = ctl.deleteInstance(instanceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = server.GetCmdChanResult(serverCh, ssntp.DELETE)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = server.GetCmdChanResult(clientCh, ssntp.DELETE)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	controllerCh := wrappedClient.addEventChan(ssntp.InstanceDeleted)
+	go client.SendDeleteEvent(instances[0].ID)
+
+	err = wrappedClient.getEventChan(controllerCh, ssntp.InstanceDeleted)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sendStatsCmd(client, t)
+
+	_, err = ctl.ds.GetInstance(instanceID)
+	if err == nil {
+		t.Fatal("instance was not deleted")
+	}
+
+	tenant, err = ctl.ds.GetTenant(tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	CNCIID := cnci.ID
+
+	// call remove subnet directly to remove the cnci.
+	go func() {
+		err = tenant.CNCIctrl.RemoveSubnet(4096)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	_, err = server.GetCmdChanResult(serverCh, ssntp.DELETE)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = server.GetCmdChanResult(netClientCh, ssntp.DELETE)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go netClient.SendDeleteEvent(CNCIID)
+
+	err = wrappedClient.getEventChan(controllerCh, ssntp.InstanceDeleted)
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -198,6 +198,12 @@ func main() {
 		return
 	}
 
+	err = initializeCNCICtrls(ctl)
+	if err != nil {
+		glog.Fatal("Unable to initialize CNCI controllers: ", err)
+		return
+	}
+
 	host := clusterConfig.Configure.Controller.ControllerFQDN
 	if host == "" {
 		host, _ = os.Hostname()
@@ -216,6 +222,7 @@ func main() {
 		s := <-signalCh
 		glog.Warningf("Received signal: %s", s)
 		ctl.ShutdownHTTPServers()
+		shutdownCNCICtrls(ctl)
 	}()
 
 	for _, server := range ctl.httpServers {

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/01org/ciao/ciao-storage"
@@ -103,6 +104,7 @@ type WorkloadRequest struct {
 	TraceLabel string
 	Volumes    []storage.BlockDevice
 	Name       string
+	Subnet     string
 }
 
 // Instance contains information about an instance of a workload.
@@ -122,6 +124,7 @@ type Instance struct {
 	Attachments []StorageAttachment `json:"-"`
 	CreateTime  time.Time           `json:"-"`
 	Name        string              `json:"name"`
+	StateLock   *sync.RWMutex       `json:"-"`
 }
 
 // SortedInstancesByID implements sort.Interface for Instance by ID string
@@ -140,9 +143,9 @@ func (s SortedNodesByID) Less(i, j int) bool { return s[i].ID < s[j].ID }
 
 // Tenant contains information about a tenant or project.
 type Tenant struct {
-	ID     string
-	Name   string
-	CNCIID string
+	ID       string
+	Name     string
+	CNCIctrl CNCIController
 }
 
 // LogEntry stores information about events.
@@ -713,4 +716,18 @@ type QuotaUpdateRequest struct {
 // QuotaListResponse holds the layout for returning quotas in the API
 type QuotaListResponse struct {
 	Quotas []QuotaDetails `json:"quotas"`
+}
+
+// CNCIController is the interface for the cnci controller associated with each tenant
+type CNCIController interface {
+	CNCIAdded(ID string) error
+	CNCIRemoved(ID string) error
+	StartFailure(ID string) error
+	Active(ID string) bool
+	ScheduleRemoveSubnet(subnet int) error
+	RemoveSubnet(subnet int) error
+	WaitForActive(subnet int) error
+	GetInstanceCNCI(InstanceID string) (*Instance, error)
+	GetSubnetCNCI(subnet string) (*Instance, error)
+	Shutdown()
 }

--- a/payloads/stats.go
+++ b/payloads/stats.go
@@ -129,6 +129,11 @@ const (
 	// Running indicates an instance is running
 	Running = ComputeStatusRunning
 
+	// Stopping indicates that an instance has been issued a delete
+	// command, however, we are unalbe to ascertain whether the
+	// instance has been deleted yet.
+	Stopping = "stopping"
+
 	// Exited indicates that an instance has been successfully created but
 	// is not currently running, either because it failed to start or was
 	// explicitly stopped by a STOP command or perhaps by a CN reboot.


### PR DESCRIPTION
This commit adds a CNCI controller to help manage the CNCI lifecyle,
and allows for multiple CNCIs per tenant (1 per subnet).

Create and implement CNCI controller interface which supports starting
a CNCI per tenant subnet. When the subnet is no longer in use (the last
host IP is deleted from this subnet), delete the CNCI after a 5 minute
delay.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>