### PR TITLE
ciao-controller: Remove Instance.Attachments

### DIFF
--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -299,11 +299,6 @@ func (ds *Datastore) Init(config Config) error {
 		}
 
 		ds.instanceVolumes[link] = key
-
-		instance := ds.instances[value.InstanceID]
-		if instance != nil {
-			instance.Attachments = append(instance.Attachments, value)
-		}
 	}
 
 	ds.attachLock = &sync.RWMutex{}

--- a/ciao-controller/openstack_compute.go
+++ b/ciao-controller/openstack_compute.go
@@ -31,9 +31,9 @@ import (
 func instanceToServer(ctl *controller, instance *types.Instance) (compute.ServerDetails, error) {
 	var volumes []string
 
-	instance.Attachments = ctl.ds.GetStorageAttachments(instance.ID)
+	attachments := ctl.ds.GetStorageAttachments(instance.ID)
 
-	for _, vol := range instance.Attachments {
+	for _, vol := range attachments {
 		volumes = append(volumes, vol.BlockID)
 	}
 

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -109,22 +109,21 @@ type WorkloadRequest struct {
 
 // Instance contains information about an instance of a workload.
 type Instance struct {
-	ID          string              `json:"instance_id"`
-	TenantID    string              `json:"tenant_id"`
-	State       string              `json:"instance_state"`
-	WorkloadID  string              `json:"workload_id"`
-	NodeID      string              `json:"node_id"`
-	MACAddress  string              `json:"mac_address"`
-	VnicUUID    string              `json:"vnic_uuid"`
-	Subnet      string              `json:"subnet"`
-	IPAddress   string              `json:"ip_address"`
-	SSHIP       string              `json:"ssh_ip"`
-	SSHPort     int                 `json:"ssh_port"`
-	CNCI        bool                `json:"-"`
-	Attachments []StorageAttachment `json:"-"`
-	CreateTime  time.Time           `json:"-"`
-	Name        string              `json:"name"`
-	StateLock   *sync.RWMutex       `json:"-"`
+	ID         string        `json:"instance_id"`
+	TenantID   string        `json:"tenant_id"`
+	State      string        `json:"instance_state"`
+	WorkloadID string        `json:"workload_id"`
+	NodeID     string        `json:"node_id"`
+	MACAddress string        `json:"mac_address"`
+	VnicUUID   string        `json:"vnic_uuid"`
+	Subnet     string        `json:"subnet"`
+	IPAddress  string        `json:"ip_address"`
+	SSHIP      string        `json:"ssh_ip"`
+	SSHPort    int           `json:"ssh_port"`
+	CNCI       bool          `json:"-"`
+	CreateTime time.Time     `json:"-"`
+	Name       string        `json:"name"`
+	StateLock  *sync.RWMutex `json:"-"`
 }
 
 // SortedInstancesByID implements sort.Interface for Instance by ID string


### PR DESCRIPTION
This member is not really needed and is not always up to date.  For up
to date information about an instance's volumes, one should call
GetStorageAttachments.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>