### PR TITLE
Fix a number issues with --hard-reset

### DIFF
--- a/ciao-launcher/README.md
+++ b/ciao-launcher/README.md
@@ -84,41 +84,37 @@ command line arguments added by glog, e.g., -alsologtostderr.
 Here is a full list of the command line parameters supported by launcher.
 
 ```
-Usage of ciao-launcher:
+Usage of ./ciao-launcher:
   -alsologtostderr
-        log to standard error as well as files
+    	log to standard error as well as files
   -cacert string
-        Client certificate
+    	Client certificate
   -ceph_id string
-        ceph client id
+    	ceph client id
   -cert string
-        CA certificate
-  -cpuprofile string
-        write profile information to file
+    	CA certificate
+  -compute-net value
+    	Compute subnet.  Multiple subnets can be specified
   -hard-reset
-        Kill and delete all instances, reset networking and exit
+    	Kill and delete all instances, reset networking and exit
   -log_backtrace_at value
-        when logging hits line file:N, emit a stack trace
+    	when logging hits line file:N, emit a stack trace
   -log_dir string
-        If non-empty, write log files in this directory
+    	If non-empty, write log files in this directory
   -logtostderr
-        log to standard error instead of files
+    	log to standard error instead of files
+  -mgmt-net value
+    	Management subnet. Multiple subnets can be specified
   -network
-        Enable networking (default true)
-  -qemu-virtualisation value
-        QEMU virtualisation method. Can be 'kvm', 'auto' or 'software' (default kvm)
+    	Enable networking (default true)
   -simulation
-        Launcher simulation
+    	Launcher simulation
   -stderrthreshold value
-        logs at or above this threshold go to stderr
-  -trace string
-        write trace information to file
+    	logs at or above this threshold go to stderr
   -v value
-        log level for V logs
+    	log level for V logs
   -vmodule value
-        comma-separated list of pattern=N settings for file-filtered logging
-  -with-ui value
-        Enables virtual consoles on VM instances.  Can be 'none', 'spice', 'nc' (default nc)
+    	comma-separated list of pattern=N settings for file-filtered logging
 ```
 
 The --with-ui, --qemu-virtualisation and --cpuprofile options are disabled by

--- a/ciao-launcher/docker_network.go
+++ b/ciao-launcher/docker_network.go
@@ -88,6 +88,8 @@ func destroyDockerNetwork(ctx context.Context, bridge string) error {
 }
 
 func resetDockerNetworking() {
+	_ = libsnnet.WipeDockerPluginDB()
+
 	cli, err := getDockerClient()
 	if err != nil {
 		return

--- a/ciao-launcher/hard_reset.go
+++ b/ciao-launcher/hard_reset.go
@@ -77,10 +77,16 @@ func qemuKillInstance(instanceDir string) {
 	_, err = fmt.Fprintln(conn, "{ \"execute\": \"quit\" }")
 	if err != nil {
 		glog.Errorf("Unable to send power down command to %s: %v\n", instanceDir, err)
+		return
 	}
 
 	// Keep reading until the socket fails.  If we close the socket straight away, qemu does not
 	// honour our quit command.
+
+	err = conn.SetReadDeadline(time.Now().Add(time.Minute))
+	if err != nil {
+		glog.Errorf("Unable to set time out on domain socket connection : %v ", err)
+	}
 
 	scanner := bufio.NewScanner(conn)
 	for scanner.Scan() {

--- a/ciao-launcher/network.go
+++ b/ciao-launcher/network.go
@@ -93,7 +93,7 @@ func initDockerNetworking(ctx context.Context) error {
 	return nil
 }
 
-func shutdownNetwork() {
+func shutdownDockerNetwork() {
 	if dockerNet == nil {
 		return
 	}
@@ -107,6 +107,10 @@ func shutdownNetwork() {
 	}
 
 	glog.Infof("Docker networking shutdown successfully")
+}
+
+func shutdownNetwork() {
+	shutdownDockerNetwork()
 }
 
 func initNetwork(ctx context.Context) error {

--- a/networking/libsnnet/docker_plugin.go
+++ b/networking/libsnnet/docker_plugin.go
@@ -171,7 +171,7 @@ func (d *DockerEpMap) NewTable() {
 
 //Name provides the name of the map
 func (d *DockerEpMap) Name() string {
-	return tableNetworkMap
+	return tableEndPointMap
 }
 
 //NewElement allocates and returns an endpoint value
@@ -202,7 +202,7 @@ func (d *DockerNwMap) NewTable() {
 
 //Name provides the name of the map
 func (d *DockerNwMap) Name() string {
-	return tableEndPointMap
+	return tableNetworkMap
 }
 
 //NewElement allocates and returns an network value

--- a/networking/libsnnet/docker_plugin.go
+++ b/networking/libsnnet/docker_plugin.go
@@ -874,3 +874,9 @@ func (d *DockerPlugin) Stop() error {
 func (d *DockerPlugin) Close() error {
 	return d.DbClose()
 }
+
+// WipeDockerPluginDB deletes the database.  The function assumes that the
+// database is not open
+func WipeDockerPluginDB() error {
+	return os.Remove(path.Join(DockerPluginCfg.DataDir, DockerPluginCfg.DbFile))
+}

--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -21,5 +21,3 @@ sudo pkill -F /tmp/dnsmasq.ciaovlan.pid
 sudo docker rm -v -f ceph-demo
 sudo rm /etc/ceph/*
 sudo rm -rf /var/lib/ciao/ciao-image
-sudo docker network rm $(sudo docker network ls --filter driver=ciao -q)
-sudo rm -f /var/lib/ciao/networking/docker_plugin.db

--- a/testutil/singlevm/cleanup.sh
+++ b/testutil/singlevm/cleanup.sh
@@ -2,6 +2,8 @@
 
 . ~/local/demo.sh
 
+ciao_vlan_ip=198.51.100.1
+ciao_vlan_subnet=${ciao_vlan_ip}/24
 ciao_gobin="$GOPATH"/bin
 ciao_host=$(hostname)
 ext_int=$(ip -o route get 8.8.8.8 | cut -d ' ' -f 5)
@@ -9,7 +11,7 @@ sudo killall ciao-scheduler
 sudo killall ciao-controller
 sudo killall ciao-launcher
 sleep 2
-sudo "$ciao_gobin"/ciao-launcher --alsologtostderr -v 3 --hard-reset
+sudo "$ciao_gobin"/ciao-launcher --alsologtostderr -v 3 --hard-reset --compute-net $ciao_vlan_subnet -mgmt-net $ciao_vlan_subnet
 sudo iptables -D FORWARD -i ciao_br -j ACCEPT
 sudo iptables -D FORWARD -i ciaovlan -j ACCEPT
 if [ "$ciao_host" == "singlevm" ]; then


### PR DESCRIPTION
--hard-reset in launcher was not working very well for a number of reasons.

1. There was a long standing bug about the fact that it could hang.
2. It didn't wipe the docker plugin DB.  This caused problems with ciao-deploy installed clusters.
3. It was unable to cleanly destroy docker containers as the docker plugin DB initialization code was broken.
4. It was unable to cleanly destroy docker containers as it was not passed information about the management and compute nets.

All of these issues are addressed by this PR.  Issues 3 and 4 meant that running a ./cleanup.sh on singlevm was really slow if there were some container instances up and running.