### PR TITLE
ciao-cert: Drop option to choose elliptic curve certs

### DIFF
--- a/ciao-cert/README.md
+++ b/ciao-cert/README.md
@@ -17,8 +17,6 @@ Usage of ciao-cert:
         Installation directory (default ".")
   -dump string
         Print details about provided certificate
-  -elliptic-key
-        Use elliptic curve algorithms
   -email string
         Certificate email address (default "ciao-devel@lists.clearlinux.org")
   -host string

--- a/ciao-cert/main.go
+++ b/ciao-cert/main.go
@@ -46,7 +46,6 @@ var (
 	anchorCert   = flag.String("anchor-cert", "", "Trust anchor certificate for signing")
 	isAnchor     = flag.Bool("anchor", false, "Whether this cert should be the trust anchor")
 	verify       = flag.Bool("verify", false, "Verify certificate")
-	isElliptic   = flag.Bool("elliptic-key", false, "Use elliptic curve algorithms")
 	email        = flag.String("email", "ciao-devel@lists.clearlinux.org", "Certificate email address")
 	organization = flag.String("organization", "", "Certificates organization")
 	installDir   = flag.String("directory", ".", "Installation directory")
@@ -120,7 +119,7 @@ func createCertificates(role ssntp.Role) {
 		if err != nil {
 			log.Fatalf("Failed to open %s for writing: %s", certName, err)
 		}
-		err = certs.CreateAnchorCert(template, *isElliptic, certOut, CAcertOut)
+		err = certs.CreateAnchorCert(template, certOut, CAcertOut)
 		if err != nil {
 			log.Fatalf("Failed to create certificate: %v", err)
 		}
@@ -145,7 +144,7 @@ func createCertificates(role ssntp.Role) {
 			log.Fatalf("Failed to open %s for writing: %s", certName, err)
 		}
 
-		err = certs.CreateCert(template, *isElliptic, bytesCert, certOut)
+		err = certs.CreateCert(template, bytesCert, certOut)
 		if err != nil {
 			log.Fatalf("Failed to create certificate: %v", err)
 		}

--- a/ciao-deploy/deploy/setup.go
+++ b/ciao-deploy/deploy/setup.go
@@ -160,7 +160,7 @@ func createSchedulerCerts(ctx context.Context, force bool, serverIP string) (str
 		return "", "", errors.Wrap(err, "Error creating scheduler certificate template")
 	}
 
-	if err := certs.CreateAnchorCert(template, false, certFile, caCertFile); err != nil {
+	if err := certs.CreateAnchorCert(template, certFile, caCertFile); err != nil {
 		return "", "", errors.Wrap(err, "Error creating anchor certificate")
 	}
 

--- a/ciao-deploy/deploy/utils.go
+++ b/ciao-deploy/deploy/utils.go
@@ -198,7 +198,7 @@ func GenerateCert(anchorCertPath string, role ssntp.Role) (path string, errOut e
 		}
 	}()
 
-	err = certs.CreateCert(t, false, anchorCertBytes, f)
+	err = certs.CreateCert(t, anchorCertBytes, f)
 	if err != nil {
 		_ = f.Close()
 		return "", errors.Wrap(err, "Error creating certificate from anchor")

--- a/testutil/ssntp_test_certs.go
+++ b/testutil/ssntp_test_certs.go
@@ -565,7 +565,7 @@ func makeTestCert(role ssntp.Role) (err error) {
 				err = fmt.Errorf("Unable to close ca file: %v", err1)
 			}
 		}()
-		err = certs.CreateAnchorCert(template, true, writer, caWriter)
+		err = certs.CreateAnchorCert(template, writer, caWriter)
 		if err != nil {
 			return fmt.Errorf("Unable to populate cert file: %v", err)
 		}
@@ -580,7 +580,7 @@ func makeTestCert(role ssntp.Role) (err error) {
 		if err != nil {
 			return fmt.Errorf("Unable to read scheduler cert file: %v", err)
 		}
-		err = certs.CreateCert(template, true, anchorCert, writer)
+		err = certs.CreateCert(template, anchorCert, writer)
 		if err != nil {
 			return fmt.Errorf("Unable to populate cert file: %v", err)
 		}


### PR DESCRIPTION
Having the ability to choose different certificate types makes the
ability to programmatic creation of certificates, e.g. ciao-deploy
problematic as the type of signing key must be known to to manage these
keys. Instead remove the option to simplify the certificate workflow.

Fixes: #1295

Signed-off-by: Rob Bradford <robert.bradford@intel.com>