### PR TITLE
qemu: Add support for memory pre-allocation

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -741,6 +741,9 @@ type Knobs struct {
 
 	// Daemonize will turn the qemu process into a daemon
 	Daemonize bool
+
+	// MemPrealloc will allocate all the RAM upfront
+	MemPrealloc bool
 }
 
 // Config is the qemu configuration structure.
@@ -987,6 +990,20 @@ func (config *Config) appendKnobs() {
 
 	if config.Knobs.Daemonize == true {
 		config.qemuParams = append(config.qemuParams, "-daemonize")
+	}
+
+	if config.Knobs.MemPrealloc == true {
+		if config.Memory.Size != "" {
+			dimmName := "dimm1"
+			objMemParam := "memory-backend-ram,id=" + dimmName + ",size=" + config.Memory.Size + ",prealloc=on"
+			deviceMemParam := "pc-dimm,id=" + dimmName + ",memdev=" + dimmName
+
+			config.qemuParams = append(config.qemuParams, "-object")
+			config.qemuParams = append(config.qemuParams, objMemParam)
+
+			config.qemuParams = append(config.qemuParams, "-device")
+			config.qemuParams = append(config.qemuParams, deviceMemParam)
+		}
 	}
 }
 

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -231,6 +231,7 @@ func TestAppendKnobsAllTrue(t *testing.T) {
 		NoDefaults:   true,
 		NoGraphic:    true,
 		Daemonize:    true,
+		MemPrealloc:  true,
 	}
 
 	testAppend(knobs, knobsString, t)
@@ -241,6 +242,7 @@ func TestAppendKnobsAllFalse(t *testing.T) {
 		NoUserConfig: false,
 		NoDefaults:   false,
 		NoGraphic:    false,
+		MemPrealloc:  false,
 	}
 
 	testAppend(knobs, "", t)


### PR DESCRIPTION
Add support for pre-allocating all of the RAM.
This increases the memory footprint of QEMU and should be used
only when needed.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>