### PR TITLE
ciao-cli: remove stray debug print

### DIFF
--- a/ciao-cli/tenant.go
+++ b/ciao-cli/tenant.go
@@ -135,8 +135,6 @@ func putCiaoTenantConfig(ID string, name string, bits int) error {
 		fatalf(err.Error())
 	}
 
-	fmt.Println(string(merge))
-
 	body := bytes.NewReader(merge)
 
 	_, err = sendCiaoRequest("PATCH", url, nil, body, "merge-patch+json")


### PR DESCRIPTION
Remove print of merge patch from tenant update.

Signed-off-by: Kristen Carlson Accardi <kristen@linux.intel.com>