### PR TITLE
ciao-controller: Only setup openstack identity handler once

### DIFF
--- a/ciao-controller/main.go
+++ b/ciao-controller/main.go
@@ -245,6 +245,12 @@ func (c *controller) createCiaoRoutes(r *mux.Router) error {
 	validServices := []osIdentity.ValidService{
 		{ServiceType: "compute", ServiceName: "ciao"},
 		{ServiceType: "compute", ServiceName: "nova"},
+		{ServiceType: "image", ServiceName: "glance"},
+		{ServiceType: "image", ServiceName: "ciao"},
+		{ServiceType: "volume", ServiceName: "ciao"},
+		{ServiceType: "volumev2", ServiceName: "ciao"},
+		{ServiceType: "volume", ServiceName: "cinder"},
+		{ServiceType: "volumev2", ServiceName: "cinderv2"},
 	}
 
 	validAdmins := []osIdentity.ValidAdmin{

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -23,7 +23,6 @@ import (
 	"github.com/01org/ciao/ciao-controller/types"
 	"github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/openstack/compute"
-	osIdentity "github.com/01org/ciao/openstack/identity"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp/uuid"
 	"github.com/gorilla/mux"
@@ -594,35 +593,11 @@ func (c *controller) ShowFlavorDetails(tenant string, flavorID string) (compute.
 }
 func (c *controller) createComputeRoutes(r *mux.Router) error {
 	config := compute.APIConfig{ComputeService: c}
-	r = compute.Routes(config, r)
+	compute.Routes(config, r)
 
 	// we add on some ciao specific routes for legacy purposes
 	// using the openstack compute port.
-	r = legacyComputeRoutes(c, r)
+	legacyComputeRoutes(c, r)
 
-	// setup identity for these routes.
-	validServices := []osIdentity.ValidService{
-		{ServiceType: "compute", ServiceName: "ciao"},
-		{ServiceType: "compute", ServiceName: "nova"},
-	}
-
-	validAdmins := []osIdentity.ValidAdmin{
-		{Project: "service", Role: "admin"},
-		{Project: "admin", Role: "admin"},
-	}
-
-	err := r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
-		h := osIdentity.Handler{
-			Client:        c.id.scV3,
-			Next:          route.GetHandler(),
-			ValidServices: validServices,
-			ValidAdmins:   validAdmins,
-		}
-
-		route.Handler(h)
-
-		return nil
-	})
-
-	return err
+	return nil
 }

--- a/ciao-controller/openstack_image.go
+++ b/ciao-controller/openstack_image.go
@@ -25,7 +25,6 @@ import (
 	imageDatastore "github.com/01org/ciao/ciao-image/datastore"
 	"github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/database"
-	osIdentity "github.com/01org/ciao/openstack/identity"
 	"github.com/01org/ciao/openstack/image"
 	"github.com/01org/ciao/payloads"
 	"github.com/01org/ciao/ssntp/uuid"
@@ -292,28 +291,5 @@ func (c *controller) createImageRoutes(r *mux.Router) error {
 	// get our routes.
 	image.Routes(apiConfig, c.id.scV3, r)
 
-	// setup identity for these routes.
-	validServices := []osIdentity.ValidService{
-		{ServiceType: "image", ServiceName: "ciao"},
-		{ServiceType: "image", ServiceName: "glance"},
-	}
-
-	validAdmins := []osIdentity.ValidAdmin{
-		{Project: "service", Role: "admin"},
-		{Project: "admin", Role: "admin"},
-	}
-
-	err := r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
-		h := osIdentity.Handler{
-			Client:        c.id.scV3,
-			Next:          route.GetHandler(),
-			ValidServices: validServices,
-			ValidAdmins:   validAdmins,
-		}
-
-		route.Handler(h)
-		return nil
-	})
-
-	return err
+	return nil
 }

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -22,7 +22,6 @@ import (
 	"github.com/01org/ciao/ciao-controller/types"
 	"github.com/01org/ciao/ciao-storage"
 	"github.com/01org/ciao/openstack/block"
-	osIdentity "github.com/01org/ciao/openstack/identity"
 	"github.com/01org/ciao/payloads"
 	"github.com/golang/glog"
 	"github.com/gorilla/mux"
@@ -425,33 +424,7 @@ func (c *controller) ShowVolumeDetails(tenant string, volume string) (block.Volu
 func (c *controller) createVolumeRoutes(r *mux.Router) error {
 	config := block.APIConfig{VolService: c}
 
-	r = block.Routes(config, r)
+	block.Routes(config, r)
 
-	// setup identity for these routes.
-	validServices := []osIdentity.ValidService{
-		{ServiceType: "volume", ServiceName: "ciao"},
-		{ServiceType: "volumev2", ServiceName: "ciao"},
-		{ServiceType: "volume", ServiceName: "cinder"},
-		{ServiceType: "volumev2", ServiceName: "cinderv2"},
-	}
-
-	validAdmins := []osIdentity.ValidAdmin{
-		{Project: "service", Role: "admin"},
-		{Project: "admin", Role: "admin"},
-	}
-
-	err := r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
-		h := osIdentity.Handler{
-			Client:        c.id.scV3,
-			Next:          route.GetHandler(),
-			ValidServices: validServices,
-			ValidAdmins:   validAdmins,
-		}
-
-		route.Handler(h)
-
-		return nil
-	})
-
-	return err
+	return nil
 }


### PR DESCRIPTION
In 10a927a379e4834866b32b7d6580107f89959aef an inefficiency was
introduced where HTTP handlers would get wrapped in the openstack
identity handler multiple times. This change removes that excessive
wrapping by expanding the list of services acceptable for the ciao
end point to be the union of all the others allowing all the others to
be removed.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>