### PR TITLE
Make ciao work with Go 1.9 and enable Go 1.9 in ciao ciao-down workloads

### DIFF
--- a/ciao-scheduler/scheduler.go
+++ b/ciao-scheduler/scheduler.go
@@ -1248,6 +1248,7 @@ func configSchedulerServer() (sched *ssntpSchedulerServer) {
 		CAcert:    *cacert,
 		Cert:      *cert,
 		ConfigURI: *configURI,
+		Log:       ssntp.Log,
 	}
 
 	setSSNTPForwardRules(sched)

--- a/networking/ciao-cnci-agent/client.go
+++ b/networking/ciao-cnci-agent/client.go
@@ -19,6 +19,7 @@ package main
 import (
 	"encoding/json"
 	"flag"
+	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -66,6 +67,8 @@ const (
 	lockFile      = "cnci-agent.lock"
 	interfacesDir = "/var/lib/ciao/network/interfaces"
 )
+
+var cnciRand io.Reader
 
 type cmdWrapper struct {
 	cmd interface{}
@@ -349,7 +352,7 @@ func connectToServer(db *cnciDatabase, doneCh chan struct{}, statusCh chan struc
 	}()
 
 	cfg := &ssntp.Config{UUID: agentUUID, URI: serverURL, CAcert: serverCertPath, Cert: clientCertPath,
-		Log: ssntp.Log}
+		Log: ssntp.Log, Rand: cnciRand}
 	client := &agentClient{db: db, cmdCh: make(chan *cmdWrapper)}
 
 	dialCh := make(chan error)

--- a/networking/ciao-cnci-agent/rand_linux.go
+++ b/networking/ciao-cnci-agent/rand_linux.go
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"sync"
+	"syscall"
+)
+
+type nbRandReader struct {
+	f    io.Reader
+	lock sync.Mutex
+}
+
+func (r *nbRandReader) Read(p []byte) (int, error) {
+	r.lock.Lock()
+	n, err := r.f.Read(p)
+	r.lock.Unlock()
+	if re, ok := err.(*os.PathError); ok {
+		if re, ok := re.Err.(syscall.Errno); ok {
+			if re == syscall.EAGAIN {
+				err = nil
+			}
+		}
+	}
+
+	return n, err
+}
+
+func init() {
+	r, err := os.Open("/dev/urandom")
+	if err != nil {
+		return
+	}
+
+	cnciRand = &nbRandReader{f: bufio.NewReader(r)}
+}

--- a/testutil/ciao-down/vm.go
+++ b/testutil/ciao-down/vm.go
@@ -59,6 +59,7 @@ func bootVM(ctx context.Context, ws *workspace, in *VMSpec) error {
 		"-drive", fmt.Sprintf("file=%s,if=virtio,media=cdrom", isoPath),
 		"-daemonize", "-enable-kvm", "-cpu", "host",
 		"-net", "nic,model=virtio",
+		"-device", "virtio-rng-pci",
 	}
 
 	for i, m := range in.Mounts {

--- a/testutil/ciao-down/workloads/ciao-fedora25.yaml
+++ b/testutil/ciao-down/workloads/ciao-fedora25.yaml
@@ -99,14 +99,14 @@ runcmd:
  - {{endTaskCheck .}}
 
  - {{beginTask . "Downloading Go" }}
- - {{download . "https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz" "/tmp/go1.8.linux-amd64.tar.gz"}}
+ - {{download . "https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz" "/tmp/go1.9.linux-amd64.tar.gz"}}
  - {{endTaskCheck .}}
  
  - {{beginTask . "Unpacking Go" }}
- - tar -C /usr/local -xzf /tmp/go1.8.linux-amd64.tar.gz
+ - tar -C /usr/local -xzf /tmp/go1.9.linux-amd64.tar.gz
  - {{endTaskCheck .}}
 
- - rm /tmp/go1.8.linux-amd64.tar.gz
+ - rm /tmp/go1.9.linux-amd64.tar.gz
 
  - {{beginTask . "Installing GCC"}}
  - dnf install -y gcc

--- a/testutil/ciao-down/workloads/ciao.yaml
+++ b/testutil/ciao-down/workloads/ciao.yaml
@@ -83,14 +83,14 @@ runcmd:
  - rm /etc/legal
 
  - {{beginTask . "Downloading Go" }}
- - {{download . "https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz" "/tmp/go1.8.linux-amd64.tar.gz"}}
+ - {{download . "https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz" "/tmp/go1.9.linux-amd64.tar.gz"}}
  - {{endTaskCheck .}}
  
  - {{beginTask . "Unpacking Go" }}
- - tar -C /usr/local -xzf /tmp/go1.8.linux-amd64.tar.gz
+ - tar -C /usr/local -xzf /tmp/go1.9.linux-amd64.tar.gz
  - {{endTaskCheck .}}
 
- - rm /tmp/go1.8.linux-amd64.tar.gz
+ - rm /tmp/go1.9.linux-amd64.tar.gz
 
  - groupadd docker
  - sudo gpasswd -a {{.User}} docker

--- a/testutil/singlevm/verify.sh
+++ b/testutil/singlevm/verify.sh
@@ -49,7 +49,7 @@ function rebootCNCI {
 	EOF
 
 	#Now wait for it to come back up
-	ping -w 90 -c 3 $ssh_ip
+	ping -w 120 -c 3 $ssh_ip
 	exitOnError $?  "Unable to ping CNCI after restart"
 
 	#Dump the tables for visual verification


### PR DESCRIPTION
This PR fixes the slow CNCI startup times and verify.sh failures seen when compiling ciao with Go 1.9. Changes in Go 1.9 meant that the cnci_agent was unable to connect to the scheduler for up to 1 minute after it had started.  The agent's TLS session was blocking waiting for /dev/urandom's entropy pool to be initialsed.  Inside a newly created VM booting for the first time this could take up to a minute, even when using virtio-rng-pci.  The issue is fixed by specifying that the cnci_agent's ssntp's tls session should read from /dev/urandom directly, rather than calling getrandom.

There are a couple of other fixes here including enabling SSNTP logging in the scheduler and increasing the ping time out in verify.sh for the CNCI.

virtio-rng-pci is also enabled for ciao-down
