### PR TITLE
ciao-cli node show fix

### DIFF
--- a/ciao-cli/node.go
+++ b/ciao-cli/node.go
@@ -334,7 +334,7 @@ func showNode(cmd *nodeShowCommand) error {
 
 func showCNCINode(cmd *nodeShowCommand) error {
 	if cmd.nodeID == "" {
-		fatalf("Missing required -cnci-id parameter")
+		fatalf("Missing required -node-id parameter")
 	}
 
 	var cnci types.CiaoCNCI


### PR DESCRIPTION
Make "ciao-cli node show" work when given a node-id and also fix the error message for when --cnci is provided but no --node-id is given.

Fixes: #660


