### PR TITLE
Hide CNCI volume from user and quotas

### DIFF
--- a/ciao-controller/command.go
+++ b/ciao-controller/command.go
@@ -248,9 +248,11 @@ func (c *controller) deleteEphemeralStorage(instanceID string) error {
 		if err != nil {
 			return errors.Wrap(err, "Error deleting block device")
 		}
-		c.qs.Release(bd.TenantID,
-			payloads.RequestedResource{Type: payloads.Volume, Value: 1},
-			payloads.RequestedResource{Type: payloads.SharedDiskGiB, Value: bd.Size})
+		if !bd.Internal {
+			c.qs.Release(bd.TenantID,
+				payloads.RequestedResource{Type: payloads.Volume, Value: 1},
+				payloads.RequestedResource{Type: payloads.SharedDiskGiB, Value: bd.Size})
+		}
 	}
 	return nil
 }

--- a/ciao-controller/instance.go
+++ b/ciao-controller/instance.go
@@ -218,6 +218,7 @@ func addBlockDevice(c *controller, tenant string, instanceID string, device stor
 		TenantID:    tenant,
 		Name:        fmt.Sprintf("Storage for instance: %s", instanceID),
 		Description: s.Tag,
+		Internal:    s.Internal,
 	}
 
 	res := <-c.qs.Consume(tenant,

--- a/ciao-controller/internal/datastore/datastore.go
+++ b/ciao-controller/internal/datastore/datastore.go
@@ -2370,6 +2370,7 @@ users:
 		Ephemeral:  false,
 		SourceType: types.ImageService,
 		SourceID:   "4e16e743-265a-4bf2-9fd1-57ada0b28904",
+		Internal:   true,
 	}
 
 	wl := types.Workload{

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -145,6 +145,7 @@ func (d blockData) Init() error {
 		create_time DATETIME,
 		name string,
 		description string,
+		internal int,
 		foreign key(tenant_id) references tenants(id)
 		);`
 
@@ -1762,7 +1763,8 @@ func (ds *sqliteDB) getTenantDevices(tenantID string) (map[string]types.BlockDat
 				block_data.state,
 				block_data.create_time,
 				block_data.name,
-				block_data.description
+				block_data.description,
+				block_data.internal
 		  FROM	block_data
 		  WHERE block_data.tenant_id = ?`
 
@@ -1777,7 +1779,7 @@ func (ds *sqliteDB) getTenantDevices(tenantID string) (map[string]types.BlockDat
 		var state string
 		var data types.BlockData
 
-		err = rows.Scan(&data.ID, &data.TenantID, &data.Size, &state, &data.CreateTime, &data.Name, &data.Description)
+		err = rows.Scan(&data.ID, &data.TenantID, &data.Size, &state, &data.CreateTime, &data.Name, &data.Description, &data.Internal)
 		if err != nil {
 			continue
 		}
@@ -1806,7 +1808,8 @@ func (ds *sqliteDB) getAllBlockData() (map[string]types.BlockData, error) {
 				block_data.state,
 				block_data.create_time,
 				block_data.name,
-				block_data.description
+				block_data.description,
+				block_data.internal
 		  FROM	block_data `
 
 	rows, err := datastore.Query(query)
@@ -1819,7 +1822,7 @@ func (ds *sqliteDB) getAllBlockData() (map[string]types.BlockData, error) {
 		var data types.BlockData
 		var state string
 
-		err = rows.Scan(&data.ID, &data.TenantID, &data.Size, &state, &data.CreateTime, &data.Name, &data.Description)
+		err = rows.Scan(&data.ID, &data.TenantID, &data.Size, &state, &data.CreateTime, &data.Name, &data.Description, &data.Internal)
 		if err != nil {
 			continue
 		}
@@ -1836,7 +1839,7 @@ func (ds *sqliteDB) getAllBlockData() (map[string]types.BlockData, error) {
 
 func (ds *sqliteDB) addBlockData(data types.BlockData) error {
 	ds.dbLock.Lock()
-	err := ds.create("block_data", data.ID, data.TenantID, data.Size, string(data.State), data.CreateTime.Format(time.RFC3339Nano), data.Name, data.Description)
+	err := ds.create("block_data", data.ID, data.TenantID, data.Size, string(data.State), data.CreateTime.Format(time.RFC3339Nano), data.Name, data.Description, data.Internal)
 	ds.dbLock.Unlock()
 
 	return err

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -449,6 +449,12 @@ func (ds *sqliteDB) create(tableName string, record ...interface{}) error {
 		// enclose strings in quotes to not confuse sqlite
 		if v.Kind() == reflect.String {
 			newval = fmt.Sprintf("'%v'", val)
+		} else if v.Kind() == reflect.Bool {
+			if val.(bool) {
+				newval = "1"
+			} else {
+				newval = "0"
+			}
 		} else {
 			newval = fmt.Sprintf("%v", val)
 		}

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -155,6 +155,7 @@ func TestSQLiteDBGetAllBlockData(t *testing.T) {
 		State:       types.Available,
 		TenantID:    uuid.Generate().String(),
 		CreateTime:  time.Now(),
+		Internal:    true,
 	}
 
 	err = db.addBlockData(data)
@@ -170,6 +171,10 @@ func TestSQLiteDBGetAllBlockData(t *testing.T) {
 	_, ok := devices[data.ID]
 	if !ok {
 		t.Fatal(err)
+	}
+
+	if reflect.DeepEqual(devices[data.ID], data) {
+		t.Fatal("Retrieved block device does not match added")
 	}
 
 	db.disconnect()

--- a/ciao-controller/openstack_volume.go
+++ b/ciao-controller/openstack_volume.go
@@ -319,6 +319,10 @@ func (c *controller) ListVolumes(tenant string) ([]block.ListVolume, error) {
 	}
 
 	for _, bd := range data {
+		if bd.Internal {
+			continue
+		}
+
 		// TBD create links
 		vol := block.ListVolume{
 			ID: bd.ID,
@@ -344,6 +348,11 @@ func (c *controller) ListVolumesDetail(tenant string) ([]block.VolumeDetail, err
 
 	for i := range devs {
 		data := &devs[i]
+
+		if data.Internal {
+			continue
+		}
+
 		var vol block.VolumeDetail
 
 		vol.ID = data.ID

--- a/ciao-controller/quotas.go
+++ b/ciao-controller/quotas.go
@@ -58,6 +58,9 @@ func populateQuotasFromDatastore(qs *quotas.Quotas, ds *datastore.Datastore) err
 		}
 		var size, count int
 		for _, bd := range bds {
+			if bd.Internal {
+				continue
+			}
 			size += bd.Size
 			count++
 		}

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -72,6 +72,9 @@ type StorageResource struct {
 
 	// Tag is a piece of abitrary search/sort identifier text
 	Tag string
+
+	// Internal indicates whether this storage should be shown to the user
+	Internal bool
 }
 
 // Workload contains resource and configuration information for a user

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -253,6 +253,7 @@ type BlockData struct {
 	CreateTime  time.Time  // when we created the volume
 	Name        string     // a human readable name for this volume
 	Description string     // some text to describe this volume.
+	Internal    bool       // whether this storage should be shown to the user
 }
 
 // StorageAttachment represents a link between a block device and


### PR DESCRIPTION
Hide the CNCI volume from the output of "ciao-cli volume list" and also make sure that it is not included in the quotas for the user. Do this by establishing an Internal field on types.BlockData that is populated from types.StorageResource (which is statically specified for the CNCI) which can be tested in conditional statements.

Fixes: #1202