### PR TITLE
Revert "ciao-launcher: Expose host /dev/random to instances"

### DIFF
--- a/ciao-launcher/qemu.go
+++ b/ciao-launcher/qemu.go
@@ -336,7 +336,6 @@ func generateQEMULaunchParams(cfg *vmConfig, isoPath, instanceDir string,
 	qmpSocket := path.Join(instanceDir, "socket")
 	qmpParam := fmt.Sprintf("unix:%s,server,nowait", qmpSocket)
 	params = append(params, "-qmp", qmpParam)
-	params = append(params, "-device", "virtio-rng-pci")
 
 	if cfg.Mem > 0 {
 		memoryParam := fmt.Sprintf("%d", cfg.Mem)
@@ -350,7 +349,6 @@ func generateQEMULaunchParams(cfg *vmConfig, isoPath, instanceDir string,
 	if !cfg.Legacy {
 		params = append(params, "-bios", qemuEfiFw)
 	}
-
 	return params
 }
 

--- a/ciao-launcher/qemu_test.go
+++ b/ciao-launcher/qemu_test.go
@@ -36,7 +36,6 @@ func genQEMUParams(networkParams []string) []string {
 	baseParams = append(baseParams, networkParams...)
 	baseParams = append(baseParams, "-enable-kvm", "-cpu", "host", "-daemonize",
 		"-qmp", "unix:/var/lib/ciao/instance/1/socket,server,nowait")
-	baseParams = append(baseParams, "-device", "virtio-rng-pci")
 
 	return baseParams
 }


### PR DESCRIPTION
Reverts 01org/ciao#1409

My observations are that with this this change our CNCI reboot time varies substantially, from 9s to over 2 minutes. With this change reverted it's sub 10s.

Fixes: #1414 