### PR TITLE
travis: Enable race detection for unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ go:
     - 1.9
     - tip
 
-env:
-    - COVERALLS_TOKEN=mwTn1pOFqEOUT13vylZNHq53NanoMznO7
 matrix:
   allow_failures:
   - go: tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,15 @@ go:
     - 1.9
     - tip
 
+env: #need empty
 matrix:
+  include:
+    - go: 1.9
+      env: TEST_CASES_FLAGS=-race
   allow_failures:
   - go: tip
+  - go: 1.9
+    env: TEST_CASES_FLAGS=-race
 
 go_import_path: github.com/01org/ciao
 
@@ -58,10 +64,10 @@ script:
    - sudo mkdir -p /var/lib/ciao/instances
    - sudo mkdir -p /var/lib/ciao/data/controller/workloads
    - sudo chmod 0777 -R /var/lib/ciao
-   - test-cases -v -timeout 9 -coverprofile /tmp/cover.out -short github.com/01org/ciao/ciao-controller/...
-   - test-cases -v -timeout 9 -coverprofile /tmp/cover.out -append-profile -short github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/payloads github.com/01org/ciao/configuration github.com/01org/ciao/testutil github.com/01org/ciao/ssntp/uuid github.com/01org/ciao/qemu github.com/01org/ciao/openstack/... github.com/01org/ciao/bat  github.com/01org/ciao/ciao-image/... github.com/01org/ciao/database/... github.com/01org/ciao/ciao-storage/... github.com/01org/ciao/deviceinfo github.com/01org/ciao/osprepare
-   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/ssntp
-   - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -v -timeout 9 -short -tags travis -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/networking/libsnnet
+   - test-cases $TEST_CASES_FLAGS -v -timeout 9 -coverprofile /tmp/cover.out -short github.com/01org/ciao/ciao-controller/...
+   - test-cases $TEST_CASES_FLAGS -v -timeout 9 -coverprofile /tmp/cover.out -append-profile -short github.com/01org/ciao/ciao-launcher github.com/01org/ciao/ciao-scheduler github.com/01org/ciao/payloads github.com/01org/ciao/configuration github.com/01org/ciao/testutil github.com/01org/ciao/ssntp/uuid github.com/01org/ciao/qemu github.com/01org/ciao/openstack/... github.com/01org/ciao/bat  github.com/01org/ciao/ciao-image/... github.com/01org/ciao/database/... github.com/01org/ciao/ciao-storage/... github.com/01org/ciao/deviceinfo github.com/01org/ciao/osprepare
+   - export GOROOT=`go env GOROOT` && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases $TEST_CASES_FLAGS -v -timeout 9 -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/ssntp
+   - export GOROOT=`go env GOROOT` && export SNNET_ENV=198.51.100.0/24 && sudo -E PATH=$PATH:$GOROOT/bin $GOPATH/bin/test-cases -race -v -timeout 9 -short -tags travis -coverprofile /tmp/cover.out -append-profile github.com/01org/ciao/networking/libsnnet
 
 after_success:
    - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=/tmp/cover.out


### PR DESCRIPTION
We've made quite a few improvements to the unit tests so we should now
try and run with race detection turned on.

Fixes: #235

Signed-off-by: Rob Bradford <robert.bradford@intel.com>