### PR TITLE
ciao-down: Add the --drive parameter

### DIFF
--- a/testutil/ciao-down/instance.go
+++ b/testutil/ciao-down/instance.go
@@ -56,12 +56,23 @@ func (m mount) String() string {
 	return fmt.Sprintf("%s,%s,%s", m.Tag, m.SecurityModel, m.Path)
 }
 
+type drive struct {
+	Path    string
+	Format  string
+	Options string
+}
+
+func (d drive) String() string {
+	return fmt.Sprintf("%s,%s,%s", d.Path, d.Format, d.Options)
+}
+
 // VMSpec holds the per-VM state.
 type VMSpec struct {
 	MemGiB       int           `yaml:"mem_gib"`
 	CPUs         int           `yaml:"cpus"`
 	PortMappings []portMapping `yaml:"ports"`
 	Mounts       []mount       `yaml:"mounts"`
+	Drives       []drive       `yaml:"drives"`
 }
 
 type workloadSpec struct {
@@ -208,6 +219,24 @@ func (in *VMSpec) mergePorts(p ports) {
 			in.PortMappings = append(in.PortMappings, port)
 		} else {
 			in.PortMappings[i] = port
+		}
+	}
+}
+
+func (in *VMSpec) mergeDrives(d drives) {
+	driveCount := len(in.Drives)
+	for _, drive := range d {
+		var i int
+		for i = 0; i < driveCount; i++ {
+			if drive.Path == in.Drives[i].Path {
+				break
+			}
+		}
+
+		if i == driveCount {
+			in.Drives = append(in.Drives, drive)
+		} else {
+			in.Drives[i] = drive
 		}
 	}
 }

--- a/testutil/ciao-down/vm.go
+++ b/testutil/ciao-down/vm.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -68,6 +69,16 @@ func bootVM(ctx context.Context, ws *workspace, in *VMSpec) error {
 		devParam := fmt.Sprintf("virtio-9p-pci,id=fs%[1]d,fsdev=fsdev%[1]d,mount_tag=%s",
 			i, m.Tag)
 		args = append(args, "-fsdev", fsdevParam, "-device", devParam)
+	}
+
+	for _, d := range in.Drives {
+		options := strings.TrimSpace(d.Options)
+		if options != "" {
+			options = "," + options
+		}
+		driveParam := fmt.Sprintf("file=%s,if=virtio,format=%s%s", d.Path,
+			d.Format, options)
+		args = append(args, "-drive", driveParam)
 	}
 
 	var b bytes.Buffer


### PR DESCRIPTION
--drive can be used to make a resource acessible on the host
available to the guest as a block device.  Currently, the only
type of resource that is supported is file backed storage stored
on the host, e.g., a qcow2 file.

Signed-off-by: Mark Ryan <mark.d.ryan@intel.com>