### PR TITLE
Restart cnci and allows failed CNCIs to be restarted

### DIFF
--- a/ciao-controller/cnci.go
+++ b/ciao-controller/cnci.go
@@ -367,11 +367,10 @@ func (c *CNCIManager) StartFailure(id string) error {
 		return errors.New("No CNCI found")
 	}
 
-	cnci.transitionState(failed)
+	delete(c.cncis, id)
+	delete(c.subnets, cnci.subnet)
 
-	// we should probably not do this, and instead we should
-	// delete from the map?
-	cnci.instance = nil
+	cnci.transitionState(failed)
 
 	return nil
 }

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -722,6 +722,7 @@ type QuotaListResponse struct {
 type CNCIController interface {
 	CNCIAdded(ID string) error
 	CNCIRemoved(ID string) error
+	CNCIStopped(id string) error
 	StartFailure(ID string) error
 	Active(ID string) bool
 	ScheduleRemoveSubnet(subnet int) error


### PR DESCRIPTION
Here's a first attempt at implementing migration of the CNCIs.  It's pretty basic but it does improve on what we currently  have.  The PR makes the following changes.

1. The CNCI manager will now restart a CNCI instance that exits or crashes.
2. It is now possible to restart failed CNCIs.
