### PR TITLE
ciao-launcher: Expose host /dev/random to instances

### DIFF
--- a/ciao-launcher/qemu.go
+++ b/ciao-launcher/qemu.go
@@ -336,6 +336,7 @@ func generateQEMULaunchParams(cfg *vmConfig, isoPath, instanceDir string,
 	qmpSocket := path.Join(instanceDir, "socket")
 	qmpParam := fmt.Sprintf("unix:%s,server,nowait", qmpSocket)
 	params = append(params, "-qmp", qmpParam)
+	params = append(params, "-device", "virtio-rng-pci")
 
 	if cfg.Mem > 0 {
 		memoryParam := fmt.Sprintf("%d", cfg.Mem)
@@ -349,6 +350,7 @@ func generateQEMULaunchParams(cfg *vmConfig, isoPath, instanceDir string,
 	if !cfg.Legacy {
 		params = append(params, "-bios", qemuEfiFw)
 	}
+
 	return params
 }
 

--- a/ciao-launcher/qemu_test.go
+++ b/ciao-launcher/qemu_test.go
@@ -36,6 +36,7 @@ func genQEMUParams(networkParams []string) []string {
 	baseParams = append(baseParams, networkParams...)
 	baseParams = append(baseParams, "-enable-kvm", "-cpu", "host", "-daemonize",
 		"-qmp", "unix:/var/lib/ciao/instance/1/socket,server,nowait")
+	baseParams = append(baseParams, "-device", "virtio-rng-pci")
 
 	return baseParams
 }


### PR DESCRIPTION
Enable virto-rng to expose the host's randomness to the guest so that it
has some randomness available for doing any crypto it needs.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>