### PR TITLE
QEMU: Enable realtime options

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -744,6 +744,13 @@ type Knobs struct {
 
 	// MemPrealloc will allocate all the RAM upfront
 	MemPrealloc bool
+
+	// Mlock will control locking of memory
+	// Only active when Realtime is set to true
+	Mlock bool
+
+	// Realtime will enable realtime QEMU
+	Realtime bool
 }
 
 // Config is the qemu configuration structure.
@@ -1003,6 +1010,15 @@ func (config *Config) appendKnobs() {
 
 			config.qemuParams = append(config.qemuParams, "-device")
 			config.qemuParams = append(config.qemuParams, deviceMemParam)
+		}
+	}
+
+	if config.Knobs.Realtime == true {
+		config.qemuParams = append(config.qemuParams, "-realtime")
+		if config.Knobs.Mlock == true {
+			config.qemuParams = append(config.qemuParams, "mlock=on")
+		} else {
+			config.qemuParams = append(config.qemuParams, "mlock=off")
 		}
 	}
 }

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -223,7 +223,7 @@ func TestAppendEmptyDevice(t *testing.T) {
 	testAppend(device, "", t)
 }
 
-var knobsString = "-no-user-config -nodefaults -nographic -daemonize"
+var knobsString = "-no-user-config -nodefaults -nographic -daemonize -realtime mlock=on"
 
 func TestAppendKnobsAllTrue(t *testing.T) {
 	knobs := Knobs{
@@ -232,6 +232,8 @@ func TestAppendKnobsAllTrue(t *testing.T) {
 		NoGraphic:    true,
 		Daemonize:    true,
 		MemPrealloc:  true,
+		Realtime:     true,
+		Mlock:        true,
 	}
 
 	testAppend(knobs, knobsString, t)
@@ -243,6 +245,8 @@ func TestAppendKnobsAllFalse(t *testing.T) {
 		NoDefaults:   false,
 		NoGraphic:    false,
 		MemPrealloc:  false,
+		Realtime:     false,
+		Mlock:        false,
 	}
 
 	testAppend(knobs, "", t)


### PR DESCRIPTION
Enable realtime options in QEMU. Also add support to control memory
locking. Turning realtime on with memory locking disabled allows
memory to be swapped out, potentially increasing density of VMs.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>