### PR TITLE
qmp: Update block device deletion for newer versions of qemu

### DIFF
--- a/ciao-launcher/qemu.go
+++ b/ciao-launcher/qemu.go
@@ -460,7 +460,7 @@ func qmpDetach(cmd virtualizerDetachCmd, q *qemu.QMP) {
 		glog.Errorf("Failed to execute device_del: %v", err)
 	} else {
 		blockdevID := fmt.Sprintf("drive_%s", cmd.volumeUUID)
-		err = q.ExecuteXBlockdevDel(context.Background(), blockdevID)
+		err = q.ExecuteBlockdevDel(context.Background(), blockdevID)
 		if err != nil {
 			glog.Errorf("Failed to execute x-blockdev-del: %v", err)
 		}

--- a/qemu/qmp_test.go
+++ b/qemu/qmp_test.go
@@ -406,8 +406,8 @@ func TestQMPXBlockdevDel(t *testing.T) {
 	buf.AddCommand("x-blockdev-del", nil, "return", nil)
 	cfg := QMPConfig{Logger: qmpTestLogger{}}
 	q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
-	checkVersion(t, connectedCh)
-	err := q.ExecuteXBlockdevDel(context.Background(),
+	q.version = checkVersion(t, connectedCh)
+	err := q.ExecuteBlockdevDel(context.Background(),
 		fmt.Sprintf("drive_%s", testutil.VolumeUUID))
 	if err != nil {
 		t.Fatalf("Unexpected error %v", err)


### PR DESCRIPTION
blockdev-del command has been added in qemu 2.9 to replace
x-blockdev-del command used earlier for deleting block devices.
Update ExecuteXBlockdevDel() to use this updated qmp command.

Rename ExecuteXBlockdevDel to ExecuteBlockdevDel as this no longer
executes x-block-del command for qemu>=2.9.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>