### PR TITLE
Knobs: Modify the behaviour of the Mlock knob.

### DIFF
--- a/qemu/qemu.go
+++ b/qemu/qemu.go
@@ -1015,9 +1015,20 @@ func (config *Config) appendKnobs() {
 
 	if config.Knobs.Realtime == true {
 		config.qemuParams = append(config.qemuParams, "-realtime")
+		// This path is redundant as the default behaviour is locked memory
+		// Realtime today does not control any other feature even though
+		// other features may be added in the future
+		// https://lists.gnu.org/archive/html/qemu-devel/2012-12/msg03330.html
 		if config.Knobs.Mlock == true {
 			config.qemuParams = append(config.qemuParams, "mlock=on")
 		} else {
+			config.qemuParams = append(config.qemuParams, "mlock=off")
+		}
+	} else {
+		// In order to turn mlock off we need the -realtime option as well
+		if config.Knobs.Mlock == false {
+			//Enable realtime anyway just to get the right swapping behaviour
+			config.qemuParams = append(config.qemuParams, "-realtime")
 			config.qemuParams = append(config.qemuParams, "mlock=off")
 		}
 	}

--- a/qemu/qemu_test.go
+++ b/qemu/qemu_test.go
@@ -223,9 +223,8 @@ func TestAppendEmptyDevice(t *testing.T) {
 	testAppend(device, "", t)
 }
 
-var knobsString = "-no-user-config -nodefaults -nographic -daemonize -realtime mlock=on"
-
 func TestAppendKnobsAllTrue(t *testing.T) {
+	var knobsString = "-no-user-config -nodefaults -nographic -daemonize -realtime mlock=on"
 	knobs := Knobs{
 		NoUserConfig: true,
 		NoDefaults:   true,
@@ -240,6 +239,7 @@ func TestAppendKnobsAllTrue(t *testing.T) {
 }
 
 func TestAppendKnobsAllFalse(t *testing.T) {
+	var knobsString = "-realtime mlock=off"
 	knobs := Knobs{
 		NoUserConfig: false,
 		NoDefaults:   false,
@@ -249,7 +249,7 @@ func TestAppendKnobsAllFalse(t *testing.T) {
 		Mlock:        false,
 	}
 
-	testAppend(knobs, "", t)
+	testAppend(knobs, knobsString, t)
 }
 
 var kernelString = "-kernel /opt/vmlinux.container -append root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable"


### PR DESCRIPTION
The Mlock knob is unfortunately tied to realtime. Now enable Mlock knob to implicitly enable realtime to get the desired swapping behavior.

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>