### PR TITLE
make subnet bits configurable

### DIFF
--- a/ciao-cli/tenant.go
+++ b/ciao-cli/tenant.go
@@ -17,15 +17,117 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"text/template"
 	"time"
 
+	"github.com/01org/ciao/ciao-controller/api"
 	"github.com/01org/ciao/ciao-controller/types"
 	"github.com/intel/tfortools"
 )
+
+func getCiaoTenantsResource() (string, error) {
+	url, err := getCiaoResource("tenants", api.TenantsV1)
+	return url, err
+}
+
+func getCiaoTenantRef(ID string) (string, error) {
+	var tenants types.TenantsListResponse
+
+	query := queryValue{
+		name:  "id",
+		value: ID,
+	}
+
+	url, err := getCiaoTenantsResource()
+	if err != nil {
+		return "", err
+	}
+
+	if !checkPrivilege() {
+		return url, err
+	}
+
+	resp, err := sendCiaoRequest("GET", url, []queryValue{query}, nil, api.TenantsV1)
+	if err != nil {
+		return "", err
+	}
+
+	err = unmarshalHTTPResponse(resp, &tenants)
+	if err != nil {
+		return "", err
+	}
+
+	if len(tenants.Tenants) != 1 {
+		return "", errors.New("No tenant by that ID found")
+	}
+
+	links := tenants.Tenants[0].Links
+	url = getRef("self", links)
+	if url == "" {
+		return url, errors.New("invalid link returned from controller")
+	}
+
+	return url, nil
+}
+
+func getCiaoTenantConfig(ID string) (types.TenantConfig, error) {
+	var config types.TenantConfig
+
+	url, err := getCiaoTenantRef(ID)
+	if err != nil {
+		return config, err
+	}
+
+	resp, err := sendCiaoRequest("GET", url, nil, nil, api.TenantsV1)
+	if err != nil {
+		return config, err
+	}
+
+	err = unmarshalHTTPResponse(resp, &config)
+
+	return config, err
+}
+
+func putCiaoTenantConfig(ID string, name string, bits int) error {
+	var config types.TenantConfig
+
+	url, err := getCiaoTenantRef(ID)
+	if err != nil {
+		return err
+	}
+
+	resp, err := sendCiaoRequest("GET", url, nil, nil, api.TenantsV1)
+	if err != nil {
+		return err
+	}
+
+	err = unmarshalHTTPResponse(resp, &config)
+
+	if name != "" {
+		config.Name = name
+	}
+
+	if bits != 0 {
+		config.SubnetBits = bits
+	}
+
+	b, err := json.Marshal(config)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	body := bytes.NewReader(b)
+
+	_, err = sendCiaoRequest("PUT", url, nil, body, api.TenantsV1)
+
+	return err
+}
 
 // Project represents a tenant UUID and friendly name.
 type Project struct {
@@ -35,7 +137,8 @@ type Project struct {
 
 var tenantCommand = &command{
 	SubCommands: map[string]subCommand{
-		"list": new(tenantListCommand),
+		"list":   new(tenantListCommand),
+		"update": new(tenantUpdateCommand),
 	},
 }
 
@@ -43,7 +146,58 @@ type tenantListCommand struct {
 	Flag      flag.FlagSet
 	quotas    bool
 	resources bool
+	config    bool
+	all       bool
+	tenantID  string
 	template  string
+}
+
+type tenantUpdateCommand struct {
+	Flag       flag.FlagSet
+	name       string
+	subnetBits int
+	tenantID   string
+}
+
+func (cmd *tenantUpdateCommand) usage(...string) {
+	fmt.Fprintf(os.Stderr, `usage: ciao-cli [options] tenant update [flags]
+
+Updates the configuration for the supplied tenant
+
+The update flags are:
+
+`)
+	cmd.Flag.PrintDefaults()
+	os.Exit(2)
+}
+
+func (cmd *tenantUpdateCommand) parseArgs(args []string) []string {
+	cmd.Flag.StringVar(&cmd.tenantID, "for-tenant", "", "Tenant to update")
+	cmd.Flag.IntVar(&cmd.subnetBits, "subnet-bits", 0, "Number of bits in subnet mask")
+	cmd.Flag.StringVar(&cmd.name, "name", "", "Tenant name")
+	cmd.Flag.Usage = func() { cmd.usage() }
+	cmd.Flag.Parse(args)
+	return cmd.Flag.Args()
+}
+
+func (cmd *tenantUpdateCommand) run(args []string) error {
+	if !checkPrivilege() {
+		fatalf("Updating tenants is only available for privileged users")
+	}
+
+	// we should not require individual parameters?
+	if cmd.name == "" && cmd.subnetBits == 0 {
+		errorf("Missing required parameters")
+		cmd.usage()
+	}
+
+	// subnet bits must be between 4 and 30
+	if cmd.subnetBits != 0 && (cmd.subnetBits > 30 || cmd.subnetBits < 4) {
+		errorf("subnet_bits must be 4-30")
+		cmd.usage()
+	}
+
+	return putCiaoTenantConfig(cmd.tenantID, cmd.name, cmd.subnetBits)
 }
 
 func (cmd *tenantListCommand) usage(...string) {
@@ -66,10 +220,18 @@ no options:
 %s
 --resources:
 
+%s
+--config:
+
+%s
+--all:
+
 %s`,
 		tfortools.GenerateUsageUndecorated([]Project{}),
 		tfortools.GenerateUsageUndecorated(types.CiaoTenantResources{}),
-		tfortools.GenerateUsageUndecorated(types.CiaoUsageHistory{}.Usages))
+		tfortools.GenerateUsageUndecorated(types.CiaoUsageHistory{}.Usages),
+		tfortools.GenerateUsageUndecorated(types.TenantConfig{}),
+		tfortools.GenerateUsageUndecorated(types.TenantsListResponse{}))
 
 	fmt.Fprintln(os.Stderr, tfortools.TemplateFunctionHelp(nil))
 	os.Exit(2)
@@ -78,6 +240,9 @@ no options:
 func (cmd *tenantListCommand) parseArgs(args []string) []string {
 	cmd.Flag.BoolVar(&cmd.quotas, "quotas", false, "List quotas status for a tenant")
 	cmd.Flag.BoolVar(&cmd.resources, "resources", false, "List consumed resources for a tenant for the past 15mn")
+	cmd.Flag.BoolVar(&cmd.config, "config", false, "List tenant config")
+	cmd.Flag.BoolVar(&cmd.all, "all", false, "List all known tenants")
+	cmd.Flag.StringVar(&cmd.tenantID, "for-tenant", "", "Tenant to get config for")
 	cmd.Flag.StringVar(&cmd.template, "f", "", "Template used to format output")
 	cmd.Flag.Usage = func() { cmd.usage() }
 	cmd.Flag.Parse(args)
@@ -99,6 +264,26 @@ func (cmd *tenantListCommand) run(args []string) error {
 	}
 	if cmd.resources {
 		return listTenantResources(t)
+	}
+	if cmd.config {
+		if checkPrivilege() == false {
+			if *tenantID == "" {
+				fatalf("Missing required -tenant-id")
+			}
+			return listTenantConfig(t, *tenantID)
+		}
+
+		if cmd.tenantID == "" {
+			fatalf("Missing required -for-tenant parameter")
+		}
+
+		return listTenantConfig(t, cmd.tenantID)
+	}
+	if cmd.all {
+		if checkPrivilege() == false {
+			fatalf("The all command is for privileged users only")
+		}
+		return listAllTenants(t)
 	}
 
 	return listUserTenants(t)
@@ -206,6 +391,60 @@ func listTenantResources(t *template.Template) error {
 	fmt.Printf("Usage for tenant %s:\n", *tenantID)
 	for _, u := range usage.Usages {
 		fmt.Printf("\t%v: [%d CPUs] [%d MB memory] [%d MB disk]\n", u.Timestamp, u.VCPU, u.Memory, u.Disk)
+	}
+
+	return nil
+}
+
+func listTenantConfig(t *template.Template, tenantID string) error {
+	config, err := getCiaoTenantConfig(tenantID)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	if t != nil {
+		if err := t.Execute(os.Stdout, &config); err != nil {
+			fatalf(err.Error())
+		}
+		return nil
+	}
+
+	fmt.Printf("Tenant [%s]\n", tenantID)
+	fmt.Printf("\tName: %s\n", config.Name)
+	fmt.Printf("\tSubnetBits: %d\n", config.SubnetBits)
+
+	return nil
+}
+
+func listAllTenants(t *template.Template) error {
+	var tenants types.TenantsListResponse
+
+	url, err := getCiaoTenantsResource()
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	resp, err := sendCiaoRequest("GET", url, nil, nil, api.TenantsV1)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	err = unmarshalHTTPResponse(resp, &tenants)
+	if err != nil {
+		fatalf(err.Error())
+	}
+
+	if t != nil {
+		if err := t.Execute(os.Stdout, &tenants); err != nil {
+			fatalf(err.Error())
+		}
+		return nil
+	}
+
+	for i, tenant := range tenants.Tenants {
+		fmt.Printf("Tenant [%d]\n", i+1)
+		fmt.Printf("\tUUID: %s\n", tenant.ID)
+		fmt.Printf("\tName: %s\n", tenant.Name)
 	}
 
 	return nil

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -173,10 +173,10 @@ var tests = []test{
 		`{"name":"Test Tenant","subnet_bits":24}`,
 	},
 	{
-		"PUT",
+		"PATCH",
 		"/tenants/093ae09b-f653-464e-9ae6-5ae28bd03a22",
 		`{"name":"Updated Test Tenant","subnet_bits":4}`,
-		fmt.Sprintf("application/%s", TenantsV1),
+		fmt.Sprintf("application/%s", "merge-patch+json"),
 		http.StatusNoContent,
 		"null",
 	},
@@ -353,7 +353,7 @@ func (ts testCiaoService) ShowTenant(ID string) (types.TenantConfig, error) {
 	return config, nil
 }
 
-func (ts testCiaoService) UpdateTenant(string, types.TenantConfig) error {
+func (ts testCiaoService) PatchTenant(string, []byte) error {
 	return nil
 }
 

--- a/ciao-controller/api/api_test.go
+++ b/ciao-controller/api/api_test.go
@@ -156,6 +156,30 @@ var tests = []test{
 		http.StatusOK,
 		`{"quotas":[{"name":"test-quota-1","value":"10","usage":"3"},{"name":"test-quota-2","value":"unlimited","usage":"10"},{"name":"test-limit","value":"123"}]}`,
 	},
+	{
+		"GET",
+		"/tenants",
+		"",
+		fmt.Sprintf("application/%s", TenantsV1),
+		http.StatusOK,
+		`{"tenants":[{"id":"bc70dcd6-7298-4933-98a9-cded2d232d02","name":"Test Tenant","links":[{"rel":"self","href":"/tenants/bc70dcd6-7298-4933-98a9-cded2d232d02"}]}]}`,
+	},
+	{
+		"GET",
+		"/tenants/093ae09b-f653-464e-9ae6-5ae28bd03a22",
+		"",
+		fmt.Sprintf("application/%s", TenantsV1),
+		http.StatusOK,
+		`{"name":"Test Tenant","subnet_bits":24}`,
+	},
+	{
+		"PUT",
+		"/tenants/093ae09b-f653-464e-9ae6-5ae28bd03a22",
+		`{"name":"Updated Test Tenant","subnet_bits":4}`,
+		fmt.Sprintf("application/%s", TenantsV1),
+		http.StatusNoContent,
+		"null",
+	},
 }
 
 type testCiaoService struct{}
@@ -299,6 +323,37 @@ func (ts testCiaoService) RestoreNode(nodeID string) error {
 }
 
 func (ts testCiaoService) UpdateQuotas(tenantID string, qds []types.QuotaDetails) error {
+	return nil
+}
+
+func (ts testCiaoService) ListTenants() ([]types.TenantSummary, error) {
+	summary := types.TenantSummary{
+		ID:   "bc70dcd6-7298-4933-98a9-cded2d232d02",
+		Name: "Test Tenant",
+	}
+
+	ref := fmt.Sprintf("/tenants/%s", summary.ID)
+
+	link := types.Link{
+		Rel:  "self",
+		Href: ref,
+	}
+
+	summary.Links = append(summary.Links, link)
+
+	return []types.TenantSummary{summary}, nil
+}
+
+func (ts testCiaoService) ShowTenant(ID string) (types.TenantConfig, error) {
+	config := types.TenantConfig{
+		Name:       "Test Tenant",
+		SubnetBits: 24,
+	}
+
+	return config, nil
+}
+
+func (ts testCiaoService) UpdateTenant(string, types.TenantConfig) error {
 	return nil
 }
 

--- a/ciao-controller/controller_test.go
+++ b/ciao-controller/controller_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -38,6 +39,7 @@ import (
 	"github.com/01org/ciao/ssntp"
 	"github.com/01org/ciao/ssntp/uuid"
 	"github.com/01org/ciao/testutil"
+	jsonpatch "github.com/evanphx/json-patch"
 )
 
 func addTestWorkload(tenantID string) error {
@@ -2011,10 +2013,27 @@ func TestUpdateTenant(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	oldconfig := config
+
 	config.Name = "test1"
 	config.SubnetBits = 30
 
-	err = ctl.UpdateTenant(tenant.ID, config)
+	a, err := json.Marshal(oldconfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := json.Marshal(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	merge, err := jsonpatch.CreateMergePatch(a, b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ctl.PatchTenant(tenant.ID, merge)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ciao-controller/internal/datastore/datastore_test.go
+++ b/ciao-controller/internal/datastore/datastore_test.go
@@ -923,6 +923,29 @@ func TestGetAllTenants(t *testing.T) {
 	// errors.
 }
 
+func TestUpdateTenant(t *testing.T) {
+	tenant, err := addTestTenant()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := types.TenantConfig{
+		Name:       "name1",
+		SubnetBits: 20,
+	}
+
+	err = ds.UpdateTenant(tenant.ID, config)
+
+	testTenant, err := ds.GetTenant(tenant.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if testTenant.Name != "name1" || testTenant.SubnetBits != 20 {
+		t.Fatal("Tenant update not successful")
+	}
+}
+
 func TestHandleTraceReport(t *testing.T) {
 	trace := payloads.Trace{
 		Frames: createTestFrameTraces("test"),

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -242,3 +242,7 @@ func (db *MemoryDB) getQuotas(tenantID string) ([]types.QuotaDetails, error) {
 func (db *MemoryDB) updateInstance(instance *types.Instance) error {
 	return nil
 }
+
+func (db *MemoryDB) updateTenant(tenant *types.Tenant) error {
+	return nil
+}

--- a/ciao-controller/internal/datastore/memorydb.go
+++ b/ciao-controller/internal/datastore/memorydb.go
@@ -37,8 +37,13 @@ type MemoryDB struct {
 }
 
 func (db *MemoryDB) fillWorkloads() error {
+	config := types.TenantConfig{
+		Name:       "",
+		SubnetBits: 24,
+	}
+
 	// add dummy public tenant.
-	return db.addTenant("public", "")
+	return db.addTenant("public", config)
 }
 
 func (db *MemoryDB) init(config Config) error {
@@ -79,11 +84,12 @@ func (db *MemoryDB) getEventLog() ([]*types.LogEntry, error) {
 	return db.logEntries, nil
 }
 
-func (db *MemoryDB) addTenant(id string, name string) error {
+func (db *MemoryDB) addTenant(id string, config types.TenantConfig) error {
 	t := &tenant{
 		Tenant: types.Tenant{
-			ID:   id,
-			Name: name,
+			ID:         id,
+			Name:       config.Name,
+			SubnetBits: config.SubnetBits,
 		},
 		network:   make(map[int]map[int]bool),
 		instances: make(map[string]*types.Instance),

--- a/ciao-controller/internal/datastore/sqlite3db.go
+++ b/ciao-controller/internal/datastore/sqlite3db.go
@@ -1161,6 +1161,28 @@ func (ds *sqliteDB) getTenantNetwork(tenant *tenant) error {
 	return err
 }
 
+func (ds *sqliteDB) updateTenant(tenant *types.Tenant) error {
+	datastore := ds.getTableDB("tenants")
+
+	ds.dbLock.Lock()
+	defer ds.dbLock.Unlock()
+
+	tx, err := datastore.Begin()
+	if err != nil {
+		return errors.Wrap(err, "error starting transaction for tenant update")
+	}
+	_, err = tx.Exec("UPDATE tenants SET name = ?, subnet_bits = ? WHERE id = ?", tenant.Name, tenant.SubnetBits, tenant.ID)
+	if err != nil {
+		tx.Rollback()
+		return errors.Wrap(err, "error executing query for tenant update")
+	}
+
+	tx.Commit()
+
+	return nil
+
+}
+
 func (ds *sqliteDB) getInstances() ([]*types.Instance, error) {
 	var instances []*types.Instance
 

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -99,9 +99,12 @@ func TestSQLiteDBGetTenantWithStorage(t *testing.T) {
 
 	// add a tenant.
 	tenantID := uuid.Generate().String()
-	mac := "validmac"
+	config := types.TenantConfig{
+		Name:       "validname",
+		SubnetBits: 24,
+	}
 
-	err = db.addTenant(tenantID, mac)
+	err = db.addTenant(tenantID, config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -720,9 +723,12 @@ func TestDeleteMappedIP(t *testing.T) {
 
 func createTestTenant(db persistentStore, t *testing.T) *tenant {
 	tid := uuid.Generate().String()
-	name := "TestTenant"
+	config := types.TenantConfig{
+		Name:       "TestTenant",
+		SubnetBits: 24,
+	}
 
-	err := db.addTenant(tid, name)
+	err := db.addTenant(tid, config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -735,8 +741,12 @@ func createTestTenant(db persistentStore, t *testing.T) *tenant {
 		t.Fatal("Expected added tenant")
 	}
 
-	if tn.Name != name {
-		t.Fatalf("Expected %v, got %v", name, tn.Name)
+	if tn.Name != config.Name {
+		t.Fatalf("Expected %v, got %v", config.Name, tn.Name)
+	}
+
+	if tn.SubnetBits != config.SubnetBits {
+		t.Fatalf("Expected SubnetBits %v , got %v\n", config.SubnetBits, tn.SubnetBits)
 	}
 	return tn
 }

--- a/ciao-controller/internal/datastore/sqlite3db_test.go
+++ b/ciao-controller/internal/datastore/sqlite3db_test.go
@@ -1184,3 +1184,46 @@ func TestAddCNCIInstance(t *testing.T) {
 
 	db.disconnect()
 }
+
+func TestSQLiteDBUpdateTenant(t *testing.T) {
+	db, err := getPersistentStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tenantID := uuid.Generate().String()
+	config := types.TenantConfig{
+		Name:       "name1",
+		SubnetBits: 24,
+	}
+
+	err = db.addTenant(tenantID, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tenant, err := db.getTenant(tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// change the name and subnet bits
+	tenant.Name = "name2"
+	tenant.SubnetBits = 20
+
+	err = db.updateTenant(&tenant.Tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tenant, err = db.getTenant(tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tenant.Name != "name2" || tenant.SubnetBits != 20 {
+		t.Fatal("update not successful")
+	}
+
+	db.disconnect()
+}

--- a/ciao-controller/tenants.go
+++ b/ciao-controller/tenants.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/01org/ciao/ciao-controller/types"
+)
+
+func (c *controller) ListTenants() ([]types.TenantSummary, error) {
+	var summary []types.TenantSummary
+
+	tenants, err := c.ds.GetAllTenants()
+	if err != nil {
+		return summary, err
+	}
+
+	for _, t := range tenants {
+		if t.ID == "public" {
+			continue
+		}
+
+		ts := types.TenantSummary{
+			ID:   t.ID,
+			Name: t.Name,
+		}
+
+		ref := fmt.Sprintf("%s/tenants/%s", c.apiURL, t.ID)
+		link := types.Link{
+			Rel:  "self",
+			Href: ref,
+		}
+		ts.Links = append(ts.Links, link)
+
+		summary = append(summary, ts)
+	}
+
+	return summary, nil
+}
+
+func (c *controller) ShowTenant(tenantID string) (types.TenantConfig, error) {
+	var config types.TenantConfig
+
+	tenant, err := c.ds.GetTenant(tenantID)
+	if err != nil {
+		return config, err
+	}
+
+	config.Name = tenant.Name
+	config.SubnetBits = tenant.SubnetBits
+
+	return config, err
+}
+
+func (c *controller) UpdateTenant(tenantID string, config types.TenantConfig) error {
+	// we need to update through datastore.
+	return c.ds.UpdateTenant(tenantID, config)
+}

--- a/ciao-controller/tenants.go
+++ b/ciao-controller/tenants.go
@@ -65,7 +65,7 @@ func (c *controller) ShowTenant(tenantID string) (types.TenantConfig, error) {
 	return config, err
 }
 
-func (c *controller) UpdateTenant(tenantID string, config types.TenantConfig) error {
+func (c *controller) PatchTenant(tenantID string, patch []byte) error {
 	// we need to update through datastore.
-	return c.ds.UpdateTenant(tenantID, config)
+	return c.ds.JSONPatchTenant(tenantID, patch)
 }

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -143,11 +143,18 @@ func (s SortedNodesByID) Len() int           { return len(s) }
 func (s SortedNodesByID) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s SortedNodesByID) Less(i, j int) bool { return s[i].ID < s[j].ID }
 
+// TenantConfig stores the configurable attributes of a tenant.
+type TenantConfig struct {
+	Name       string
+	SubnetBits int
+}
+
 // Tenant contains information about a tenant or project.
 type Tenant struct {
-	ID       string
-	Name     string
-	CNCIctrl CNCIController
+	ID         string
+	Name       string
+	CNCIctrl   CNCIController
+	SubnetBits int
 }
 
 // LogEntry stores information about events.

--- a/ciao-controller/types/types.go
+++ b/ciao-controller/types/types.go
@@ -145,8 +145,8 @@ func (s SortedNodesByID) Less(i, j int) bool { return s[i].ID < s[j].ID }
 
 // TenantConfig stores the configurable attributes of a tenant.
 type TenantConfig struct {
-	Name       string
-	SubnetBits int
+	Name       string `json:"name"`
+	SubnetBits int    `json:"subnet_bits"`
 }
 
 // Tenant contains information about a tenant or project.
@@ -155,6 +155,18 @@ type Tenant struct {
 	Name       string
 	CNCIctrl   CNCIController
 	SubnetBits int
+}
+
+// TenantSummary is a short form of Tenant
+type TenantSummary struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Links []Link `json:"links,omitempty"`
+}
+
+// TenantsListResponse stores a list of tenants retrieved by listTenants
+type TenantsListResponse struct {
+	Tenants []TenantSummary `json:"tenants"`
 }
 
 // LogEntry stores information about events.


### PR DESCRIPTION
This PR makes the number of bits in the subnet mask a configurable attribute of the tenant. It also allows the tenant name to be configurable.

Fixes: #1407 