### PR TITLE
ciao-cli: Validate that requested number of instances is positive

### DIFF
--- a/ciao-cli/instance.go
+++ b/ciao-cli/instance.go
@@ -423,6 +423,11 @@ func (cmd *instanceAddCommand) validateAddCommandArgs() {
 		cmd.usage()
 	}
 
+	if cmd.instances < 1 {
+		errorf("Invalid value for -instances: %d", cmd.instances)
+		cmd.usage()
+	}
+
 	if cmd.name != "" {
 		r := regexp.MustCompile("^[a-z0-9-]{1,64}?$")
 		if !r.MatchString(cmd.name) {


### PR DESCRIPTION
Ensure that if supplied to ciao-cli instance add, --instances is a
positive number greater than 0.

Fixes: #889

Signed-off-by: Rob Bradford <robert.bradford@intel.com>